### PR TITLE
Nicer error message relating to #479

### DIFF
--- a/src/_gettsim/transfers/unterhalt.py
+++ b/src/_gettsim/transfers/unterhalt.py
@@ -38,6 +38,14 @@ def unterhaltsvors_m(
 
     """
 
+    if "mindestunterhalt" not in unterhalt_params:
+        raise NotImplementedError(
+            """
+        Unterhaltsvorschuss is not implemented yet prior to 2016, see
+        https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
+
+        """
+        )
     altersgrenzen = sorted(unterhalt_params["mindestunterhalt"].keys())
     if (alter < altersgrenzen[0]) and alleinerz_tu:
         out = (


### PR DESCRIPTION
### What problem do you want to solve?

Produce a nicer error if `mindestunterhalt` is required before 2016, link to #479 in that message.