### PR TITLE
Fix encoding issue with files containing umlauts.

### DIFF
--- a/gettsim/pre_processing/policy_for_date.py
+++ b/gettsim/pre_processing/policy_for_date.py
@@ -39,7 +39,7 @@ from gettsim.taxes.zve import vorsorge_since_2010
 def get_policies_for_date(year, group, month=1, day=1, raw_group_data=None):
     if not raw_group_data:
         raw_group_data = yaml.safe_load(
-            (ROOT_DIR / "data" / f"{group}.yaml").read_text()
+            (ROOT_DIR / "data" / f"{group}.yaml").read_text(encoding="utf-8")
         )
 
     actual_date = datetime.date(year=year, month=month, day=day)
@@ -188,7 +188,7 @@ def process_data(policy_date, group, raw_group_data=None, parameters=None):
 def load_regrouped_data(policy_date, group, raw_group_data=None, parameters=None):
     if not raw_group_data:
         raw_group_data = yaml.safe_load(
-            (ROOT_DIR / "data" / f"{group}.yaml").read_text()
+            (ROOT_DIR / "data" / f"{group}.yaml").read_text(encoding="utf-8")
         )
     additional_keys = ["note", "reference", "deviation_from"]
     tax_data = {}

--- a/gettsim/tests/conftest.py
+++ b/gettsim/tests/conftest.py
@@ -6,64 +6,90 @@ from gettsim.config import ROOT_DIR
 
 @pytest.fixture(scope="session")
 def ges_renten_vers_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "ges_renten_vers.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "ges_renten_vers.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def eink_st_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "eink_st.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "eink_st.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def eink_st_abzuege_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "eink_st_abzuege.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "eink_st_abzuege.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def soli_st_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "soli_st.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "soli_st.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def arbeitsl_geld_2_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "arbeitsl_geld_2.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "arbeitsl_geld_2.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def arbeitsl_geld_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "arbeitsl_geld.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "arbeitsl_geld.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def unterhalt_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "unterhalt.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "unterhalt.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def abgelt_st_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "abgelt_st.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "abgelt_st.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def wohngeld_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "wohngeld.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "wohngeld.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def kinderzuschlag_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "kinderzuschlag.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "kinderzuschlag.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def kindergeld_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "kindergeld.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "kindergeld.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def soz_vers_beitr_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "soz_vers_beitr.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "soz_vers_beitr.yaml").read_text(encoding="utf-8")
+    )
 
 
 @pytest.fixture(scope="session")
 def elterngeld_raw_data():
-    return yaml.safe_load((ROOT_DIR / "data" / "elterngeld.yaml").read_text())
+    return yaml.safe_load(
+        (ROOT_DIR / "data" / "elterngeld.yaml").read_text(encoding="utf-8")
+    )


### PR DESCRIPTION
### What problem do you want to solve?

Some tests failed because they relied on params in yaml files which have not been read with the correct encoding. Use utf-8 for files containing umlauts.

FYI: @Eric-Sommer @hmgaudecker @MaxBlesch 