### PR TITLE
Fix capital income in synthetic data

### DIFF
--- a/docs/gettsim_objects/variables.rst
+++ b/docs/gettsim_objects/variables.rst
@@ -14,7 +14,7 @@ household.
 +-------------------------+----------------------------------------------+-------------+
 | _`tu_id`                | Tax Unit identifier                          | IntSeries   |
 +-------------------------+----------------------------------------------+-------------+
-| _`kind`                 | Dummy: Child by SOEP Definition              | BoolSeries  |
+| _`kind`                 | Dummy: Dependent child living with parents   | BoolSeries  |
 +-------------------------+----------------------------------------------+-------------+
 | _`anz_minderj_hh`       | Number of children between 0 and 18 in hous  | IntSeries   |
 +-------------------------+----------------------------------------------+-------------+

--- a/gettsim/synthetic_data/synthetic.py
+++ b/gettsim/synthetic_data/synthetic.py
@@ -288,7 +288,7 @@ def create_one_set_of_households(
 
     # Income and wealth
     df["bruttolohn_m"] = kwargs.get("bruttolohn_m", 0)
-    df["kapital_eink_m"] = kwargs.get("bruttolohn_m", 0)
+    df["kapital_eink_m"] = kwargs.get("kapital_eink_m", 0)
     df["eink_selbst_m"] = kwargs.get("eink_selbst_m", 0)
     df["vermögen_hh"] = kwargs.get("vermögen_hh", 0)
     dim = kwargs.get("dimension", 1)


### PR DESCRIPTION
### What problem do you want to solve?

When creating synthetic data, capital income is wrongly assigned according to `bruttolohn_m` argument. This is hereby corrected
