### PR TITLE
Implement optional rounding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,9 +27,8 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   abbreviations, now `kinderfreib` everywhere). (:ghuser:`hmgaudecker`,
   :ghuser:`ChristianZimpelmann`)
 * :gh:`343` New argument for `compute_taxes_and_transfers`: `rounding`. If set to False,
-  rounding of outputs is disabled. Note: This PR did not yet add rounding
-  specifications for all relevant functions. This will be done in future PRs.
-  (:ghuser:`ChristianZimpelmann`).
+  rounding of outputs is disabled. Add rounding for `eink_st_tu`. Rounding for other
+  functions will be introduced in future PRs. (:ghuser:`ChristianZimpelmann`).
 
 0.4.2 — 2022-01-25
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,8 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   tax is meant). Make variables consistent (e.g. `kinderfreibetrag` had different
   abbreviations, now `kinderfreib` everywhere). (:ghuser:`hmgaudecker`,
   :ghuser:`ChristianZimpelmann`)
-
+* :gh:`343` New argument for `compute_taxes_and_transfers`: `rounding`. If set to False,
+  rounding of outputs is disabled (:ghuser:`ChristianZimpelmann`).
 
 0.4.2 — 2022-01-25
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,9 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   abbreviations, now `kinderfreib` everywhere). (:ghuser:`hmgaudecker`,
   :ghuser:`ChristianZimpelmann`)
 * :gh:`343` New argument for `compute_taxes_and_transfers`: `rounding`. If set to False,
-  rounding of outputs is disabled (:ghuser:`ChristianZimpelmann`).
+  rounding of outputs is disabled. Note: This PR did not yet add rounding
+  specifications for all relevant functions. This will be done in future PRs.
+  (:ghuser:`ChristianZimpelmann`).
 
 0.4.2 — 2022-01-25
 ------------------

--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
   - python
   - bokeh
+  - black
   - ipython
   - nbsphinx
   - numpydoc

--- a/gettsim/dag.py
+++ b/gettsim/dag.py
@@ -260,20 +260,21 @@ def execute_dag(dag, data, targets, debug):
 
     Returns
     -------
-    data : dict
+    results : dict
         Dictionary of pd.Series with the resulting data.
 
     """
+    results = data.copy()
     # Needed for garbage collection.
-    visited_nodes = set(data)
+    visited_nodes = set(results)
     skipped_nodes = set()
 
     for task in nx.topological_sort(dag):
-        if task not in data and task not in skipped_nodes:
+        if task not in results and task not in skipped_nodes:
             if "function" in dag.nodes[task]:
-                kwargs = _dict_subset(data, dag.predecessors(task))
+                kwargs = _dict_subset(results, dag.predecessors(task))
                 try:
-                    data[task] = dag.nodes[task]["function"](**kwargs).rename(task)
+                    results[task] = dag.nodes[task]["function"](**kwargs).rename(task)
                 except Exception as e:
                     if debug:
                         traceback.print_exc()
@@ -291,9 +292,9 @@ def execute_dag(dag, data, targets, debug):
             visited_nodes.add(task)
 
             if not debug:
-                data = collect_garbage(data, task, visited_nodes, targets, dag)
+                results = collect_garbage(results, task, visited_nodes, targets, dag)
 
-    return data
+    return results
 
 
 def _dict_subset(dictionary, keys):

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -213,12 +213,12 @@ def prepare_functions_and_set_up_dag(
     _fail_if_targets_not_in_functions(all_functions, targets)
 
     # Partial parameters to functions such that they disappear in the DAG.
-    partialled_functions = _partial_parameters_to_functions(all_functions, params)
+    partialed_functions = _partial_parameters_to_functions(all_functions, params)
 
     # Create DAG and perform checks which depend on data which is not part of the DAG
     # interface.
     dag = create_dag(
-        functions=partialled_functions,
+        functions=partialed_functions,
         targets=targets,
         columns_overriding_functions=columns_overriding_functions,
         check_minimal_specification=check_minimal_specification,

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -96,12 +96,12 @@ def compute_taxes_and_transfers(
 
     # Set up dag.
     dag = prepare_functions_and_set_up_dag(
-        params,
-        targets,
-        columns_overriding_functions,
-        check_minimal_specification,
-        rounding,
-        all_functions,
+        all_functions=all_functions,
+        targets=targets,
+        params=params,
+        columns_overriding_functions=columns_overriding_functions,
+        check_minimal_specification=check_minimal_specification,
+        rounding=rounding,
     )
 
     # Do some checks.
@@ -175,24 +175,27 @@ def check_data_check_functions_and_merge_functions(
 
 
 def prepare_functions_and_set_up_dag(
-    params,
+    all_functions,
     targets,
+    params,
     columns_overriding_functions,
     check_minimal_specification,
     rounding,
-    all_functions,
 ):
     """Set up the DAG. Partial functions before that and add rounding afterwards.
 
     Parameters
     ----------
