### PR TITLE
Documentation for Vermögensbegriff

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ releases are available on `Anaconda.org <https://anaconda.org/gettsim/gettsim>`_
 * :gh:`383` Remove ä, ö, ü from file names (:ghuser:`ChristianZimpelmann`).
 * :gh:`415` Define supported groupings in `config.py`. (:ghuser:`LauraGergeleit`,
   :ghuser:`ChristianZimpelmann`)
+* :gh:`416` Added documentation page for Vermögensbegriff for transfers.
+  (:ghuser:`LauraGergeleit`)
 
 0.5.1 — 2022-04-21
 ------------------

--- a/docs/gettsim_objects/index.rst
+++ b/docs/gettsim_objects/index.rst
@@ -11,3 +11,4 @@ This section documents the code inside GETTSIM.
    input_variables
    variables_out
    params
+   means_testing

--- a/docs/gettsim_objects/input_variables.rst
+++ b/docs/gettsim_objects/input_variables.rst
@@ -86,8 +86,9 @@ household.
 +---------------------------+---------------------------------------------+--------------+
 | _`immobilie_baujahr_hh`   | Construction year of dwelling               | int          |
 +---------------------------+---------------------------------------------+--------------+
-|:ref:`vermögen_bedürft_hh  | Assets for means testing of household       | float        |
-|<means_testing>`           |                                             |              |
+|| _`vermögen_bedürft_hh`   || Assets for means testing of household.     || float       |
+||                          || :ref:`See this page for more details.      ||             |
+|                           | <means_testing>`                            |              |
 +---------------------------+---------------------------------------------+--------------+
 | _`entgeltp`               | Earnings points for pension claim           | float        |
 +---------------------------+---------------------------------------------+--------------+

--- a/docs/gettsim_objects/input_variables.rst
+++ b/docs/gettsim_objects/input_variables.rst
@@ -7,140 +7,141 @@ The table below gives an overview of all variables needed to run GETTSIM complet
 Note that the variables with _hh at the end, have to be constant over the whole
 household.
 
