### PR TITLE
Gerinfügigkeitsgrenzen

### DIFF
--- a/gettsim/parameters/soz_vers_beitr.yaml
+++ b/gettsim/parameters/soz_vers_beitr.yaml
@@ -770,6 +770,28 @@ geringfügige_eink_grenzen_m:
     deviation_from: previous
     reference: Art. 4 G. v. 28.11.2018 BGBl. I S. 2016
     midi_job: 1300
+  2022-10-01:
+    midi_job: 1600
+    reference: Art. 7 G. v. 28.06.2022 BGBl. I S. 969
+    note: the former mini_job parameter depends on the statutory minimum wage since 2022-10-01
+
+geringf_eink_faktor:
+  name:
+    de: Faktor, mit dem der Mindestlohn in der Berechnung der Geringfügigkeitsgrenze multipliziert wird.
+  reference: §8 (1) Nr. 1a SGB IV
+  2022-10-01:
+    scalar: 130
+    reference: Art. 7 G. v. 28.06.2022 BGBl. I S. 969
+
+geringf_eink_divisor:
+  name:
+    de: Betrag, durch den der Mindestlohn, multipliziert mit gering_eink_faktor, dividiert wird,
+        um die Geringfügigkeitsgrenze zu erhalten.
+  reference: §8 (1) Nr. 1a SGB IV
+  2022-10-01:
+    scalar: 3
+    reference: Art. 7 G. v. 28.06.2022 BGBl. I S. 969
+
 
 ag_abgaben_geringf:
   name:
@@ -807,6 +829,31 @@ ges_pflegev_zusatz_kinderlos_mindestalter:
   reference: § 55 Abs. 3 SGB XI
   2005-01-01:
     scalar: 23
+
+mindestlohn:
+  name:
+    de: Allgemeiner gesetzlicher Mindestlohn pro Stunde
+    en: Statutory hourly minimum wage
+  unit: Euro
+  reference: §1 (2) Mindestlohngesetz
+  2015-01-01:
+    scalar: 8.5
+  2017-01-01:
+    scalar: 8.84
+  2019-01-01:
+    scalar: 9.19
+  2020-01-01:
+    scalar: 9.35
+  2021-01-01:
+    scalar: 9.5
+  2021-07-01:
+    scalar: 9.6
+  2022-01-01:
+    scalar: 9.82
+  2022-07-01:
+    scalar: 10.45
+  2022-10-01:
+    scalar: 12
 
 rounding:
   midi_job_faktor_f:

--- a/gettsim/policy_environment.py
+++ b/gettsim/policy_environment.py
@@ -12,6 +12,15 @@ from gettsim.config import ROOT_DIR
 from gettsim.piecewise_functions import check_thresholds
 from gettsim.piecewise_functions import get_piecewise_parameters
 from gettsim.piecewise_functions import piecewise_polynomial
+from gettsim.social_insurance_contributions.eink_grenzen import (
+    geringfügigkeitsgrenze_ab_2022,
+)
+from gettsim.social_insurance_contributions.eink_grenzen import (
+    geringfügigkeitsgrenze_ost_vor_2022,
+)
+from gettsim.social_insurance_contributions.eink_grenzen import (
+    geringfügigkeitsgrenze_west_vor_2022,
+)
 from gettsim.social_insurance_contributions.ges_krankenv import (
     _ges_krankenv_beitr_satz_arbeitg_ab_2019,
 )
@@ -350,6 +359,13 @@ def load_reforms_for_date(date):
         functions[
             "arbeitsl_geld_2_regelsatz_m_hh"
         ] = arbeitsl_geld_2_regelsatz_m_hh_ab_2011
+
+    if date >= datetime.date(year=2022, month=10, day=1):
+        functions["geringfügigkeitsgrenze_west"] = geringfügigkeitsgrenze_ab_2022
+        functions["geringfügigkeitsgrenze_ost"] = geringfügigkeitsgrenze_ab_2022
+    else:
+        functions["geringfügigkeitsgrenze_west"] = geringfügigkeitsgrenze_west_vor_2022
+        functions["geringfügigkeitsgrenze_ost"] = geringfügigkeitsgrenze_ost_vor_2022
 
     if date < datetime.date(year=2005, month=10, day=1):
         functions[

--- a/gettsim/social_insurance_contributions/eink_grenzen.py
+++ b/gettsim/social_insurance_contributions/eink_grenzen.py
@@ -2,7 +2,7 @@ from gettsim.shared import add_rounding_spec
 
 
 def mini_job_grenze(
-    wohnort_ost: bool, geringfügigkeitsgrenze_west: int, gerinfügigkeitsgrenze_ost: int
+    wohnort_ost: bool, geringfügigkeitsgrenze_west: int, geringfügigkeitsgrenze_ost: int
 ) -> float:
     """Select the income threshold depending on place of living
 
@@ -16,7 +16,7 @@ def mini_job_grenze(
     -------
 
     """
-    out = gerinfügigkeitsgrenze_ost if wohnort_ost else geringfügigkeitsgrenze_west
+    out = geringfügigkeitsgrenze_ost if wohnort_ost else geringfügigkeitsgrenze_west
     return float(out)
 
 

--- a/gettsim/tests/test_data/sozialv_beitr.csv
+++ b/gettsim/tests/test_data/sozialv_beitr.csv
@@ -16,3 +16,4 @@ hh_id,tu_id,p_id,bruttolohn_m,wohnort_ost,alter,selbstständig,hat_kinder,eink_s
 15,15,222,3000,FALSE,40,FALSE,FALSE,0,0,FALSE,2020,603.75,,,,,,279,53.25,235.5,36,,Sozialversicherungs-Rechner auf www.barmer.de
 16,16,223,750,FALSE,40,FALSE,FALSE,0,0,FALSE,2022,123.19,,,,,,56.25,11.59,48.09,7.26,,Sozialversicherungs-Rechner auf www.tk.de
 17,17,224,1050,FALSE,40,FALSE,TRUE,0,0,FALSE,2022,196.54,,,,,,91.51,15.01,78.22,11.80,,Sozialversicherungs-Rechner auf www.tk.de
+18,18,225,510,FALSE,30,FALSE,FALSE,0,0,FALSE,2023,0,,,,,,0,0,0,0,,Einführung Geringfügigkeitsgrenze 2022


### PR DESCRIPTION
Models changes in mini / midi job rulings effective since 2022-10-01

- higher Midi-Job threshold
- mini job threshold is now called 'Geringfügigkeitsgrenze' and requires three new parameters
  - `mindestlohn`
  - `geringf_eink_faktor`
  - `geringf_eink_divisor`
- In addition, a policy change needs to introduced in `policy_functions.py`