### PR TITLE
Moving assignment zve_list to policy_for_date. 

### DIFF
--- a/gettsim/policy_for_date.py
+++ b/gettsim/policy_for_date.py
@@ -60,10 +60,14 @@ def get_policies_for_date(year, tax_data_raw=None, month=1, day=1):
         tax_data["vorsorge"] = vorsorge2010
     else:
         tax_data["vorsorge"] = vorsorge_dummy
-    if year >= 2009:
-        tax_data["zve_list"] = ["nokfb", "kfb", "abg_nokfb", "abg_kfb"]
-    else:
-        tax_data["zve_list"] = ["nokfb", "kfb"]
+    # TODO: We need to adapt favorability check for that. See
+    #  https://github.com/iza-institute-of-labor-economics/gettsim/issues/81 for
+    #  details.
+    # if year >= 2009:
+    #     tax_data["zve_list"] = ["nokfb", "kfb", "abg_nokfb", "abg_kfb"]
+    # else:
+    #     tax_data["zve_list"] = ["nokfb", "kfb"]
+    tax_data["zve_list"] = ["nokfb", "kfb"]
 
     tax_data["tax_schedule"] = tarif
     return tax_data

--- a/gettsim/policy_for_date.py
+++ b/gettsim/policy_for_date.py
@@ -60,6 +60,10 @@ def get_policies_for_date(year, tax_data_raw=None, month=1, day=1):
         tax_data["vorsorge"] = vorsorge2010
     else:
         tax_data["vorsorge"] = vorsorge_dummy
+    if year >= 2009:
+        tax_data["zve_list"] = ["nokfb", "kfb", "abg_nokfb", "abg_kfb"]
+    else:
+        tax_data["zve_list"] = ["nokfb", "kfb"]
 
     tax_data["tax_schedule"] = tarif
     return tax_data

--- a/gettsim/tax_transfer.py
+++ b/gettsim/tax_transfer.py
@@ -19,7 +19,7 @@ from gettsim.taxes.kindergeld import kindergeld
 from gettsim.taxes.zve import zve
 
 
-def tax_transfer(df, tb, tb_pens=None):
+def tax_transfer(df, tax_data, tax_data_pensions=None):
     """ The German Tax-Transfer System.
 
     Arguments:
@@ -41,7 +41,7 @@ def tax_transfer(df, tb, tb_pens=None):
     """
 
     # set default arguments
-    tb_pens = [] if tb_pens is None else tb_pens
+    tax_data_pensions = [] if tax_data_pensions is None else tax_data_pensions
     # if hyporun is False:
     # df = uprate(df, datayear, settings['taxyear'], settings['MAIN_PATH'])
 
@@ -75,7 +75,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=person,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "m_wage_l1",
@@ -97,7 +97,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=person,
         in_cols=in_cols,
         out_cols=[out_col],
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = ["m_wage", "east", "age", "year", "byear", "exper", "EP"]
     out_col = "pensions_sim"
@@ -107,7 +107,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=person,
         in_cols=in_cols,
         out_cols=[out_col],
-        func_kwargs={"tb": tb, "tb_pens": tb_pens},
+        func_kwargs={"tb": tax_data, "tb_pens": tax_data_pensions},
     )
     in_cols = [
         "m_wage",
@@ -132,11 +132,7 @@ def tax_transfer(df, tb, tb_pens=None):
         "east",
         "gkvbeit",
     ]
