### PR TITLE
Revert the sorting of results in #429 / d44c2f2a, which broke docs etc.

### DIFF
--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -714,11 +714,7 @@ def _prepare_results(results, data, debug):
     if debug:
         results = pd.DataFrame({**data, **results})
     else:
-        identifiers = [f"{g}_id" for g in SUPPORTED_GROUPINGS if f"{g}_id" in data] + [
-            "p_id"
-        ]
-        data_ids = {k: v for k, v in data.items() if k in identifiers}
-        results = pd.DataFrame({**data_ids, **results})
+        results = pd.DataFrame(results)
     results = _reorder_columns(results)
 
     return results


### PR DESCRIPTION
### What problem do you want to solve?

#429 broke notebooks in the documentation and elsewhere by sorting results. 

GETTSIM should never change the ordering of rows; everything is built on the premise of those staying constant.

We may want to require users to pass sorted DataFrames only, that would be for #388 (would require that we have nested columns only).