### PR TITLE
Support Python 3.8.

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -5,9 +5,10 @@ package:
   version: {{ data.get('version') }}
 
 source:
-  path: ../
+  git_url: ../
 
 build:
+  number: 0
   noarch: python
 
 requirements:
@@ -21,6 +22,7 @@ requirements:
     - networkx
     - pandas
     - pydot
+    - pygments
     - pytest
     - pyyaml
 

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pyyaml
 
 test:
+  requires:
+    - pytest
   source_files:
     - gettsim/data
     - gettsim/tests

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run pre-commits.
-        if: runner.os == 'Linux' && matrix.python-version == '3.7'
+        if: runner.os == 'Linux' && matrix.python-version == '3.8'
         shell: bash -l {0}
         run: |
           pre-commit install -f --install-hooks

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7']
+        python-version: ['3.6', '3.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - uses: goanpeca/setup-miniconda@v1
@@ -30,13 +30,13 @@ jobs:
         run: pytest --cov-report=xml --cov=./
 
       - name: Upload coverage report.
-        if: runner.os == 'Linux' && matrix.python-version == '3.7'
+        if: runner.os == 'Linux' && matrix.python-version == '3.8'
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run pre-commits.
-        if: runner.os == 'Linux' && matrix.python-version == '3.7'
+        if: runner.os == 'Linux' && matrix.python-version == '3.8'
         shell: bash -l {0}
         run: |
           pre-commit install -f --install-hooks

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -8,7 +8,9 @@ on:
     - '*'
 
 jobs:
+
   run-tests:
+
     name: Run tests for ${{ matrix.os }} on ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -16,6 +18,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.6', '3.7', '3.8']
+
     steps:
       - uses: actions/checkout@v2
       - uses: goanpeca/setup-miniconda@v1

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run pre-commits.
-        if: runner.os == 'Linux' && matrix.python-version == '3.8'
+        if: runner.os == 'Linux' && matrix.python-version == '3.7'
         shell: bash -l {0}
         run: |
           pre-commit install -f --install-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: ^\.
 repos:
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.0
+    rev: v2.3.4
     hooks:
     -   id: reorder-python-imports
         files: '(\.pyi?|wscript)$'
@@ -20,7 +20,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.4.3
+    rev: v2.7.2
     hooks:
     -   id: pyupgrade
         args: [
@@ -44,7 +44,7 @@ repos:
         -   id: doc8
             args: [--max-line-length, "88"]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
     -   id: flake8
         files: '(\.py|wscript)$'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,6 @@ repos:
     rev: v2.3.4
     hooks:
     -   id: reorder-python-imports
-        files: '(\.pyi?|wscript)$'
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
@@ -23,33 +22,45 @@ repos:
     rev: v2.7.2
     hooks:
     -   id: pyupgrade
-        args: [
-          --py36-plus
-        ]
+        args: [--py36-plus]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.7.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==19.3b0]
-        files: '(\.md|\.rst)$'
+        additional_dependencies: [black]
 -   repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:
     -   id: black
-        files: '(\.pyi?|wscript)$'
-        language_version: python3.7
 -   repo: https://github.com/PyCQA/doc8
     rev: 0.8.1rc3
     hooks:
-        -   id: doc8
-            args: [--max-line-length, "88"]
+    -   id: doc8
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
     hooks:
     -   id: flake8
-        files: '(\.py|wscript)$'
         additional_dependencies: [
-            flake8-alfred, flake8-bugbear, flake8-builtins, flake8-comprehensions,
-            flake8-docstrings, flake8-eradicate, flake8-print, flake8-todo,
-            flake8-unused-arguments, pep8-naming, pydocstyle, Pygments,
+            flake8-alfred,
+            flake8-bugbear,
+            flake8-builtins,
+            flake8-comprehensions,
+            flake8-docstrings,
+            flake8-eradicate,
+            flake8-print,
+            # flake8-pytest-style,  # produces SyntaxError with umlauts.
+            flake8-todo,
+            flake8-unused-arguments,
+            pep8-naming,
+            pydocstyle,
+            Pygments,
         ]
+# -   repo: https://github.com/codespell-project/codespell
+#     rev: v1.17.1
+#     hooks:
+#     -   id: codespell
+-   repo: meta
+    hooks:
+    -   id: check-hooks-apply
+    -   id: check-useless-excludes
+    # -   id: identity  # Prints all files passed to pre-commits. Debugging.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.8
 
 conda:
   environment: docs/rtd_environment.yml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   ``functions`` instead of ``user_functions``, ``set_up_policy_environment`` instead of
   ``get_policy_for_date``, ``columns_overriding_functions`` instead of ``user_columns``
   and some more changes.
+* :gh:`225` makes gettsim ready for Python 3.8 (:ghuser:`tobiasraabe`).
 
 
 0.3.4 - 2020-xx-xx

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python
   - bokeh
   - ipython
   - nbsphinx

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - pdbpp
   - pre-commit
   - pydot
+  - pygments
   - pyyaml
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,5 @@ dependencies:
   - sphinx-automodapi
   - sphinx-copybutton
   - sphinx_rtd_theme
-  - virtualenv >= 20.0.3
   - pip:
     - bump2version

--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,6 @@ dependencies:
   - sphinx-automodapi
   - sphinx-copybutton
   - sphinx_rtd_theme
+  - virtualenv >= 20.0.3
   - pip:
     - bump2version

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: gettsim
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python
   - pip
   - anaconda-client
   - bokeh

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: gettsim
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python>=3.7
   - pip
   - anaconda-client
   - bokeh

--- a/gettsim/tests/test_functions_loader.py
+++ b/gettsim/tests/test_functions_loader.py
@@ -1,7 +1,7 @@
 import textwrap
 
-from gettsim.functions_loader import _load_functions
 from gettsim.config import ROOT_DIR
+from gettsim.functions_loader import _load_functions
 
 
 def func():

--- a/gettsim/tests/test_functions_loader.py
+++ b/gettsim/tests/test_functions_loader.py
@@ -1,7 +1,7 @@
 import textwrap
-from pathlib import Path
 
 from gettsim.functions_loader import _load_functions
+from gettsim.config import ROOT_DIR
 
 
 def func():
@@ -23,9 +23,7 @@ def test_load_modules():
 
 
 def test_load_path():
-    assert _load_functions(
-        Path(__file__).parent.joinpath("..", "soz_vers", "krankenv_pflegev.py")
-    )
+    assert _load_functions(ROOT_DIR / "soz_vers" / "krankenv_pflegev.py")
 
 
 def test_special_attribute_module_is_set(tmp_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,6 @@ filterwarnings =
 	ignore: evaluating in Python space because the '\*' operator is not supported by
 	ignore: The TerminalReporter.writer attribute is
 	ignore: Repeated execution of the test suite
-	ignore: The 'check_less_precise' keyword in testing.assert_*_equal is deprecated
+	ignore: The 'check_less_precise' keyword in testing.assert_
 markers =
 	wip: Test that are work-in-progress.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,5 +40,6 @@ filterwarnings =
 	ignore: evaluating in Python space because the '\*' operator is not supported by
 	ignore: The TerminalReporter.writer attribute is
 	ignore: Repeated execution of the test suite
+	ignore: The 'check_less_precise' keyword in testing.assert_*_equal is deprecated
 markers =
 	wip: Test that are work-in-progress.


### PR DESCRIPTION
- gettsim is now tested with Python 3.8. There had been no problems.
- gettsim also works with pandas 1.1 which caused some problems with estimagic. They changed the way to test two pandas series or dataframes only up to some precision. `check_less_precise` (https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.testing.assert_series_equal.html) is deprecated since 1.1 and replaced by atol and rtol. At some point, we should switch and set pandas 1.1 as the new lower bound.