### PR TITLE
proper modelling of Kinderfreibetrag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   (:ghuser:`MaxBlesch`, :ghuser:`mjbloemer`)
 * Add ALG II transfer withdrawal 2005-01-01 to 2005-09-30
   (:ghuser:`mjbloemer`, :ghuser:`MaxBlesch`)
+* Child tax allowance modelled as two separate items. (:ghuser:`Eric-Sommer`)
 
 
 0.2.1 - 2019-11-20

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -20,7 +20,7 @@ kifreib_s_exm:
       note: Wert in Euro. Wert laut Gesetz 2102 DM.
     1996-01-01:
       value: 1601
-      note: Art. 1. G. v. 20.10.1995 BGBl. I S. 1250. Wert in Euro. Laut Gesetz 261 DM pro Monat.
+      note: Art. 1. G. v. 11.10.1995 BGBl. I S. 1250. Wert in Euro. Laut Gesetz 261 DM pro Monat.
     1997-01-01:
       value: 1767
       note: Wert in Euro. Laut Gesetz 288 DM pro Monat (ab 2000 3456 DM pro Jahr)

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -8,25 +8,22 @@ kifreib_s_exm:
   values:
     1984-01-01:
       value: 110
-      note:
+      note: Wert in Euro. Der Betrag laut Gesetz ist 216 DM.
     1986-01-01:
       value: 635
-      note:
+      note: Art. 1 G. v. 26.06.1985 BGBl. I S. 1153. Wert in Euro. Der Betrag im Gesetz lautet 1242 DM.
     1990-01-01:
       value: 773
-      note: .
-    1994-01-01:
+      note: Wert in Euro. Wert laut Gesetz 1512 DM.
+    1992-01-01:
       value: 1049
-      note:
+      note: Wert in Euro. Wert laut Gesetz 2102 DM.
     1996-01-01:
       value: 1601
-      note: Art. 1. G. v. 20.10.1995 BGBl. I S. 1250
+      note: Art. 1. G. v. 20.10.1995 BGBl. I S. 1250. Wert in Euro. Laut Gesetz 261 DM pro Monat.
     1997-01-01:
       value: 1767
-      note: .
-    2000-01-01:
-      value: 1767
-      note: Art. 1 G. v. 28.12.1999 BGBl. I S. 2552
+      note: Wert in Euro. Laut Gesetz 288 DM pro Monat (ab 2000 3456 DM pro Jahr)
     2002-01-01:
       value: 1824
       note: Art. 1 G. v. 19.12.2000 BGBl. I S. 1790
@@ -61,7 +58,7 @@ kifreib_bea:
   values:
     2000-01-01:
       value: 774
-      note: Art. 1 G. v. 28.12.1999 BGBl. I. S. 2552
+      note: Art. 1 G. v. 28.12.1999 BGBl. I. S. 2552. Wert in Euro. Wert laut Gesetz 1512 DM.
     2002-01-01:
       value: 1080
       note:

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -59,9 +59,6 @@ kifreib_bea:
     de: §32 (6) EStG, seit 2000.
     en:
   values:
-    1970-01-01:
-      value: 0
-      note: implizit
     2000-01-01:
       value: 774
       note: Art. 1 G. v. 28.12.1999 BGBl. I. S. 2552

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -1,56 +1,76 @@
-kifreib:
+kifreib_s_exm:
   name:
-    de: Kinderfreibetrag (sächliches Existenzminimum des Kindes sowie Betreuungs- und Erziehungs- oder Ausbildungsbedarf)
+    de: Kinderfreibetrag (sächliches Existenzminimum des Kindes).
     en:
   description:
     de: § 32(6) EStG
     en:
   values:
     1984-01-01:
-      value: 221
+      value: 110
       note:
     1986-01-01:
-      value: 1270
+      value: 635
       note:
     1990-01-01:
-      value: 1546
+      value: 773
       note: .
     1994-01-01:
-      value: 2098
+      value: 1049
       note:
     1996-01-01:
-      value: 3203
-      note: .
+      value: 1601
+      note: Art. 1. G. v. 20.10.1995 BGBl. I S. 1250
     1997-01-01:
-      value: 3534
+      value: 1767
       note: .
     2000-01-01:
-      value: 5080
-      note: .
+      value: 1767
+      note: Art. 1 G. v. 28.12.1999 BGBl. I S. 2552
     2002-01-01:
-      value: 5808
-      note:
+      value: 1824
+      note: Art. 1 G. v. 19.12.2000 BGBl. I S. 1790
     2009-01-01:
