### PR TITLE
393 definition of regelaltersgrenze not correct

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
   (:ghuser:`Eric-Sommer`, :ghuser:`ChristianZimpelmann`).
 * :gh:`385` Make altersentlastungsbetrag dependent on age not on current
   date (:ghuser:`m-pannier`, :ghuser:`lillyfischer`).
+* :gh:`393` normal retirement age adjustment aligned with the rules.
+  (:ghuser:`TeBackh`).
 
 
 0.5.1 — 2022-04-21

--- a/gettsim/parameters/ges_rente.yaml
+++ b/gettsim/parameters/ges_rente.yaml
@@ -730,11 +730,12 @@ regelaltersgrenze:
   description:
     de:
       Stückweise lineare Funktion, die die Regelaltersgrenze angibt, bei der das Individuum mit seinem vollen Rentenanspruch in Rente
-      gehen kann. Geht die Person früher oder später in Rente, ist der Zugangsfaktor und damit der Rentenanspruch höher oder niedriger.
+      gehen kann. Geht die Person früher oder später in Rente, ist der Zugangsfaktor und damit der Rentenanspruch höher oder niedriger, 
+      wenn keine Ausnahmeregelungen erfüllt sind.
     en:
       Piecewise linear function returning the regelaltersgrenze at which the agent is allowed to get pensions with his full
       claim. If the agent retires earlier or later, the Zugangsfaktor and therefore
-      the pension claim is higher or lower.
+      the pension claim is higher or lower, unless special conditions apply.
   reference: § 35 Satz 2 SGB VI
   note:
     de: >-
@@ -745,15 +746,19 @@ regelaltersgrenze:
   2002-01-01:
     0:
       lower_threshold: -inf
-      upper_threshold: 1947
+      upper_threshold: 1946
       rate_linear: 0
       intercept_at_lower_threshold: 65
     1:
-      lower_threshold: 1947
-      upper_threshold: 1971
+      lower_threshold: 1946
+      upper_threshold: 1958
       rate_linear: 0.083333333
     2:
-      lower_threshold: 1971
+      lower_threshold: 1958
+      upper_threshold: 1964
+      rate_linear: 0.166666667
+    3:
+      lower_threshold: 1964
       upper_threshold: inf
       rate_linear: 0
 

--- a/gettsim/parameters/ges_rente.yaml
+++ b/gettsim/parameters/ges_rente.yaml
@@ -740,7 +740,8 @@ regelaltersgrenze:
   note:
     de: >-
       Diese Funktion ist hier ab 2002 angegeben. Vor 2002 ist das Steuersystem nicht
-      implementiert.
+      implementiert. Bis einschließlich Jahrgang 1946 ist NRA 65, danach steigt es bis Jahrgang 1964. 
+      Ab einschließlich Jahrgang 1964 gilt NRA 67.
     en:
   type: piecewise_linear
   2002-01-01:


### PR DESCRIPTION
### What problem do you want to solve?

Problem of Issue 393. I fixed the parameters of the piecewise function for the regelaltersgrenze.

### Todo

- [X] Replace cohort thresholds and adjustment rates for 2007 reform
- [X] If it is a relevant contribution, put it in `CHANGES.rst`.
- [ ] check rules for cohorts before 1945.
- [ ] create tests