### PR TITLE
Fix broken links in tutorials

### DIFF
--- a/docs/gettsim_objects/variables.rst
+++ b/docs/gettsim_objects/variables.rst
@@ -3,7 +3,7 @@
 Basic input variables
 =====================
 
-The table below gives an overview of all variables needed to run GETTSIM completly.
+The table below gives an overview of all variables needed to run GETTSIM completely.
 Note that the variables with _hh at the end, have to be constant over the whole
 household.
 

--- a/docs/tutorials/advanced_usage.ipynb
+++ b/docs/tutorials/advanced_usage.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "To get a better picture of how *Kindergeld* is implemented in GETTSIM and, meanwhile, of the structure of the German taxes and transfers system, we can utilize GETTSIM's visualization capabilities which are concentrated in the function `plot_dag`. This function creates a directed acyclic graph (DAG) for the taxes and transfers system. It offers many different visualization possibilities. The [guide on visualizing the taxes and transfers system](../how_to_guides/visualizing_the_system.ipynb) gives an in depth explanation of the function. \n",
     "\n",
-    "To figure out which variables are relevant for the child benefit, we plot an according slice of the entire taxes and transfers system implemented in GETTSIM using `plot_dag`. The function was already imported with all other relevant packages at the beginning of this tutorial. To select the relevant plot, we have to define selectors that we can pass as arguments to the function. We can check the possible output variables [here](../gettsim_objects/variables.rst) to find the relevant variable name for our application."
+    "To figure out which variables are relevant for the child benefit, we plot an according slice of the entire taxes and transfers system implemented in GETTSIM using `plot_dag`. The function was already imported with all other relevant packages at the beginning of this tutorial. To select the relevant plot, we have to define selectors that we can pass as arguments to the function. We can check the possible output variables [here](../gettsim_objects/variables_out.rst) to find the relevant variable name for our application."
    ]
   },
   {
@@ -1552,7 +1552,7 @@
    "source": [
     "#### Error Messages and Warnings: Unused Inputs\n",
     "\n",
-    "The function `compute_taxes_and_transfers` also has an option that allows you to check for unused inputs in your data. This functionality is controlled through the argument `check_minimal_specification`. By default, it is set to `ignore`, meaning no check is conduced. However, it can also be set to `warn` to trigger a warning or `raise` and error that includes a message stating the unused inputs."
+    "The function `compute_taxes_and_transfers` also has an option that allows you to check for unused inputs in your data. This functionality is controlled through the argument `check_minimal_specification`. By default, it is set to `ignore`, meaning no check is conduced. However, it can also be set to `warn` to trigger a warning or `raise` an error that includes a message stating the unused inputs."
    ]
   },
   {

--- a/docs/tutorials/basic_usage.ipynb
+++ b/docs/tutorials/basic_usage.ipynb
@@ -217,7 +217,7 @@
     "\n",
     "The data has to fulfill certain requirements in order for GETTSIM to be able to process it properly. Specifically, GETTSIM requires data to be specified as a [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) with  columns marking different input variables. GETTSIM parses the column names, which means that the data columns must be named in a specific way for GETTSIM to recognize them as input variables.\n",
     "\n",
-    "There are a total of 41 input names that GETTSIM recognizes, as especially transfers in the German system depend on many different variables. There is a detailed list of them [here](https://gettsim.readthedocs.io/en/latest/crosswalk.html#required-input-columns). The information specified in these inputs can be used to compute taxes and transfers for the selected household, tax unit, or individual data. The required inputs depend on the desired outputs i.e. the data set does not necessarily have to contain all 41 input variables. A small example is illustrated below. \n",
+    "There are a total of 41 input names that GETTSIM recognizes, as especially transfers in the German system depend on many different variables. There is a detailed list of them [here](https://gettsim.readthedocs.io/en/stable/gettsim_objects/variables.html). The information specified in these inputs can be used to compute taxes and transfers for the selected household, tax unit, or individual data. The required inputs depend on the desired outputs i.e. the data set does not necessarily have to contain all 41 input variables. A small example is illustrated below. \n",
     "\n",
     "#### Exemplary Data Set\n",
     "\n",

--- a/docs/tutorials/debugging.ipynb
+++ b/docs/tutorials/debugging.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Eventually, all code will fail. Even GETTSIM's and your code is no exception. Therefore, GETTSIM offers a debug mode for the function `compute_taxes_and_transfers` which helps you to find the source of the error.\n",
     "\n",
-    "Let us take the same example as used in the [tutorial on basic usage](basic_usage.ipynb), but reduced to the computation of `rentev_beitr_m` which are the monthly contribution to the pension insurance."
+    "Let us take the same example as used in the [tutorial on basic usage](basic_usage.ipynb), but reduced to the computation of `rentenv_beitr_m` which are the monthly contribution to the pension insurance."
    ]
   },
   {


### PR DESCRIPTION
### What problem do you want to solve?

The "Basic Usage" and "Advanced Usage" tutorials contained a link to the possible input variables and possible output variables respectively. The former link gave a "page not found", and the latter was supposed to link to the output variables and instead linked the input variables.

Also corrected some typos.

### Todo

- [x] Fix link in "Basic Usage.ipynb"
- [x] Fix link in "Advanced Usage.ipynb"
- [x] Fix Typos in "Advanced Usage.ipynb", "Debugging.ipynb" and "Variables.rst"
