### PR TITLE
Add updated wohngeld parameters for 2022

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
    (:ghuser:`LauraGergeleit`).
 * :gh:`319`:gh:`320` Implement changes for social assistance and social security
    becoming effective in 2022 (:ghuser:`Eric-Sommer`).
+* :gh:`322`: Add updated wohngeld parameters for 2022 (:ghuser:`mjbloemer`,
+  :ghuser:`lillyfischer`).
 
 0.4.1 - 2021-04-11
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
    (:ghuser:`LauraGergeleit`).
 * :gh:`319`:gh:`320` Implement changes for social assistance and social security
    becoming effective in 2022 (:ghuser:`Eric-Sommer`).
-* :gh:`322`: Add updated wohngeld parameters for 2022 (:ghuser:`mjbloemer`,
+* :gh:`322` Add updated wohngeld parameters for 2022 (:ghuser:`mjbloemer`,
   :ghuser:`lillyfischer`).
 
 0.4.1 - 2021-04-11

--- a/gettsim/parameters/wohngeld.yaml
+++ b/gettsim/parameters/wohngeld.yaml
@@ -372,6 +372,57 @@ koeffizienten_berechnungsformel:
         a: -0.14
         b: 0.000101
         c: 0.0000513
+    2022-01-01:
+      note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die Werte für a, b und c werden neu/erneut definiert.
+      reference: V. v. 08.06.2021 BGBl. I S. 1371.
+      1:
+        a: 0.04
+        b: 0.000564
+        c: 0.0001157
+      2:
+        a: 0.03
+        b: 0.000394
+        c: 0.0000863
+      3:
+        a: 0.02
+        b: 0.00034
+        c: 0.0000695
+      4:
+        a: 0.01
+        b: 0.000304
+        c: 0.0000361
+      5:
+        a: 0
+        b: 0.000268
+        c: 0.0000352
+      6:
+        a: -0.01
+        b: 0.000251
+        c: 0.0000302
+      7:
+        a: -0.02
+        b: 0.000232
+        c: 0.000031
+      8:
+        a: -0.03
+        b: 0.000206
+        c: 0.000031
+      9:
+        a: -0.04
+        b: 0.000179
+        c: 0.0000326
+      10:
+        a: -0.06
+        b: 0.000143
+        c: 0.0000377
+      11:
+        a: -0.1
+        b: 0.000107
+        c: 0.0000444
+      12:
+        a: -0.14
+        b: 0.000098
+        c: 0.0000503
 
 bonus_12_mehr:
   name:
@@ -1654,6 +1705,57 @@ max_miete:
       6: 139
       7: 153
     reference: Art. 1 G. v. 30.11.2019, BGBl I S. 1877.
+  2022-01-01:
+    1:
+      1: 347
+      2: 392
+      3: 438
+      4: 491
+      5: 540
+      6: 591
+      7: 651
+    2:
+      1: 420
+      2: 474
+      3: 530
+      4: 595
+      5: 654
+      6: 716
+      7: 788
+    3:
+      1: 501
+      2: 564
+      3: 631
+      4: 708
+      5: 778
+      6: 853
+      7: 937
+    4:
+      1: 584
+      2: 659
+      3: 736
+      4: 825
+      5: 909
+      6: 995
+      7: 1095
+    5:
+      1: 667
+      2: 752
+      3: 841
+      4: 944
+      5: 1038
+      6: 1137
+      7: 1251
+    5plus:
+      1: 79
+      2: 90
+      3: 102
+      4: 114
+      5: 124
+      6: 143
+      7: 157
+    note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die monatlichen Werte werden um 2,788 Prozent erhöht. Es gelten Rundungsregeln die hier berücksichtigt werden.
+    reference: V. v. 08.06.2021 BGBl. I S. 1371.
 vermögensfreibetrag_grund:
   name:
     de: Grund-Vermögensfreibetrag für den Haushalt

--- a/gettsim/parameters/wohngeld.yaml
+++ b/gettsim/parameters/wohngeld.yaml
@@ -19,7 +19,7 @@ koeffizienten_berechnungsformel:
       de: Parameter a, b, c der Wohngeldformel
       en:
     description:
-      de:  WoGG - Anlage 2 (bis 2019 Anlage 1) (zu § 19 (1))
+      de:  WoGG - Anlage 2 (bis 2019 Anlage 1) (zu § 19 (1)). Zudem WoGG § 43 in Verbindung mit V. v. 03.06.2021 BGBl. I S. 1369.
       en:
     note: The keys from 1 to 12 below refer to the household size.
     1984-01-01:
@@ -373,7 +373,7 @@ koeffizienten_berechnungsformel:
         b: 0.000101
         c: 0.0000513
     2022-01-01:
-      note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die Werte für a, b und c werden neu/erneut definiert.
+      note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes.
       reference: V. v. 03.06.2021 BGBl. I S. 1369.
       1:
         a: 0.04
@@ -681,7 +681,7 @@ max_miete:
     de: Höchstbeträge für Miete und Belastung
     en:
   description:
-    de: Anlage 1 WoGG, bis 2019 §12 (1) WoGG. Vor 2009 §8 (1) WoGG.
+    de: Anlage 1 WoGG, bis 2019 §12 (1) WoGG. Vor 2009 §8 (1) WoGG. Zudem WoGG § 43 in Verbindung mit V. v. 03.06.2021 BGBl. I S. 1369.
     en:
   note: Die Werte sind nach Anzahl Personen - maximales Baujahr des Hauses (vor 2009) - Mietstufe geordnet. Alle Werte in vollen Euro.
   unit: euro
@@ -1754,7 +1754,7 @@ max_miete:
       5: 124
       6: 143
       7: 157
-    note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die monatlichen Werte werden um 2,788 Prozent erhöht. Es gelten Rundungsregeln die hier berücksichtigt werden.
+    note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes.
     reference: V. v. 03.06.2021 BGBl. I S. 1369.
 vermögensfreibetrag_grund:
   name:

--- a/gettsim/parameters/wohngeld.yaml
+++ b/gettsim/parameters/wohngeld.yaml
@@ -374,7 +374,7 @@ koeffizienten_berechnungsformel:
         c: 0.0000513
     2022-01-01:
       note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die Werte für a, b und c werden neu/erneut definiert.
-      reference: V. v. 08.06.2021 BGBl. I S. 1371.
+      reference: V. v. 03.06.2021 BGBl. I S. 1369.
       1:
         a: 0.04
         b: 0.000564
@@ -1755,7 +1755,7 @@ max_miete:
       6: 143
       7: 157
     note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes. Die monatlichen Werte werden um 2,788 Prozent erhöht. Es gelten Rundungsregeln die hier berücksichtigt werden.
-    reference: V. v. 08.06.2021 BGBl. I S. 1371.
+    reference: V. v. 03.06.2021 BGBl. I S. 1369.
 vermögensfreibetrag_grund:
   name:
     de: Grund-Vermögensfreibetrag für den Haushalt

--- a/gettsim/parameters/wohngeld.yaml
+++ b/gettsim/parameters/wohngeld.yaml
@@ -373,7 +373,6 @@ koeffizienten_berechnungsformel:
         b: 0.000101
         c: 0.0000513
     2022-01-01:
-      note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes.
       reference: V. v. 03.06.2021 BGBl. I S. 1369.
       1:
         a: 0.04
@@ -1754,7 +1753,6 @@ max_miete:
       5: 124
       6: 143
       7: 157
-    note: Eine neuartige Verordnung regelt die Forschreibung des Wohngeldes.
     reference: V. v. 03.06.2021 BGBl. I S. 1369.
 vermögensfreibetrag_grund:
   name:

--- a/gettsim/parameters/wohngeld.yaml
+++ b/gettsim/parameters/wohngeld.yaml
@@ -19,7 +19,7 @@ koeffizienten_berechnungsformel:
       de: Parameter a, b, c der Wohngeldformel
       en:
     description:
-      de:  WoGG - Anlage 2 (bis 2019 Anlage 1) (zu § 19 (1)). Zudem WoGG § 43 in Verbindung mit V. v. 03.06.2021 BGBl. I S. 1369.
+      de:  WoGG - Anlage 2 (bis 2019 Anlage 1) (zu § 19 (1)). Seit 2022 auch §24 Wohngeldverordnung (WoGV).
       en:
     note: The keys from 1 to 12 below refer to the household size.
     1984-01-01:
@@ -681,7 +681,7 @@ max_miete:
     de: Höchstbeträge für Miete und Belastung
     en:
   description:
-    de: Anlage 1 WoGG, bis 2019 §12 (1) WoGG. Vor 2009 §8 (1) WoGG. Zudem WoGG § 43 in Verbindung mit V. v. 03.06.2021 BGBl. I S. 1369.
+    de: Anlage 1 WoGG, bis 2019 §12 (1) WoGG. Vor 2009 §8 (1) WoGG. Seit 2022 auch §24 Wohngeldverordnung (WoGV).
     en:
   note: Die Werte sind nach Anzahl Personen - maximales Baujahr des Hauses (vor 2009) - Mietstufe geordnet. Alle Werte in vollen Euro.
   unit: euro


### PR DESCRIPTION
A new decree updates Wohngeld parameters: Values are updated by 2,788 percent. Additional rounding rules apply.

Reference: V. v. 03.06.2021 BGBl. I S. 1369. https://offenegesetze.de/veroeffentlichung/bgbl1/2021/28#page=113

Additional Reference: https://www.bundesregierung.de/breg-de/suche/wohngeld-steigt-ab-januar-2022-1884454

Note that [_Anlage 1 (zu § 12 Absatz 1)_](https://www.buzer.de/gesetz/8380/a233450.htm) and [_Anlage 2 (zu § 19 Absatz 1)_](https://www.buzer.de/gesetz/8380/a156499.htm
) remains unchanged. This is because there is a new [§ 43](https://www.buzer.de/gesetz/8380/a156498.htm):

> 2Die erste Fortschreibung des Wohngeldes erfolgt zum 1. Januar 2022.
> 
>   (2) § 12 Absatz 4 Satz 1 findet bei der Fortschreibung des Wohngeldes keine Anwendung.

This PR implements these changes.