-    params : dict
-        A dictionary with parameters from the policy environment. For more
-        information see the documentation of the :ref:`param_files`.
+    all_functions : dict
+        All internal and user functions except the ones that are overridden by an input
+        column.
     targets : list of str
         List of strings with names of functions whose output is actually
         needed by the user. By default, ``targets`` contains all key outputs as
         defined by `gettsim.config.DEFAULT_TARGETS`.
+    params : dict
+        A dictionary with parameters from the policy environment. For more
+        information see the documentation of the :ref:`param_files`.
     columns_overriding_functions : str list of str
         Names of columns in the data which are preferred over function defined in the
         tax and transfer system.
@@ -201,9 +204,6 @@ def prepare_functions_and_set_up_dag(
         be silenced, emitted as warnings or errors.
     rounding : bool, default True
         Indicator for whether rounding should be applied as specified in the law.
-    all_functions : dict
-        All internal and user functions except the ones that are overridden by an input
-        column.
 
     Returns
     -------
@@ -213,15 +213,15 @@ def prepare_functions_and_set_up_dag(
     _fail_if_targets_not_in_functions(all_functions, targets)
 
     # Partial parameters to functions such that they disappear in the DAG.
-    all_functions = _partial_parameters_to_functions(all_functions, params)
+    partialled_functions = _partial_parameters_to_functions(all_functions, params)
 
     # Create DAG and perform checks which depend on data which is not part of the DAG
     # interface.
     dag = create_dag(
-        all_functions,
-        targets,
-        columns_overriding_functions,
-        check_minimal_specification,
+        functions=partialled_functions,
+        targets=targets,
+        columns_overriding_functions=columns_overriding_functions,
+        check_minimal_specification=check_minimal_specification,
     )
 
     # Add rounding to functions.

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -628,7 +628,6 @@ def _add_rounding_to_functions_in_dag(dag, params, data):
                     and "rounding" in params[params_key]
                     and task in params[params_key]["rounding"]
                 ):
-
                     raise KeyError(
                         f"Rounding specifications for function {task} are expected in "
                         "the parameter dictionary at "
@@ -636,6 +635,7 @@ def _add_rounding_to_functions_in_dag(dag, params, data):
                         " do not exist. If this function should not be rounded,"
                         " remove the respective decorator."
                     )
+
                 rounding_spec = params[params_key]["rounding"][task]
 
                 # Check if expected parameters are present in rounding specifications

--- a/gettsim/interface.py
+++ b/gettsim/interface.py
@@ -766,12 +766,9 @@ def _add_rounding_to_functions_in_dag(dag_raw, params):
                             f"is missing at ['{params_key}']['rounding']['{task}']."
                         )
                     )
-
                 # Add rounding.
-                base = rounding_spec["base"]
-                direction = rounding_spec["direction"]
                 dag.nodes[task]["function"] = _add_rounding_to_one_function(
-                    base, direction
+                    base=rounding_spec["base"], direction=rounding_spec["direction"],
                 )(dag.nodes[task]["function"])
     return dag
 

--- a/gettsim/parameters/eink_st.yaml
+++ b/gettsim/parameters/eink_st.yaml
@@ -239,3 +239,12 @@ ertragsanteil:
       upper_threshold: inf
       rate_linear: 0.0
       intercept_at_lower_threshold: 1
+
+rounding:
+  eink_st_tu:
+    note:
+      en: Starting date unclear
+    1984-01-01:
+      base: 1
+      direction: down
+      reference: § 32a Abs. 1 S. 6 EStG

--- a/gettsim/parameters/eink_st.yaml
+++ b/gettsim/parameters/eink_st.yaml
@@ -248,3 +248,7 @@ rounding:
       base: 1
       direction: down
       reference: § 32a Abs. 1 S. 6 EStG
