### PR TITLE
Release 0.3.1 and skip and emit warning if gettsim.test() is repeatedly called.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ This is a record of all past ``gettsim`` releases and what went into them in rev
 chronological order. We follow `semantic versioning <https://semver.org/>`_ and all
 releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_.
 
+0.3.x - 2020-06-xx
+------------------
+
+* :gh:`188` adds a skip and a warning if `gettsim.test()` is repeatedly called.
+
 0.3.0 - 2020-06-03
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,12 +5,17 @@ This is a record of all past ``gettsim`` releases and what went into them in rev
 chronological order. We follow `semantic versioning <https://semver.org/>`_ and all
 releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_.
 
-0.3.x - 2020-06-xx
+
+0.3.1 - 2020-06-05
 ------------------
 
-* :gh:`188` adds a skip and a warning if `gettsim.test()` is repeatedly called.
+* :gh:`188` removes misleading code bits from the documentation and adds a copy-button
+  (:ghuser:`tobiasraabe`).
+* :gh:`191` adds a skip and a warning if `gettsim.test()` is repeatedly called
+  (:ghuser:`tobiasraabe`).
 
-0.3.0 - 2020-06-03
+
+0.3.0 - 2020-06-04
 ------------------
 
 * Cleanup of ALG II parameters and documentation (:ghuser:`mjbloemer`)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,11 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Extensions configuration ------------------------------------------------
 
-extlinks = {"ghuser": ("https://github.com/%s", "@")}
+extlinks = {
+    "ghuser": ("https://github.com/%s", "@"),
+    "gh": ("https://github.com/iza-institute-of-labor-economics/gettsim/pulls/%s", "#"),
+}
+
 todo_include_todos = True
 todo_emit_warnings = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ import datetime as dt
 project = "GETTSIM"
 copyright = f"{dt.datetime.now().year}, GETTSIM team"  # noqa: A001
 author = "GETTSIM team"
-release = "0.3.0"
+release = "0.3.1"
 version = ".".join(release.split(".")[:2])
 
 

--- a/gettsim/__init__.py
+++ b/gettsim/__init__.py
@@ -1,12 +1,25 @@
+import itertools
+import warnings
+
 import pytest
 
 from gettsim.config import ROOT_DIR
 from gettsim.interface import compute_taxes_and_transfers  # noqa: F401
 from gettsim.pre_processing.policy_for_date import get_policies_for_date  # noqa: F401
 
-
 __version__ = "0.3.0"
+
+COUNTER_TEST_EXECUTIONS = itertools.count()
 
 
 def test():
-    pytest.main([str(ROOT_DIR)])
+    n_test_executions = next(COUNTER_TEST_EXECUTIONS)
+
+    if n_test_executions == 0:
+        pytest.main([str(ROOT_DIR)])
+    else:
+        warnings.warn(
+            "Repeated execution of the test suite is not possible. Start a new Python"
+            "session or restart the kernel in a Jupyter/IPython notebook to re-run the"
+            "tests."
+        )

--- a/gettsim/__init__.py
+++ b/gettsim/__init__.py
@@ -7,7 +7,7 @@ from gettsim.config import ROOT_DIR
 from gettsim.interface import compute_taxes_and_transfers  # noqa: F401
 from gettsim.pre_processing.policy_for_date import get_policies_for_date  # noqa: F401
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 COUNTER_TEST_EXECUTIONS = itertools.count()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ PROJECT_URLS = {
 
 setup(
     name="gettsim",
-    version="0.3.0",
+    version="0.3.1",
     description=DESCRIPTION,
     long_description=DESCRIPTION + "\n\n" + README,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
### What problem do you want to solve?

Repeatedly calling `gettsim.test()` is not possible because there seems to be some state dependence.

### Solution

Skip all other calls to the function except the first and emit a warning.