### PR TITLE
Fix Windows on Azure.

### DIFF
--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -63,7 +63,7 @@ jobs:
 
   - script: |
       call activate gettsim
-      conda develop .
+      pip install -e .
       pytest
 
 

--- a/.azure-pipelines.yaml
+++ b/.azure-pipelines.yaml
@@ -30,7 +30,6 @@ jobs:
 
   - bash: |
       source activate gettsim
-      conda develop .
       pytest --cov-report xml --cov=./
 
   - bash: |
@@ -63,7 +62,6 @@ jobs:
 
   - script: |
       call activate gettsim
-      pip install -e .
       pytest
 
 
@@ -99,5 +97,4 @@ jobs:
 
   - bash: |
       source activate gettsim
-      conda develop .
       pytest


### PR DESCRIPTION
### What problem do you want to solve?

The tests on Windows did not run and reported success. See git push --set-upstream origin fix-windows-on-azure for an example.

The error was introduced in #100 when I changed from `pip install -e` to `conda develop .`. Apparently, the latter causes trouble, but I do not know why.

Azure is nice because it provides more resources than other providers, but the lack of an official support for conda is just annoying. In the long-run we should keep an eye on Github Actions which also support 10 simultaenous builds and also caches stages. This means, for example, that as long the environment is not changed, it is not recreated. This would speed up the test suite tremendously. Conda support is also premature at the moment (`https://github.com/actions/starter-workflows/issues/44`), but maybe this will change in future.