### PR TITLE
update schedule for pre-commit autoupdate from weekly to monthly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,9 +62,9 @@ repos:
         args:
           - --in-place
           - --wrap-summaries
-          - '88'
+          - "88"
           - --wrap-descriptions
-          - '88'
+          - "88"
           - --blank
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
@@ -78,7 +78,7 @@ repos:
           - flake8-docstrings
           - flake8-eradicate
           - flake8-print
-            # flake8-pytest-style,  # produces SyntaxError with umlauts.
+          # flake8-pytest-style,  # produces SyntaxError with umlauts.
           - flake8-todo
           - flake8-typing-imports
           - flake8-unused-arguments
@@ -104,14 +104,14 @@ repos:
   #       args: [-v, --fail-under=50]
   #       exclude: ^(dashboard/|gettsim/docs/)
 
-  - repo: https://github.com/lyz-code/yamlfix
-    rev: 1.2.0
-    hooks:
-      - id: yamlfix
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.28.0
-    hooks:
-      - id: yamllint
+  # - repo: https://github.com/lyz-code/yamlfix
+  #   rev: 1.2.0
+  #   hooks:
+  #     - id: yamlfix
+  # - repo: https://github.com/adrienverge/yamllint.git
+  #   rev: v1.28.0
+  #   hooks:
+  #     - id: yamllint
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
@@ -122,7 +122,7 @@ repos:
           - mdformat-black
         args:
           - --wrap
-          - '88'
+          - "88"
         files: (README\.md)
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
@@ -133,7 +133,7 @@ repos:
           - mdformat-black
         args:
           - --wrap
-          - '88'
+          - "88"
         files: (docs/.)
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
@@ -145,7 +145,7 @@ repos:
           - types-PyYAML
           - types-pytz
   - repo: https://github.com/mgedmin/check-manifest
-    rev: '0.49'
+    rev: "0.49"
     hooks:
       - id: check-manifest
         args:
@@ -166,3 +166,6 @@ repos:
         args:
           - --extra-keys
           - metadata.kernelspec
+
+ci:
+  autoupdate_schedule: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 ---
 repos:
+  - repo: https://github.com/lyz-code/yamlfix
+    rev: 1.2.0
+    hooks:
+      - id: yamlfix
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -62,9 +70,9 @@ repos:
         args:
           - --in-place
           - --wrap-summaries
-          - "88"
+          - '88'
           - --wrap-descriptions
-          - "88"
+          - '88'
           - --blank
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
@@ -104,15 +112,6 @@ repos:
   #       args: [-v, --fail-under=50]
   #       exclude: ^(dashboard/|gettsim/docs/)
 
-  # - repo: https://github.com/lyz-code/yamlfix
-  #   rev: 1.2.0
-  #   hooks:
-  #     - id: yamlfix
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.28.0
-    hooks:
-      - id: yamllint
-
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
     hooks:
@@ -122,7 +121,7 @@ repos:
           - mdformat-black
         args:
           - --wrap
-          - "88"
+          - '88'
         files: (README\.md)
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
@@ -133,7 +132,7 @@ repos:
           - mdformat-black
         args:
           - --wrap
-          - "88"
+          - '88'
         files: (docs/.)
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.991
@@ -145,7 +144,7 @@ repos:
           - types-PyYAML
           - types-pytz
   - repo: https://github.com/mgedmin/check-manifest
-    rev: "0.49"
+    rev: '0.49'
     hooks:
       - id: check-manifest
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,10 +108,10 @@ repos:
   #   rev: 1.2.0
   #   hooks:
   #     - id: yamlfix
-  # - repo: https://github.com/adrienverge/yamllint.git
-  #   rev: v1.28.0
-  #   hooks:
-  #     - id: yamllint
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16

--- a/src/_gettsim/parameters/soli_st.yaml
+++ b/src/_gettsim/parameters/soli_st.yaml
@@ -3,6 +3,7 @@ soli_st:
   name:
     de: Solidaritätszuschlag
     en: null
+
   description:
     de: >-
       Ab 1995, der upper threshold im Intervall 1 ist nach der Formel


### PR DESCRIPTION
### What problem do you want to solve?

- To avoid too much noise, update schedule for pre-commit autoupdate from weekly to monthly
- I also realized that `yamlfix` introduces CRLF line endings on windows which lets `yamllint` to fail. When changing the order such that `mixed-line-ending` is run after the yaml pre-commit hooks, the second commit runs through.

### Todo

- [ ] Decide whether monthly schedule is indeed the prefered option (alternatives: quarterly or weekly)
- [ ] Find out whether there is a better fix for the second problem
