### PR TITLE
Fix off-by-one error in include statement in documentation.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Welcome to GETTSIM's documentation!
 ===================================
 
 .. include:: ../README.rst
-   :start-line: 32
+   :start-line: 31
    :end-line: 41
 
 


### PR DESCRIPTION
### What problem do you want to solve?

Inclusion of README.rst in main page of docs starts one line too late.

https://gettsim.readthedocs.io/en/latest/