+    1997-01-01:
+      base: 1
+      direction: down
+      reference: § 32a Abs. 1 S. 6 EStG

--- a/gettsim/parameters/ges_rentenv.yaml
+++ b/gettsim/parameters/ges_rentenv.yaml
@@ -468,10 +468,3 @@ rentenwert_ost:
   2019-07-01:
     scalar: 31.89
     reference:
-
-rounding:
-  ges_rente_m:
-    1984-01-01:
-      base: 0.01
-      direction: nearest
-      reference: § 123 SGB VI Abs. 1

--- a/gettsim/parameters/ges_rentenv.yaml
+++ b/gettsim/parameters/ges_rentenv.yaml
@@ -468,3 +468,10 @@ rentenwert_ost:
   2019-07-01:
     scalar: 31.89
     reference:
+
+rounding:
+  ges_rente_m:
+    1984-01-01:
+      base: 0.01
+      direction: nearest
+      reference: § 123 SGB VI Abs. 1

--- a/gettsim/policy_environment.py
+++ b/gettsim/policy_environment.py
@@ -377,33 +377,36 @@ def _load_rounding_parameters(date, rounding_spec):
     date : datetime.date
         The date for which the policy system is set up.
     rounding_spec : dictionary
-        The dictionary that contains rounding parameters
-        for several functions and several dates
+          - Keys: Functions to be rounded.
+          - Values: Rounding parameters for all dates
 
     Returns:
-        dictionary: Rounding parameters for the specified date
+        dictionary:
+          - Keys: Functions to be rounded.
+          - Values: Rounding parameters for the specified date
     """
     out = {}
     rounding_parameters = ["direction", "base"]
 
     # Load values of all parameters at the specified date.
-    for function_name in rounding_spec.keys():
+    for function_name, rounding_spec_func in rounding_spec.items():
 
         # Find all specified policy dates before date.
         policy_dates_before_date = sorted(
             key
-            for key in rounding_spec[function_name].keys()
+            for key in rounding_spec_func.keys()
             if isinstance(key, datetime.date) and key <= date
         )
 
         # If any rounding specs are defined for a date before the specified
         # date, copy them to params dictionary.
-        # If not, no key for this function name is created (this will
-        # raise an error later if the user doesn't adjust params df before calling
-        # `compute_taxes_and_transfers`).
+        # If no appropriate rounding specs are found for the requested date,
+        # the function will not appear in the returned dictionary.
+        # Note this will raise an error later unless the user adds an
+        # appropriate rounding specification to the parameters dictionary.
         if policy_dates_before_date:
             policy_date_in_place = np.max(policy_dates_before_date)
-            policy_in_place = rounding_spec[function_name][policy_date_in_place]
+            policy_in_place = rounding_spec_func[policy_date_in_place]
             out[function_name] = {}
             for key in [k for k in policy_in_place if k in rounding_parameters]:
                 out[function_name][key] = policy_in_place[key]

--- a/gettsim/shared.py
+++ b/gettsim/shared.py
@@ -60,8 +60,7 @@ def get_names_of_arguments_without_defaults(function):
 
 
 def add_rounding_spec(params_key):
-    """Decorator to add the parameter key where rounding specifications are
-    found to a function.
+    """Decorator adding the location of the rounding specification to a function.
 
     Parameters
     ----------

--- a/gettsim/shared.py
+++ b/gettsim/shared.py
@@ -57,3 +57,30 @@ def get_names_of_arguments_without_defaults(function):
             argument_names_without_defaults.append(parameter)
 
     return argument_names_without_defaults
+
+
+def add_rounding_spec(base, direction):
+    """Decorator to add rounding specification attributes to a function.
+    Parameters
+    ----------
+    base : float
+        Precision of rounding (e.g. 0.1 to round to the first decimal place)
+    direction : str
+        Whether the series should be rounded up, down or to the nearest number
+    Returns
+    -------
+    func : function
+        Function with rounding specification attributes
+    """
+
+    # Check inputs
+    if not (type(base) in [int, float]):
+        raise ValueError("'base' needs to be a number")
+    if direction not in ["up", "down", "nearest"]:
+        raise ValueError("'direction' must be one of 'up', 'down', or 'nearest'")
+
+    def inner(func):
+        func.__roundingspec__ = {"base": base, "direction": direction}
+        return func
+
+    return inner

--- a/gettsim/shared.py
+++ b/gettsim/shared.py
@@ -66,7 +66,7 @@ def add_rounding_spec(params_key):
     Parameters
     ----------
     params_key : str
-        Key of the parameters dictionnairy where rouding specifications are found. For
+        Key of the parameters dictionary where rouding specifications are found. For
         functions that are not user-written this is just the name of the respective
         .yaml file.
 
@@ -75,12 +75,6 @@ def add_rounding_spec(params_key):
     func : function
         Function with __rounding_params_key__ attribute
     """