-      value: 6024
+      value: 1932
+      note: Art. 1 G. v. 22.12.2008 BGBl. I S. 2955
+    2010-01-01:
+      value: 2184
+      note: Art. 1 G. v. 22.12.2009 BGBl. I S. 3950
+    2015-01-01:
+      value: 2256
+      note: Art. 1 G. v. 16.07.2015 BGBl. I S. 1202
+    2016-01-01:
+      value: 2304
+      note: Art. 2 G. v. 16.07.2015 BGBl. I S. 1202
+    2017-01-01:
+      value: 2358
+      note: Art. 8 G. v. 20.12.2016 BGBl. I. S. 3000
+    2018-01-01:
+      value: 2394
+      note: Art. 9 G. v. 20.12.2016 BGBl. I. S. 3000
+    2019-01-01:
+      value: 2490
+      note: Art. 1 G. v. 29.11.2018 BGBl. I S. 2210
+kifreib_bea:
+  name:
+    de: Kinderfreibetrag. Betreuungs-, Erziehungs-, Ausbildungsfreibetrag.
+    en:
+  description:
+    de: §32 (6) EStG, seit 2000.
+    en:
+  values:
+    1970-01-01:
+      value: 0
+      note: implizit
+    2000-01-01:
+      value: 774
+      note: Art. 1 G. v. 28.12.1999 BGBl. I. S. 2552
+    2002-01-01:
+      value: 1080
       note:
     2010-01-01:
-      value: 7008
-      note:
-    2015-01-01:
-      value: 7152
-      note: geändert durch BGBl. 2015 Nr. 30
-    2016-01-01:
-      value: 7248
-      note: geändert durch BGBl. 2015 Nr. 30
-    2017-01-01:
-      value: 7356
-      note: geändert durch Artikel 8 v. 20.12.2016, BGBl I S. 3000
-    2018-01-01:
-      value: 7428
-      note: Art. 9 BGBL I. S. 3000 v. 20.12.2016
-    2019-01-01:
-      value: 7620
-      note:
+      value: 1320
+      note: Art. 1 G. v. 22.12.2009 BGBl. I S. 3950
 vorsp_rv:
   name:
     de: Bemessungsgrundlage, Vorsorgepauschale, Anteil des Beitrags der RV-Beiträge

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -8,7 +8,7 @@ kifreib_s_exm:
   values:
     1983-01-01:
       value: 110
-      note: Art. 1 G. v. 20.12.1985 BGBl. I S. 1857. Wert in Euro. Der Betrag laut Gesetz ist 216 DM.
+      note: Art. 1 G. v. 23.12.1982 BGBl. I S. 1857. Wert in Euro. Der Betrag laut Gesetz ist 216 DM.
     1986-01-01:
       value: 635
       note: Art. 1 G. v. 26.06.1985 BGBl. I S. 1153. Wert in Euro. Der Betrag im Gesetz lautet 1242 DM.

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -3,12 +3,12 @@ kifreib_s_exm:
     de: Kinderfreibetrag (sächliches Existenzminimum des Kindes).
     en:
   description:
-    de: § 32(6) EStG
+    de: § 32(6) EStG, früher auch Absatz 7 und 8.
     en:
   values:
-    1984-01-01:
+    1983-01-01:
       value: 110
-      note: Wert in Euro. Der Betrag laut Gesetz ist 216 DM.
+      note: Art. 1 G. v. 20.12.1985 BGBl. I S. 1857. Wert in Euro. Der Betrag laut Gesetz ist 216 DM.
     1986-01-01:
       value: 635
       note: Art. 1 G. v. 26.06.1985 BGBl. I S. 1153. Wert in Euro. Der Betrag im Gesetz lautet 1242 DM.
@@ -17,7 +17,7 @@ kifreib_s_exm:
       note: Artikel 1 G. v. 25.07.1988 BGBl. I S. 1093. Wert in Euro. Der Betrag im Gesetz lautet 1512 DM.
     1992-01-01:
       value: 1049
-      note: Wert in Euro. Wert laut Gesetz 2102 DM.
+      note: Art. 1 G. v. 25.02.1992 BGBl. I S. 297. Wert in Euro. Wert laut Gesetz 2052 DM.
     1996-01-01:
       value: 1601
       note: Art. 1. G. v. 11.10.1995 BGBl. I S. 1250. Wert in Euro. Laut Gesetz 261 DM pro Monat.

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -26,7 +26,7 @@ kifreib_s_exm:
       note: Wert in Euro. Laut Gesetz 288 DM pro Monat (ab 2000 3456 DM pro Jahr)
     2002-01-01:
       value: 1824
-      note: Art. 1 G. v. 19.12.2000 BGBl. I S. 1790
+      note: Art. 1 G. v. 16.08.2001 BGBl. I S. 2074
     2009-01-01:
       value: 1932
       note: Art. 1 G. v. 22.12.2008 BGBl. I S. 2955
