### PR TITLE
Fix levels of internal variables and provide helpful error message if variable with wrong level is requested as target

### DIFF
--- a/gettsim/benefits/arbeitsl_geld_2/eink_anr_frei.py
+++ b/gettsim/benefits/arbeitsl_geld_2/eink_anr_frei.py
@@ -16,10 +16,9 @@ def eink_anr_frei_bis_10_2005(
     return out
 
 
-def eink_anr_frei_ab_10_2005(
-    bruttolohn_m, kinder_in_hh_individual, arbeitsl_geld_2_params
-):
+def eink_anr_frei_ab_10_2005(hh_id, bruttolohn_m, kinder_in_hh, arbeitsl_geld_2_params):
     out = bruttolohn_m * 0
+    kinder_in_hh_individual = hh_id.replace(kinder_in_hh).astype(bool)
     out.loc[kinder_in_hh_individual] = piecewise_polynomial(
         x=bruttolohn_m.loc[kinder_in_hh_individual],
         thresholds=arbeitsl_geld_2_params["eink_anr_frei_kinder"]["thresholds"],
@@ -39,9 +38,7 @@ def eink_anr_frei_ab_10_2005(
     return out
 
 
-def arbeitsl_geld_2_2005_netto_quote(
-    bruttolohn_m, nettolohn_m, arbeitsl_geld_2_params,
-):
+def arbeitsl_geld_2_2005_netto_quote(bruttolohn_m, nettolohn_m, arbeitsl_geld_2_params):
     """Calculate Nettoquote.
 
     Quotienten von bereinigtem Nettoeinkommen und Bruttoeinkommen. § 3 Abs. 2 Alg II-V.

--- a/gettsim/demographic_vars.py
+++ b/gettsim/demographic_vars.py
@@ -67,10 +67,6 @@ def kinder_in_hh(kind, hh_id):
     return kind.groupby(hh_id).any()
 
 
-def kinder_in_hh_individual(hh_id, kinder_in_hh):
-    return hh_id.replace(kinder_in_hh).astype(bool)
-
-
 def haushaltsgröße(hh_id):
     return hh_id.groupby(hh_id).transform("size")
 

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -210,7 +210,10 @@ def _expand_data(data, ids):
     for name, s in data.items():
         for level in ["hh", "tu"]:
             if f"_{level}_" in name or name.endswith(f"_{level}"):
-                expanded_s = s.loc[ids[f"{level}_id"]]
+                try:
+                    expanded_s = s.loc[ids[f"{level}_id"]]
+                except KeyError:
+                    raise KeyError(f"Cannot expand {name} to level {level}")
                 expanded_s.index = ids[f"{level}_id"].index
                 data[name] = expanded_s
 

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -213,7 +213,13 @@ def _expand_data(data, ids):
                 try:
                     expanded_s = s.loc[ids[f"{level}_id"]]
                 except KeyError:
-                    raise KeyError(f"Cannot expand {name} to level {level}")
+                    raise KeyError(
+                        f"Variable '{name}' is not a reduced series with one value per "
+                        f"value in '{level}'. If it is not a reduced series, change the"
+                        f" name such that it does not include '_{level}_' or ends with "
+                        f"`_{level}`. If it should be a reduced series, fix the "
+                        "function."
+                    )
                 expanded_s.index = ids[f"{level}_id"].index
                 data[name] = expanded_s
 

--- a/gettsim/tests/test_interface.py
+++ b/gettsim/tests/test_interface.py
@@ -1,7 +1,10 @@
 from contextlib import contextmanager
 
+import numpy as np
+import pandas as pd
 import pytest
 
+from gettsim.interface import _expand_data
 from gettsim.interface import _fail_if_functions_and_columns_overlap
 from gettsim.interface import _fail_if_user_columns_are_not_in_data
 from gettsim.interface import _fail_if_user_columns_are_not_in_functions
@@ -55,3 +58,13 @@ def test_fail_if_functions_and_columns_overlap(
 ):
     with expectation:
         _fail_if_functions_and_columns_overlap(data, functions, type_, user_columns)
+
+
+def test_expand_data_raise_error():
+    data = {"wrong_variable_hh": pd.Series(data=np.arange(4), index=np.arange(4))}
+    ids = pd.Series(
+        data=np.arange(8), index=np.arange(4).repeat(2), name="hh_id"
+    ).to_frame()
+
+    with pytest.raises(KeyError):
+        _expand_data(data, ids)


### PR DESCRIPTION
### What problem do you want to solve?

`kinder_in_hh_individual` did not play well with `debug=True` because it is not at the household level

### Solution

- Remove as it was a one-liner used in one place only
- Add a custom error message to the interface (suggestions for improvements welcome!)