-+-------------------------+---------------------------------------------+--------------+
-| Variable name           | Description                                 | Type         |
-+=========================+=============================================+==============+
-| _`hh_id`                | Household identifier                        | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`tu_id`                | Tax Unit identifier (married couples + kids)| int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`kind`                 | Dummy: Dependent child living with parents  | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`bruttolohn_m`         | Monthly wage                                | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`alter`                | Age of Individual                           | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`rentner`              | Dummy: Pensioner employment status          | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`alleinerz`            | Dummy: Single parent                        | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`wohnort_ost`          | Dummy: Living in former East Germany        | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`in_priv_krankenv`     | Dummy: In private health insurance          | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`priv_rentenv_beitr_m` | Monthly private pension contribution        | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`in_ausbildung`        | Dummy: Employment status “in education”     | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`selbstständig`        | Dummy: Individual is self-employed          | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`hat_kinder`           | Dummy: Individual has kids (incl. not in hh)| bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`betreuungskost_m`     | Monthly childcare expenses                  | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`sonstig_eink_m`       | Additional income                           | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`eink_selbst_m`        | Monthly income from self-employment         | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`eink_vermietung_m`    | Monthly rental income                       | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`kapitaleink_brutto_m` | Monthly capital income                      | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`bruttokaltmiete_m_hh` | Monthly rent expenses for household         | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`heizkosten_m_hh`      | Monthly heating expenses for household      | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`wohnfläche_hh`        | Size of household dwelling in square meters | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`bewohnt_eigentum_hh`  | Dummy: Owner-occupied housing               | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`arbeitsl_monate_lfdj` | Months in unemployment, current year        | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`arbeitsl_monate_vorj` | Months in unemployment, previous year       | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`arbeitsl_monate_v2j`  | Months in unemployment, two years before    | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`arbeitsstunden_w`     | Weekly working hours of individual          | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`bruttolohn_vorj_m`    | Monthly wage, previous year                 | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`geburtstag`           | Day of birth                                | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`geburtsmonat`         | Month of birth                              | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`geburtsjahr`          | Year of birth                               | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`jahr_renteneintr`     | Year of retirement                          | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_elterngeld`         | Number of months hh received elterngeld     | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_elterngeld_vat_hh`  | Number of months father received elterngeld | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_elterngeld_mut_hh`  | Number of months mother received elterngeld | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`behinderungsgrad`     | Handicap degree (between 0 and 100)         | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`schwerbeh_g`          | Severerly handicapped, with flag "G"        | bool         |
-+-------------------------+---------------------------------------------+--------------+
-| _`mietstufe`            | Level of rents in city (1: low, 3: average) | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`immobilie_baujahr_hh` | Construction year of dwelling               | int          |
-+-------------------------+---------------------------------------------+--------------+
-| _`vermögen_bedürft_hh`  | Assets for means testing of household       | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`entgeltp`             | Earnings points for pension claim           | float        |
-+-------------------------+---------------------------------------------+--------------+
-|| _`grundr_zeiten`       || Number of months determining Grundrente    || int         |
-||                        || eligibility                                ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`grundr_bew_zeiten`   || Number of months determining Grundrente    || int         |
-||                        || payments                                   ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`grundr_entgeltp`     || Average `entgeltp` during                  || float       |
-||                        || `grundr_bew_zeiten`                        ||             |
-+-------------------------+---------------------------------------------+--------------+
-| _`priv_rente_m`         | Amount of monthly private pension           | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`weiblich`             | True if female                              | bool         |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_pflichtbeitrag`    || Total months of mandatory pension          || float       |
-||                        || insurance contributions                    ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_freiw_beitrag`     || Total months of voluntary pension          || float       |
-||                        || insurance contributions                    ||             |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_mutterschutz`       | Total months of maternal protections        | float        |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_arbeitsunfähig`    || Total months of sickness, rehabilitation,  || float       |
-||                        || measures for worklife participation        ||             |
-||                        || (Teilhabe)                                 ||             |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_krank_ab_16_bis_24` | Months of sickness between age 16 and 24    | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_arbeitslos`         | Total months of unemployment (registered)   | float        |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_ausbild_suche`      | Total months of apprenticeship search       | float        |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_schul_ausbild`     || Months of schooling (incl college, uni     || float       |
-||                        || from age 17, max. 8 years)                 ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_alg1_übergang`     || Total months of unemployment (only time    || float       |
-||                        || of Entgeltersatzleistungen, not ALGII),    ||             |
-||                        || i.e. Arbeitslosengeld, Unterhaltsgeld,     ||             |
-||                        || Übergangsgeld                              ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_geringf_beschäft`  || Total month of marginal employment (w/o    || float       |
-||                        || mandatory contributions) (computed after   ||             |
-||                        || § 244a SGB VI - earningspoints/0,0313)     ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_ersatzzeit`        || Months during military, persecution/escape,|| float       |
-||                        || internment and consecutive sickness        ||             |
-+-------------------------+---------------------------------------------+--------------+
-| _`m_kind_berücks_zeit`  | Total months of childcare till age 10       | float        |
-+-------------------------+---------------------------------------------+--------------+
-|| _`m_pfleg_berücks_zeit`|| Total months of home care                  || float       |
-||                        || (01.01.1992-31.03.1995)                    ||             |
-+-------------------------+---------------------------------------------+--------------+
-|| _`y_pflichtbeitr_ab_40`|| Total years of mandat. contributions after || float       |
-||                        || age 40                                     ||             |
-+-------------------------+---------------------------------------------+--------------+
++---------------------------+---------------------------------------------+--------------+
+| Variable name             | Description                                 | Type         |
++===========================+=============================================+==============+
+| _`hh_id`                  | Household identifier                        | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`tu_id`                  | Tax Unit identifier (married couples + kids)| int          |
++---------------------------+---------------------------------------------+--------------+
+| _`kind`                   | Dummy: Dependent child living with parents  | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`bruttolohn_m`           | Monthly wage                                | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`alter`                  | Age of Individual                           | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`rentner`                | Dummy: Pensioner employment status          | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`alleinerz`              | Dummy: Single parent                        | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`wohnort_ost`            | Dummy: Living in former East Germany        | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`in_priv_krankenv`       | Dummy: In private health insurance          | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`priv_rentenv_beitr_m`   | Monthly private pension contribution        | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`in_ausbildung`          | Dummy: Employment status “in education”     | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`selbstständig`          | Dummy: Individual is self-employed          | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`hat_kinder`             | Dummy: Individual has kids (incl. not in hh)| bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`betreuungskost_m`       | Monthly childcare expenses                  | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`sonstig_eink_m`         | Additional income                           | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`eink_selbst_m`          | Monthly income from self-employment         | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`eink_vermietung_m`      | Monthly rental income                       | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`kapitaleink_brutto_m`   | Monthly capital income                      | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`bruttokaltmiete_m_hh`   | Monthly rent expenses for household         | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`heizkosten_m_hh`        | Monthly heating expenses for household      | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`wohnfläche_hh`          | Size of household dwelling in square meters | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`bewohnt_eigentum_hh`    | Dummy: Owner-occupied housing               | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`arbeitsl_monate_lfdj`   | Months in unemployment, current year        | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`arbeitsl_monate_vorj`   | Months in unemployment, previous year       | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`arbeitsl_monate_v2j`    | Months in unemployment, two years before    | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`arbeitsstunden_w`       | Weekly working hours of individual          | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`bruttolohn_vorj_m`      | Monthly wage, previous year                 | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`geburtstag`             | Day of birth                                | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`geburtsmonat`           | Month of birth                              | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`geburtsjahr`            | Year of birth                               | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`jahr_renteneintr`       | Year of retirement                          | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`m_elterngeld`           | Number of months hh received elterngeld     | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`m_elterngeld_vat_hh`    | Number of months father received elterngeld | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`m_elterngeld_mut_hh`    | Number of months mother received elterngeld | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`behinderungsgrad`       | Handicap degree (between 0 and 100)         | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`schwerbeh_g`            | Severerly handicapped, with flag "G"        | bool         |
++---------------------------+---------------------------------------------+--------------+
+| _`mietstufe`              | Level of rents in city (1: low, 3: average) | int          |
++---------------------------+---------------------------------------------+--------------+
+| _`immobilie_baujahr_hh`   | Construction year of dwelling               | int          |
++---------------------------+---------------------------------------------+--------------+
+|:ref:`vermögen_bedürft_hh  | Assets for means testing of household       | float        |
+|<means_testing>`           |                                             |              |
++---------------------------+---------------------------------------------+--------------+
+| _`entgeltp`               | Earnings points for pension claim           | float        |
++---------------------------+---------------------------------------------+--------------+
+|| _`grundr_zeiten`         || Number of months determining Grundrente    || int         |
+||                          || eligibility                                ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`grundr_bew_zeiten`     || Number of months determining Grundrente    || int         |
+||                          || payments                                   ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`grundr_entgeltp`       || Average `entgeltp` during                  || float       |
+||                          || `grundr_bew_zeiten`                        ||             |
++---------------------------+---------------------------------------------+--------------+
+| _`priv_rente_m`           | Amount of monthly private pension           | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`weiblich`               | True if female                              | bool         |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_pflichtbeitrag`      || Total months of mandatory pension          || float       |
+||                          || insurance contributions                    ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_freiw_beitrag`       || Total months of voluntary pension          || float       |
+||                          || insurance contributions                    ||             |
++---------------------------+---------------------------------------------+--------------+
+| _`m_mutterschutz`         | Total months of maternal protections        | float        |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_arbeitsunfähig`      || Total months of sickness, rehabilitation,  || float       |
+||                          || measures for worklife participation        ||             |
+||                          || (Teilhabe)                                 ||             |
++---------------------------+---------------------------------------------+--------------+
+| _`m_krank_ab_16_bis_24`   | Months of sickness between age 16 and 24    | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`m_arbeitslos`           | Total months of unemployment (registered)   | float        |
++---------------------------+---------------------------------------------+--------------+
+| _`m_ausbild_suche`        | Total months of apprenticeship search       | float        |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_schul_ausbild`       || Months of schooling (incl college, uni     || float       |
+||                          || from age 17, max. 8 years)                 ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_alg1_übergang`       || Total months of unemployment (only time    || float       |
+||                          || of Entgeltersatzleistungen, not ALGII),    ||             |
+||                          || i.e. Arbeitslosengeld, Unterhaltsgeld,     ||             |
+||                          || Übergangsgeld                              ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_geringf_beschäft`    || Total month of marginal employment (w/o    || float       |
+||                          || mandatory contributions) (computed after   ||             |
+||                          || § 244a SGB VI - earningspoints/0,0313)     ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_ersatzzeit`          || Months during military, persecution/escape,|| float       |
+||                          || internment and consecutive sickness        ||             |
++---------------------------+---------------------------------------------+--------------+
+| _`m_kind_berücks_zeit`    | Total months of childcare till age 10       | float        |
++---------------------------+---------------------------------------------+--------------+
+|| _`m_pfleg_berücks_zeit`  || Total months of home care                  || float       |
+||                          || (01.01.1992-31.03.1995)                    ||             |
++---------------------------+---------------------------------------------+--------------+
+|| _`y_pflichtbeitr_ab_40`  || Total years of mandat. contributions after || float       |
+||                          || age 40                                     ||             |
++---------------------------+---------------------------------------------+--------------+

--- a/docs/gettsim_objects/means_testing.rst
+++ b/docs/gettsim_objects/means_testing.rst
@@ -5,7 +5,7 @@ Assets considered for means testing
 
 | The table below gives an overview of all tangible and intangible assets which are considered when performing means for several transfers. A cross indicates that the asset class is not considered and, hence, deducted from the overall assets of a household.
 
-| This documentation shall help to understand the composition of the :ref:`basic input variable <input_variables>` 'vermögen_bedürft_hh'. Despite small differences over the transfers we decided, for now, to require only one wealth variable as input and use it for all transfers.
+| This documentation shall help to understand the composition of the :ref:`basic input variable <input_variables>` 'vermögen_bedürft_hh'. Despite small differences over the transfers, we decided, for now, to require only one wealth variable as input and use it for all transfers.
 
 .. note::
    | ALGII = Grundsicherung für Arbeitslose
@@ -14,7 +14,7 @@ Assets considered for means testing
    | KiZu = Kinderzuschlag
 
    HC = hardship case
-   (The realization of these assets would constitute a particular hardship for the person, § 90 Abs.3 SGBXII `<https://www.gesetze-im-internet.de/sgb_12/__90.html>`_)
+   (Asset class is not considered if it would constitute a particular hardship for that person, see § 90 Abs.3 SGBXII `<https://www.gesetze-im-internet.de/sgb_12/__90.html>`_)
 
 +-----------------------------------------------+---------+---------+---------+---------+
 | Not counted as assets                         |  ALGII  |  GSA/E  |  WoGe   |  KiZu   |