@@ -61,7 +61,7 @@ kifreib_bea:
       note: Art. 1 G. v. 28.12.1999 BGBl. I. S. 2552. Wert in Euro. Wert laut Gesetz 1512 DM.
     2002-01-01:
       value: 1080
-      note:
+      note: Art. 1 G. v. 16.08.2001 BGBl. I S. 2074
     2010-01-01:
       value: 1320
       note: Art. 1 G. v. 22.12.2009 BGBl. I S. 3950

--- a/gettsim/data/e_st_abzuege.yaml
+++ b/gettsim/data/e_st_abzuege.yaml
@@ -14,7 +14,7 @@ kifreib_s_exm:
       note: Art. 1 G. v. 26.06.1985 BGBl. I S. 1153. Wert in Euro. Der Betrag im Gesetz lautet 1242 DM.
     1990-01-01:
       value: 773
-      note: Wert in Euro. Wert laut Gesetz 1512 DM.
+      note: Artikel 1 G. v. 25.07.1988 BGBl. I S. 1093. Wert in Euro. Der Betrag im Gesetz lautet 1512 DM.
     1992-01-01:
       value: 1049
       note: Wert in Euro. Wert laut Gesetz 2102 DM.

--- a/gettsim/taxes/zve.py
+++ b/gettsim/taxes/zve.py
@@ -111,7 +111,11 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
     nokfb_lower = tax_unit["zve_nokfb"].min()
 
     # Add both components for ease of notation.
-    kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+    try:
+        kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+        # 'kifreib_bea' does not exist before 2000.
+    except NameError:
+        kifreib_total = params["kifreib_s_exm"]
 
     diff_kifreib = nokfb_lower - (kifreib_total * child_num_kg)
 

--- a/gettsim/taxes/zve.py
+++ b/gettsim/taxes/zve.py
@@ -111,10 +111,10 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
     nokfb_lower = tax_unit["zve_nokfb"].min()
 
     # Add both components for ease of notation.
-    try:
-        kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+    if params["year"] >= 2000:
         # 'kifreib_bea' does not exist before 2000.
-    except NameError:
+        kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+    else:
         kifreib_total = params["kifreib_s_exm"]
 
     diff_kifreib = nokfb_lower - (kifreib_total * child_num_kg)

--- a/gettsim/taxes/zve.py
+++ b/gettsim/taxes/zve.py
@@ -112,8 +112,8 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
 
     # Add both components for ease of notation.
     if params["year"] >= 2000:
-        # 'kifreib_bea' does not exist before 2000.
         kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+    # 'kifreib_bea' does not exist before 2000.
     else:
         kifreib_total = params["kifreib_s_exm"]
 

--- a/gettsim/taxes/zve.py
+++ b/gettsim/taxes/zve.py
@@ -110,7 +110,10 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
     # Find out who has the lower zve among partners
     nokfb_lower = tax_unit["zve_nokfb"].min()
 
-    diff_kifreib = nokfb_lower - (0.5 * params["kifreib"] * child_num_kg)
+    # Add both components for ease of notation.
+    kifreib_total = params["kifreib_s_exm"] + params["kifreib_bea"]
+
+    diff_kifreib = nokfb_lower - (kifreib_total * child_num_kg)
 
     # If the couple is married and one earns not enough to split the kinderfeibetrag,
     # things get a bit more complicated
@@ -118,9 +121,9 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
 
         # The high earner gets half of the total kinderfreibetrag plus the amount the
         # lower earner can't claim.
-        kifreib_higher = (0.5 * params["kifreib"] * child_num_kg) + abs(diff_kifreib)
+        kifreib_higher = (kifreib_total * child_num_kg) + abs(diff_kifreib)
         # The second earner subtracts the remaining amount
-        kifreib_lower = 0.5 * params["kifreib"] * child_num_kg - abs(diff_kifreib)
+        kifreib_lower = kifreib_total * child_num_kg - abs(diff_kifreib)
         # Then we assign each earner the amount and return the series
         tax_unit.loc[
             ~tax_unit["child"] & tax_unit["zve_nokfb"] != nokfb_lower, "kifreib"
@@ -134,9 +137,7 @@ def kinderfreibetrag(tax_unit, params, kindergeld_params):
     # For non married couples or couples where both earn enough this are a lot easier.
     # Just split the kinderfreibetrag 50/50.
     else:
-        tax_unit.loc[~tax_unit["child"], "kifreib"] = (
-            0.5 * params["kifreib"] * child_num_kg
-        )
+        tax_unit.loc[~tax_unit["child"], "kifreib"] = kifreib_total * child_num_kg
         return tax_unit
 
 


### PR DESCRIPTION
closes #104 

- [x] separate parameters for *sächliches Existenzminimum* and *BEA*.
- [x] numbers as in the law, not multiplied by two. `zve()` adjusted accordingly.