### PR TITLE
Remove parameters ahvermiet and ahvzins

### DIFF
--- a/gettsim/data/arbeitsl_geld_2.yaml
+++ b/gettsim/data/arbeitsl_geld_2.yaml
@@ -710,31 +710,3 @@ a2_but_2:
     2019-08-01:
       value: 15
       note: G. v. 29.04.2019 BGBl. I S. 530.
-ahvmiet:
-  name:
-    de: ALG2 Jährliche Mieteinnahmen, ab denen Immobilienvermögen unterstellt wird
-    en:
-  description:
-    de:
-    en:
-  values:
-    2002-01-01:
-      value: 1200
-      note:
-    2006-01-01:
-      value: 0
-      note:
-ahvzins:
-  name:
-    de: ALG2 Jährlicher Zinsbetrag, ab dem Geldvermögen unterstellt wird
-    en:
-  description:
-    de:
-    en:
-  values:
-    2002-01-01:
-      value: 200
-      note:
-    2006-01-01:
-      value: 0
-      note:


### PR DESCRIPTION
This PR removes the parameters [ahvermiet](https://github.com/iza-institute-of-labor-economics/gettsim/blob/669a2cd585f13735b42cd0977eca7a8dbf3fb4ee/gettsim/data/arbeitsl_geld_2.yaml#L684) and [ahvzins](https://github.com/iza-institute-of-labor-economics/gettsim/blob/669a2cd585f13735b42cd0977eca7a8dbf3fb4ee/gettsim/data/arbeitsl_geld_2.yaml#L698).

### What problem do you want to solve?

closes #128

### Considered alternatives

* add description and note keys

Discuss alternatives in #128