--- a/docs/gettsim_objects/means_testing.rst
+++ b/docs/gettsim_objects/means_testing.rst
@@ -1,0 +1,54 @@
+.. _means_testing:
+
+Assets for means testing
+========================
+
+| The table below gives an overview of all tangible and intangible assets which are deducted from the overall assets of a household when performing means testing for the respective transfer.
+
+| This documentation shall help to understand the composition of the :ref:`basic input variable <input_variables>` 'vermögen_bedürft_hh'.
+
+.. note::
+   | ALGII = Grundsicherung für Arbeitslose
+   | GSA/E = Grundsicherung im Alter/ bei Erwerbsminderung
+   | WoGe = Wohngeld
+   | KiZu = Kinderzuschlag
+
+   HS = hardship case
+
++-----------------------------------------------+---------+---------+---------+---------+
+| Not counted as assets                         |  ALGII  |  GSA/E  |  WoGe   |  KiZu   |
++===============================================+=========+=========+=========+=========+
+| Appropriate household goods                   |    x    |    x    |    x    |    x    |
++-----------------------------------------------+---------+---------+---------+---------+
+|| adequate motor vehicle for each              ||   x    || x (HC) ||   x    ||   x    |
+|| person capable of working                    ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+|| Assets for retirement provision and          ||   x    ||   x    ||   x    ||   x    |
+|| retirement assets                            ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+|| owner-occupied house/apartment of            ||   x    ||   x    ||   x    ||   x    |
+|| appropriate size                             ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+|| Assets for obtaining/maintaining a house     ||   x    ||   x    ||   x    ||   x    |
+|| property for people in need of care          ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+|| Assets to build up/secure a livelihood       ||   x    ||   x    ||   x    ||   x    |
+|| or Establishment of a household              ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+| Family and heirloom pieces                    | x (HC)  |    x    |         | x (HC)  |
++-----------------------------------------------+---------+---------+---------+---------+
+|| Property and rights, if realization would    ||   x    ||   x    ||        ||   x    |
+|| be uneconomical or a particular hardship     ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+|| Items to start/continue vocational           ||   x    ||   x    ||   x    ||   x    |
+|| training/employment                          ||        ||        ||        ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+| Items for the satisfaction of spiritual needs ||        ||   x    ||   x    ||        |
++-----------------------------------------------+---------+---------+---------+---------+
+
+.. seealso::
+    Here you can check out the legal bases for the definition of assets for each transfer.
+     * ALGII: §12 SGBII `<https://www.gesetze-im-internet.de/sgb_2/__12.html>`_
+     * GSA/E: §90 SGBXII `<https://www.gesetze-im-internet.de/sgb_12/__90.html>`_
+     * WoGe: §21 WoGG `<https://www.gesetze-im-internet.de/bkgg_1996/__6a.html>`_
+     * KiZu: §6a BKGG, Abs.3 `<https://www.gesetze-im-internet.de/bkgg_1996/__6a.html>`_

