### PR TITLE
Add a check for non-unique targets.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ chronological order. We follow `semantic versioning <https://semver.org/>`_ and 
 releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_.
 
 
+0.3.3 - 2020-xx-xx
+------------------
+
+* :gh:`xxx` adds a check for duplicate ``targets`` (:ghuser:`tobiasraabe`).
+
+
 0.3.2 - 2020-06-19
 ------------------
 

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -1,3 +1,4 @@
+import collections
 import copy
 import textwrap
 from pathlib import Path
@@ -72,6 +73,7 @@ def compute_taxes_and_transfers(
 
     if isinstance(targets, str):
         targets = [targets]
+    _fail_if_targets_are_not_unique(targets)
 
     if user_columns is None:
         user_columns = []
@@ -265,6 +267,32 @@ def _reduce_series_to_value_per_group(name, s, level, groups):
         raise ValueError(message)
 
     return grouper.max()
+
+
+def _fail_if_targets_are_not_unique(targets):
+    """Fail if targets are not unique.
+
+    Example
+    -------
+    >>> _fail_if_targets_are_not_unique(["a", "a", "b", "c", "c", "c"])
+    Traceback (most recent call last):
+     ...
+    ValueError: The following targets are given multiple times, but should be unique:
+    <BLANKLINE>
+    [
+        "a",
+        "c",
+    ]
+    <BLANKLINE>
+
+    """
+    dupls = [item for item, count in collections.Counter(targets).items() if count > 1]
+    if dupls:
+        formatted = create_linewise_printed_list(dupls)
+        raise ValueError(
+            "The following targets are given multiple times, but should be unique:"
+            f"\n{formatted}"
+        )
 
 
 def _fail_if_user_columns_are_not_in_data(data, columns):

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ warn-symbols =
 	pytest.mark.wip = Remove 'wip' mark for tests.
 
 [tool:pytest]
+addopts = --doctest-modules
 filterwarnings =
 	ignore: .*XMLParser*:DeprecationWarning
 	ignore: .*'tree.iter()'*:PendingDeprecationWarning


### PR DESCRIPTION
### What problem do you want to solve?

The ``targets`` passed by the user might not be unique and create duplicated columns in the output. Raise an error if it happens.