-
-    # # Check inputs
-    # if not (type(base) in [int, float]):
-    #     raise ValueError("'base' needs to be a number")
-    # if direction not in ["up", "down", "nearest"]:
-    #     raise ValueError("'direction' must be one of 'up', 'down', or 'nearest'")
 
     def inner(func):
         func.__rounding_params_key__ = params_key

--- a/gettsim/shared.py
+++ b/gettsim/shared.py
@@ -59,28 +59,31 @@ def get_names_of_arguments_without_defaults(function):
     return argument_names_without_defaults
 
 
-def add_rounding_spec(base, direction):
-    """Decorator to add rounding specification attributes to a function.
+def add_rounding_spec(params_key):
+    """Decorator to add the parameter key where rounding specifications are
+    found to a function.
+
     Parameters
     ----------
-    base : float
-        Precision of rounding (e.g. 0.1 to round to the first decimal place)
-    direction : str
-        Whether the series should be rounded up, down or to the nearest number
+    params_key : str
+        Key of the parameters dictionnairy where rouding specifications are found. For
+        functions that are not user-written this is just the name of the respective
+        .yaml file.
+
     Returns
     -------
     func : function
-        Function with rounding specification attributes
+        Function with __rounding_params_key__ attribute
     """
 
-    # Check inputs
-    if not (type(base) in [int, float]):
-        raise ValueError("'base' needs to be a number")
-    if direction not in ["up", "down", "nearest"]:
-        raise ValueError("'direction' must be one of 'up', 'down', or 'nearest'")
+    # # Check inputs
+    # if not (type(base) in [int, float]):
+    #     raise ValueError("'base' needs to be a number")
+    # if direction not in ["up", "down", "nearest"]:
+    #     raise ValueError("'direction' must be one of 'up', 'down', or 'nearest'")
 
     def inner(func):
-        func.__roundingspec__ = {"base": base, "direction": direction}
+        func.__rounding_params_key__ = params_key
         return func
 
     return inner

--- a/gettsim/taxes/favorability_check.py
+++ b/gettsim/taxes/favorability_check.py
@@ -9,6 +9,7 @@ similar check applies to whether it is more profitable to tax capital incomes wi
 standard 25% rate or to include it in the tariff.
 
 """
+from gettsim.shared import add_rounding_spec
 from gettsim.typing import BoolSeries
 from gettsim.typing import FloatSeries
 from gettsim.typing import IntSeries