--- a/docs/gettsim_objects/means_testing.rst
+++ b/docs/gettsim_objects/means_testing.rst
@@ -1,11 +1,11 @@
 .. _means_testing:
 
-Assets for means testing
-========================
+Assets considered for means testing
+===================================
 
-| The table below gives an overview of all tangible and intangible assets which are deducted from the overall assets of a household when performing means testing for the respective transfer.
+| The table below gives an overview of all tangible and intangible assets which are considered when performing means for several transfers. A cross indicates that the asset class is not considered and, hence, deducted from the overall assets of a household.
 
-| This documentation shall help to understand the composition of the :ref:`basic input variable <input_variables>` 'vermögen_bedürft_hh'.
+| This documentation shall help to understand the composition of the :ref:`basic input variable <input_variables>` 'vermögen_bedürft_hh'. Despite small differences over the transfers we decided, for now, to require only one wealth variable as input and use it for all transfers.
 
 .. note::
    | ALGII = Grundsicherung für Arbeitslose
@@ -13,27 +13,28 @@ Assets for means testing
    | WoGe = Wohngeld
    | KiZu = Kinderzuschlag
 
-   HS = hardship case
+   HC = hardship case
+   (The realization of these assets would constitute a particular hardship for the person, § 90 Abs.3 SGBXII `<https://www.gesetze-im-internet.de/sgb_12/__90.html>`_)
 
 +-----------------------------------------------+---------+---------+---------+---------+
 | Not counted as assets                         |  ALGII  |  GSA/E  |  WoGe   |  KiZu   |
 +===============================================+=========+=========+=========+=========+
 | Appropriate household goods                   |    x    |    x    |    x    |    x    |
 +-----------------------------------------------+---------+---------+---------+---------+
