### PR TITLE
Remove SOEP correspondence from Documentation

### DIFF
--- a/docs/gettsim_objects/variables.rst
+++ b/docs/gettsim_objects/variables.rst
@@ -14,7 +14,7 @@ household.
 +-------------------------+----------------------------------------------+-------------+
 | _`tu_id`                | Tax Unit identifier                          | IntSeries   |
 +-------------------------+----------------------------------------------+-------------+
-| _`kind`                 | Dummy: Child by SOEP Definition              | BoolSeries  |
+| _`kind`                 | Dummy: Dependent child living with parents   | BoolSeries  |
 +-------------------------+----------------------------------------------+-------------+
 | _`anz_minderj_hh`       | Number of children between 0 and 18 in hous  | IntSeries   |
 +-------------------------+----------------------------------------------+-------------+


### PR DESCRIPTION
### What problem do you want to solve?
The list of input variables defines `kind` as `Dummy: Child by SOEP definition`. I changed that since gettsim is supposed to be agnostic of which survey is used as input.