-    out_cols = [
-        "zve_nokfb",
-        "zve_abg_nokfb",
-        "zve_kfb",
-        "zve_abg_kfb",
+    out_cols = [f"zve_{inc}" for inc in tax_data["zve_list"]] + [
         "kifreib",
         "gross_e1",
         "gross_e4",
@@ -160,21 +156,17 @@ def tax_transfer(df, tb, tb_pens=None):
         level=tax_unit,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
-    in_cols = [
+    in_cols = [f"zve_{inc}" for inc in tax_data["zve_list"]] + [
         "child",
-        "zve_nokfb",
-        "zve_kfb",
-        "zve_abg_kfb",
-        "zve_abg_nokfb",
         "gross_e5",
         "zveranl",
         "gross_e5_tu",
     ]
     out_cols = (
-        [f"tax_{inc}" for inc in tb["zve_list"]]
-        + [f"tax_{inc}_tu" for inc in tb["zve_list"]]
+        [f"tax_{inc}" for inc in tax_data["zve_list"]]
+        + [f"tax_{inc}_tu" for inc in tax_data["zve_list"]]
         + ["abgst_tu", "abgst", "soli", "soli_tu"]
     )
     df = _apply_tax_transfer_func(
@@ -183,7 +175,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=tax_unit,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = ["age", "w_hours", "ineducation", "m_wage"]
     out_cols = ["kindergeld_basis", "kindergeld_tu_basis"]
@@ -193,13 +185,11 @@ def tax_transfer(df, tb, tb_pens=None):
         level=tax_unit,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
-    in_cols = [
+    in_cols = [f"tax_{inc}_tu" for inc in tax_data["zve_list"]] + [
         "zveranl",
         "child",
-        "tax_nokfb_tu",
-        "tax_kfb_tu",
         "abgst_tu",
         "kindergeld_basis",
         "kindergeld_tu_basis",
@@ -217,7 +207,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=tax_unit,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "alleinerz",
@@ -238,7 +228,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=tax_unit,
         in_cols=in_cols,
         out_cols=[out_col],
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "tu_id",
@@ -276,7 +266,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=household,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "hid",
@@ -318,7 +308,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=household,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "pid",
@@ -352,7 +342,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=household,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "hh_korr",
@@ -376,7 +366,7 @@ def tax_transfer(df, tb, tb_pens=None):
         level=household,
         in_cols=in_cols,
         out_cols=out_cols,
-        func_kwargs={"tb": tb},
+        func_kwargs={"tb": tax_data},
     )
     in_cols = [
         "m_wage",
@@ -453,5 +443,4 @@ def calculate_tax_and_transfers(dataset, policy_year):
     tax_data_pensions = pd.read_excel(ROOT_DIR / "data" / "pensions.xlsx").set_index(
         "var"
     )
-    tax_data["zve_list"] = ["nokfb", "kfb"]
     return tax_transfer(dataset, tax_data, tax_data_pensions)

--- a/gettsim/tests/test_favorability_check.py
+++ b/gettsim/tests/test_favorability_check.py
@@ -6,6 +6,7 @@ import pytest
 from pandas.testing import assert_series_equal
 
 from gettsim.config import ROOT_DIR
+from gettsim.policy_for_date import get_policies_for_date
 from gettsim.taxes.favorability_check import favorability_check
 
 
@@ -35,10 +36,10 @@ def input_data():
 
 
 @pytest.mark.parametrize("year, column", product(YEARS, TEST_COLUMNS))
-def test_favorability_check(input_data, year, column):
+def test_favorability_check(input_data, tax_policy_data, year, column):
     year_data = input_data[input_data["year"] == year]
     df = year_data[INPUT_COLS].copy()
-    tb = {"zve_list": ["nokfb", "kfb"], "yr": year}
+    tb = get_policies_for_date(year=year, tax_data_raw=tax_policy_data)
     for col in OUT_COLS:
         df[col] = np.nan
     df = df.groupby(["hid", "tu_id"]).apply(favorability_check, tb=tb)

--- a/gettsim/tests/test_tax_sched.py
+++ b/gettsim/tests/test_tax_sched.py
@@ -37,8 +37,6 @@ def test_tax_sched(input_data, tax_policy_data, year):
     year_data = input_data[input_data["year"] == year]
     df = year_data[INPUT_COLS].copy()
     tb = get_policies_for_date(year=year, tax_data_raw=tax_policy_data)
-    # list of tax bases
-    tb["zve_list"] = ["nokfb", "kfb"]
     OUT_COLS = (
         [f"tax_{inc}" for inc in tb["zve_list"]]
         + [f"tax_{inc}_tu" for inc in tb["zve_list"]]

--- a/gettsim/tests/test_tax_transfer.py
+++ b/gettsim/tests/test_tax_transfer.py
@@ -21,5 +21,4 @@ def test_tax_transfer(input_data, tax_policy_data, year):
     df = input_data[input_data["year"] == year].copy()
     tb_pens = pd.read_excel(ROOT_DIR / "data" / "pensions.xlsx").set_index("var")
     tb = get_policies_for_date(year=year, tax_data_raw=tax_policy_data)
-    tb["zve_list"] = ["nokfb", "kfb"]
     tax_transfer(df, tb, tb_pens)


### PR DESCRIPTION
### What problem do you want to solve?

In #61, the definition of zve_list was not moved into policy_for_date and is still assigned in each test_case. As of 2009 the Abgeltungssteuer was introduced we also need to include this in the favorability check of the different ways to calculate the income tax. For more details see #76 and #81.

### Todo

- [x] We move the assignment of zve_list to policy_for_date
- [ ] We adapt favorability_check.py as discussed in #81 .  