-|| adequate motor vehicle for each              ||   x    || x (HC) ||   x    ||   x    |
+|| Adequate motor vehicle for each              ||   x    || x (HC) ||   x    ||   x    |
 || person capable of working                    ||        ||        ||        ||        |
 +-----------------------------------------------+---------+---------+---------+---------+
 || Assets for retirement provision and          ||   x    ||   x    ||   x    ||   x    |
 || retirement assets                            ||        ||        ||        ||        |
 +-----------------------------------------------+---------+---------+---------+---------+
-|| owner-occupied house/apartment of            ||   x    ||   x    ||   x    ||   x    |
+|| Owner-occupied house/apartment of            ||   x    ||   x    ||   x    ||   x    |
 || appropriate size                             ||        ||        ||        ||        |
 +-----------------------------------------------+---------+---------+---------+---------+
 || Assets for obtaining/maintaining a house     ||   x    ||   x    ||   x    ||   x    |
 || property for people in need of care          ||        ||        ||        ||        |
 +-----------------------------------------------+---------+---------+---------+---------+
 || Assets to build up/secure a livelihood       ||   x    ||   x    ||   x    ||   x    |
-|| or Establishment of a household              ||        ||        ||        ||        |
+|| or establishment of a household              ||        ||        ||        ||        |
 +-----------------------------------------------+---------+---------+---------+---------+
 | Family and heirloom pieces                    | x (HC)  |    x    |         | x (HC)  |
 +-----------------------------------------------+---------+---------+---------+---------+
@@ -47,7 +48,7 @@ Assets for means testing
 +-----------------------------------------------+---------+---------+---------+---------+
 
 .. seealso::
-    Here you can check out the legal bases for the definition of assets for each transfer.
+    See the following links for legal bases for the definition of assets for each transfer.
      * ALGII: §12 SGBII `<https://www.gesetze-im-internet.de/sgb_2/__12.html>`_
      * GSA/E: §90 SGBXII `<https://www.gesetze-im-internet.de/sgb_12/__90.html>`_
      * WoGe: §21 WoGG `<https://www.gesetze-im-internet.de/bkgg_1996/__6a.html>`_


### PR DESCRIPTION
### What problem do you want to solve?
Referring to #326, the variable `vermögen_hh` was changed into `vermögen_bedürft_hh` (Vermögen für Bedürftigkeitsprüfungen). In order to understand which assets are not counted towards Vermögen for each relevant transfer, a table was created, which shall be added to the documentation of GETTSIM, as asked [here](https://github.com/iza-institute-of-labor-economics/gettsim/issues/326#issuecomment-1158598062). 