@@ -43,6 +44,7 @@ def kinderfreib_günstiger_tu(
     return eink_st_kein_kinderfreib > eink_st_kinderfreib_tu
 
 
+@add_rounding_spec(params_key="eink_st")
 def eink_st_tu_bis_1996(eink_st_kinderfreib_tu: FloatSeries) -> FloatSeries:
     """Income tax calculation until 1996.
 
@@ -60,6 +62,7 @@ def eink_st_tu_bis_1996(eink_st_kinderfreib_tu: FloatSeries) -> FloatSeries:
     return eink_st_kinderfreib_tu
 
 
+@add_rounding_spec(params_key="eink_st")
 def eink_st_tu_ab_1997(
     eink_st_kein_kinderfreib_tu: FloatSeries,
     eink_st_kinderfreib_tu: FloatSeries,

--- a/gettsim/tests/test_docs.py
+++ b/gettsim/tests/test_docs.py
@@ -46,7 +46,7 @@ def test_all_input_vars_documented(
     default_input_variables, time_indep_function_names, all_function_names
 ):
     """Test if arguments of all non-internal functions are either the name of another
-    function, a documented input variable, or a parameter dictionnairy
+    function, a documented input variable, or a parameter dictionary
     """
     functions = _load_functions(PATHS_TO_INTERNAL_FUNCTIONS)
 

--- a/gettsim/tests/test_interface.py
+++ b/gettsim/tests/test_interface.py
@@ -170,6 +170,15 @@ def test_partial_parameters_to_functions():
     # Partial function produces correct result
     assert partial_func(2) == 3
 
+
+def test_partial_parameters_to_functions_removes_argument():
+    def test_func(arg_1, arbeitsl_geld_2_params):
+        return arg_1 + arbeitsl_geld_2_params["test_param_1"]
+
+    partial_func = _partial_parameters_to_functions(
+        {"test_func": test_func}, {"arbeitsl_geld_2": {"test_param_1": 1}}
+    )["test_func"]
+
     # Fails if params is added to partial function
     with pytest.raises(
         TypeError, match=("got multiple values for argument "),

--- a/gettsim/tests/test_interface.py
+++ b/gettsim/tests/test_interface.py
@@ -13,6 +13,8 @@ from gettsim.interface import _fail_if_columns_overriding_functions_are_not_in_d
 from gettsim.interface import _fail_if_columns_overriding_functions_are_not_in_functions
 from gettsim.interface import _fail_if_datatype_is_false
 from gettsim.interface import _fail_if_functions_and_columns_overlap
+from gettsim.interface import _partial_parameters_to_functions
+from gettsim.shared import add_rounding_spec
 
 
 @pytest.fixture(scope="module")
@@ -155,3 +157,38 @@ def test_consecutive_internal_test_runs():
 
     with pytest.warns(UserWarning, match="Repeated execution of the test suite"):
         test("--collect-only")
+
+
+def test_partial_parameters_to_functions():
+    def test_func(arg_1, arbeitsl_geld_2_params):
+        return arg_1 + arbeitsl_geld_2_params["test_param_1"]
+
+    partial_func = _partial_parameters_to_functions(
+        {"test_func": test_func}, {"arbeitsl_geld_2": {"test_param_1": 1}}
+    )["test_func"]
+
+    # Partial function produces correct result
+    assert partial_func(2) == 3
+
+    # Fails if params is added to partial function
+    with pytest.raises(
+        TypeError, match=("got multiple values for argument "),
+    ):
+        partial_func(2, {"test_param_1": 1})
+
+    # No error for original function
+    test_func(2, {"test_param_1": 1})
+
+
+def test_partial_parameters_to_functions_keep_decorator():
+    """Make sure that rounding decorator is kept for partial function"""
+
+    @add_rounding_spec(params_key="params_key_test")
+    def test_func(arg_1, arbeitsl_geld_2_params):
+        return arg_1 + arbeitsl_geld_2_params["test_param_1"]
+
+    partial_func = _partial_parameters_to_functions(
+        {"test_func": test_func}, {"arbeitsl_geld_2": {"test_param_1": 1}}
+    )["test_func"]
+
+    assert partial_func.__rounding_params_key__ == "params_key_test"

--- a/gettsim/tests/test_interface.py
+++ b/gettsim/tests/test_interface.py
@@ -38,6 +38,16 @@ def minimal_input_data():
     return out
 
 
+# Create a partial function which is used by some tests below
+def func_before_partial(arg_1, arbeitsl_geld_2_params):
+    return arg_1 + arbeitsl_geld_2_params["test_param_1"]
+
+
+func_after_partial = _partial_parameters_to_functions(
+    {"test_func": func_before_partial}, {"arbeitsl_geld_2": {"test_param_1": 1}}
+)["test_func"]
+
+
 def test_fail_if_datatype_is_false(input_data):
     with does_not_raise():
         _fail_if_datatype_is_false(input_data, [], [])
@@ -160,33 +170,21 @@ def test_consecutive_internal_test_runs():
 
 
 def test_partial_parameters_to_functions():
-    def test_func(arg_1, arbeitsl_geld_2_params):
-        return arg_1 + arbeitsl_geld_2_params["test_param_1"]
-
-    partial_func = _partial_parameters_to_functions(
-        {"test_func": test_func}, {"arbeitsl_geld_2": {"test_param_1": 1}}
-    )["test_func"]
 
     # Partial function produces correct result
-    assert partial_func(2) == 3
+    assert func_after_partial(2) == 3
 
 
 def test_partial_parameters_to_functions_removes_argument():
-    def test_func(arg_1, arbeitsl_geld_2_params):
-        return arg_1 + arbeitsl_geld_2_params["test_param_1"]
-
-    partial_func = _partial_parameters_to_functions(
-        {"test_func": test_func}, {"arbeitsl_geld_2": {"test_param_1": 1}}
-    )["test_func"]
 
     # Fails if params is added to partial function
     with pytest.raises(
         TypeError, match=("got multiple values for argument "),
     ):
-        partial_func(2, {"test_param_1": 1})
+        func_after_partial(2, {"test_param_1": 1})
 
     # No error for original function
-    test_func(2, {"test_param_1": 1})
+    func_before_partial(2, {"test_param_1": 1})
 
 
 def test_partial_parameters_to_functions_keep_decorator():

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -114,7 +114,6 @@ def test_rounding(base, direction, input_values, exp_output):
     ],
 )
 def test_no_rounding(base, direction, input_values, exp_output):
-    """Check if no rounding if disabled"""
 
     # Define function that should be rounded
     @add_rounding_spec(params_key="params_key_test")

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -52,7 +52,6 @@ def test_fail_if_no_rounding_specs(rounding_specs):
     "base, direction", [(1, "upper"), ("0.1", "down"), (5, "closest")],
 )
 def test_fail_if_rounding_specs_wrong_format(base, direction):
-    """Unsupported rounding specifications"""
     with pytest.raises(ValueError):
 
         @add_rounding_spec(params_key="params_key_test")

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -1,0 +1,182 @@
+import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from gettsim import compute_taxes_and_transfers
+from gettsim.config import INTERNAL_PARAM_GROUPS
+from gettsim.config import PATHS_TO_INTERNAL_FUNCTIONS
+from gettsim.config import ROOT_DIR
+from gettsim.functions_loader import _load_functions
+from gettsim.policy_environment import load_reforms_for_date
+from gettsim.shared import add_rounding_spec
+
+
+def test_decorator():
+    @add_rounding_spec(params_key="params_key_test")
+    def test_func():
+        return 0
+
+    assert test_func.__rounding_params_key__ == "params_key_test"
+
+
+@pytest.mark.parametrize(
+    "rounding_specs",
+    [{}, {"params_key_test": {}}, {"params_key_test": {"rounding": {}}}],
+)
+def test_fail_if_no_rounding_specs(rounding_specs):
+    """Missing rounding specifications"""
+
+    with pytest.raises(KeyError):
+
+        @add_rounding_spec(params_key="params_key_test")
+        def test_func():
+            return 0
+
+        compute_taxes_and_transfers(
+            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
+            functions=[test_func],
+            params=rounding_specs,
+            targets=["test_func"],
+        )
+
+
+@pytest.mark.parametrize(
+    "base, direction", [(1, "upper"), ("0.1", "down"), (5, "closest")],
+)
+def test_fail_if_rounding_specs_wrong_format(base, direction):
+    """Unsupported rounding specifications"""
+    with pytest.raises(ValueError):
+
+        @add_rounding_spec(params_key="params_key_test")
+        def test_func():
+            return 0
+
+        rounding_specs = {
+            "params_key_test": {
+                "rounding": {"test_func": {"base": base, "direction": direction}}
+            }
+        }
+
+        compute_taxes_and_transfers(
+            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
+            functions=[test_func],
+            params=rounding_specs,
+            targets=["test_func"],
+        )
+
+
+@pytest.mark.parametrize(
+    "base, direction, input_values, exp_output",
+    [
+        (1, "up", [100.24, 100.78], [101.0, 101.0]),
+        (1, "down", [100.24, 100.78], [100.0, 100.0]),
+        (1, "nearest", [100.24, 100.78], [100.0, 101.0]),
+        (5, "up", [100.24, 100.78], [105.0, 105.0]),
+        (0.1, "down", [100.24, 100.78], [100.2, 100.7]),
+        (0.001, "nearest", [100.24, 100.78], [100.24, 100.78]),
+    ],
+)
+def test_rounding(base, direction, input_values, exp_output):
+    """Check if rounding is correct"""
+
+    # Define function that should be rounded
+    @add_rounding_spec(params_key="params_key_test")
+    def test_func(income):
+        return income
+
+    data = pd.DataFrame([{"p_id": 1}, {"p_id": 2}])
+    data["income"] = input_values
+    rounding_specs = {
+        "params_key_test": {
+            "rounding": {"test_func": {"base": base, "direction": direction}}
+        }
+    }
+
+    calc_result = compute_taxes_and_transfers(
+        data=data, functions=[test_func], params=rounding_specs, targets=["test_func"],
+    )
+    np.array_equal(calc_result["test_func"].values, np.array(exp_output))
+
+
+@pytest.mark.parametrize(
+    "base, direction, input_values, exp_output",
+    [
+        (5, "up", [100.24, 100.78], [100.24, 100.78]),
+        (0.1, "down", [100.24, 100.78], [100.24, 100.78]),
+        (0.001, "nearest", [100.24, 100.78], [100.24, 100.78]),
+    ],
+)
+def test_no_rounding(base, direction, input_values, exp_output):
+    """Check if no rounding if disabled"""
+
+    # Define function that should be rounded
+    @add_rounding_spec(params_key="params_key_test")
+    def test_func(income):
+        return income
+
+    data = pd.DataFrame([{"p_id": 1}, {"p_id": 2}])
+    data["income"] = input_values
+    rounding_specs = {
+        "params_key_test": {
+            "rounding": {"test_func": {"base": base, "direction": direction}}
+        }
+    }
+
+    calc_result = compute_taxes_and_transfers(
+        data=data, functions=[test_func], params=rounding_specs, targets=["test_func"],
+    )
+    np.array_equal(calc_result["test_func"].values, np.array(exp_output))
+
+
+def test_decorator_for_all_functions_with_rounding_spec():
+    """Check if all functions for which rounding parameters are specified have
+    an attribute which indicates rounding
+    """
+
+    # Find all functions for which rounding parameters are specified
+    params_dict = {
+        group: yaml.load(
+            (ROOT_DIR / "parameters" / f"{group}.yaml").read_text(encoding="utf-8"),
+            Loader=yaml.CLoader,
+        )
+        for group in INTERNAL_PARAM_GROUPS
+    }
+    params_keys_with_rounding_spec = [
+        k for k in params_dict if "rounding" in params_dict[k]
+    ]
+    function_names_with_rounding_spec = [
+        fn for k in params_keys_with_rounding_spec for fn in params_dict[k]["rounding"]
+    ]
+
+    # Load mapping of time dependent functions. This will be much nicer after #334 is
+    # addressed.
+    time_dependent_functions = {}
+    for year in range(1990, 2021):
+        year_functions = load_reforms_for_date(datetime.date(year=year, month=1, day=1))
+        new_dict = {func.__name__: key for key, func in year_functions.items()}
+        time_dependent_functions = {**time_dependent_functions, **new_dict}
+
+    # Add time dependent functions for which rounding specs for new name exist
+    # and remove new name from list
+    function_names_to_check = function_names_with_rounding_spec + [
+        k
+        for k, v in time_dependent_functions.items()
+        if v in function_names_with_rounding_spec
+    ]
+    function_names_to_check = [
+        fn
+        for fn in function_names_to_check
+        if fn not in time_dependent_functions.values()
+    ]
+
+    # Loop over these functions and check if attribute __rounding_params_key__ exists
+    all_functions = _load_functions(PATHS_TO_INTERNAL_FUNCTIONS)
+    for fn in function_names_to_check:
+        assert hasattr(all_functions[fn], "__rounding_params_key__"), (
+            f"For the function {fn}, rounding parameters are specified. But the "
+            "function is missing the add_rounding_spec decorator. The attribute "
+            "__rounding_params_key__ is not found."
+        )

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -24,7 +24,12 @@ def test_decorator():
 
 @pytest.mark.parametrize(
     "rounding_specs",
-    [{}, {"params_key_test": {}}, {"params_key_test": {"rounding": {}}}],
+    [
+        {},
+        {"params_key_test": {}},
+        {"params_key_test": {"rounding": {}}},
+        {"params_key_test": {"rounding": {"test_func": {}}}},
+    ],
 )
 def test_fail_if_no_rounding_specs(rounding_specs):
     """Missing rounding specifications"""

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -31,8 +31,7 @@ def test_decorator():
         {"params_key_test": {"rounding": {"test_func": {}}}},
     ],
 )
-def test_fail_if_no_rounding_specs(rounding_specs):
-    """Missing rounding specifications"""
+def test_no_rounding_specs(rounding_specs):
 
     with pytest.raises(KeyError):
 
@@ -51,7 +50,7 @@ def test_fail_if_no_rounding_specs(rounding_specs):
 @pytest.mark.parametrize(
     "base, direction", [(1, "upper"), ("0.1", "down"), (5, "closest")],
 )
-def test_fail_if_rounding_specs_wrong_format(base, direction):
+def test_rounding_specs_wrong_format(base, direction):
     with pytest.raises(ValueError):
 
         @add_rounding_spec(params_key="params_key_test")

--- a/gettsim/tests/test_rounding.py
+++ b/gettsim/tests/test_rounding.py
@@ -13,6 +13,15 @@ from gettsim.functions_loader import _load_functions
 from gettsim.policy_environment import load_reforms_for_date
 from gettsim.shared import add_rounding_spec
 
+rounding_specs_and_exp_results = [
+    (1, "up", [100.24, 100.78], [101.0, 101.0]),
+    (1, "down", [100.24, 100.78], [100.0, 100.0]),
+    (1, "nearest", [100.24, 100.78], [100.0, 101.0]),
+    (5, "up", [100.24, 100.78], [105.0, 105.0]),
+    (0.1, "down", [100.24, 100.78], [100.2, 100.7]),
+    (0.001, "nearest", [100.24, 100.78], [100.24, 100.78]),
+]
+
 
 def test_decorator():
     @add_rounding_spec(params_key="params_key_test")
@@ -72,15 +81,7 @@ def test_rounding_specs_wrong_format(base, direction):
 
 
 @pytest.mark.parametrize(
-    "base, direction, input_values, exp_output",
-    [
-        (1, "up", [100.24, 100.78], [101.0, 101.0]),
-        (1, "down", [100.24, 100.78], [100.0, 100.0]),
-        (1, "nearest", [100.24, 100.78], [100.0, 101.0]),
-        (5, "up", [100.24, 100.78], [105.0, 105.0]),
-        (0.1, "down", [100.24, 100.78], [100.2, 100.7]),
-        (0.001, "nearest", [100.24, 100.78], [100.24, 100.78]),
-    ],
+    "base, direction, input_values, exp_output", rounding_specs_and_exp_results,
 )
 def test_rounding(base, direction, input_values, exp_output):
     """Check if rounding is correct"""
@@ -105,14 +106,9 @@ def test_rounding(base, direction, input_values, exp_output):
 
 
 @pytest.mark.parametrize(
-    "base, direction, input_values, exp_output",
-    [
-        (5, "up", [100.24, 100.78], [100.24, 100.78]),
-        (0.1, "down", [100.24, 100.78], [100.24, 100.78]),
-        (0.001, "nearest", [100.24, 100.78], [100.24, 100.78]),
-    ],
+    "base, direction, input_values_exp_output, _ignore", rounding_specs_and_exp_results,
 )
-def test_no_rounding(base, direction, input_values, exp_output):
+def test_no_rounding(base, direction, input_values_exp_output, _ignore):  # noqa: U101
 
     # Define function that should be rounded
     @add_rounding_spec(params_key="params_key_test")
@@ -120,7 +116,7 @@ def test_no_rounding(base, direction, input_values, exp_output):
         return income
 
     data = pd.DataFrame([{"p_id": 1}, {"p_id": 2}])
-    data["income"] = input_values
+    data["income"] = input_values_exp_output
     rounding_specs = {
         "params_key_test": {
             "rounding": {"test_func": {"base": base, "direction": direction}}
@@ -130,7 +126,7 @@ def test_no_rounding(base, direction, input_values, exp_output):
     calc_result = compute_taxes_and_transfers(
         data=data, functions=[test_func], params=rounding_specs, targets=["test_func"],
     )
-    np.array_equal(calc_result["test_func"].values, np.array(exp_output))
+    np.array_equal(calc_result["test_func"].values, np.array(input_values_exp_output))
 
 
 def test_decorator_for_all_functions_with_rounding_spec():


### PR DESCRIPTION
### What problem do you want to solve?

Implement the possibility for optional rounding as specified in [GEP-05](https://gettsim--324.org.readthedocs.build/en/324/geps/gep-05.html). 

And implement optional rounding for one examplary function (`eink_st_tu`)

Addresses #88.

#316 was started earlier and will implement rounding for all Grundrente and Grundsicherung im Alter variables after this PR is merged.


### Todo

- [x] Implement decorators functions
- [x] Implement way to set globally whether outputs should be rounded or not (where applicable)
- [x] Add rounding parameter and decorator for `eink_st_tu`
- [x] Write tests for rounding decorator

### Open ToDos after PR

- Reintroduce rounding where applicable