### PR TITLE
Show all plots in docs, raise error outside of vectorized function

### DIFF
--- a/docs/tutorials/advanced_usage.ipynb
+++ b/docs/tutorials/advanced_usage.ipynb
@@ -110,7 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_dag(functions=policy_functions, selectors=selectors)"
+    "plot_dag(functions=policy_functions, selectors=selectors).show()"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "selectors = {\"type\": \"neighbors\", \"node\": \"kindergeld_m\", \"order\": 2}\n",
-    "plot_dag(functions=policy_functions, selectors=selectors)"
+    "plot_dag(functions=policy_functions, selectors=selectors).show()"
    ]
   },
   {
@@ -491,7 +491,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_kindergeld(df)"
+    "plot_kindergeld(df).show()"
    ]
   },
   {
@@ -565,7 +565,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_kindergeld(df_new)"
+    "plot_kindergeld(df_new).show()"
    ]
   },
   {
@@ -604,7 +604,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.0 | packaged by conda-forge | (main, Oct 25 2022, 06:24:40) [GCC 10.4.0]"
   },
   "toc": {
    "base_numbering": 1,

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -129,6 +129,20 @@ def compute_taxes_and_transfers(
         aggregator=None,
         enforce_signature=True,
     )
+
+    if "unterhalt" in params:
+        if (
+            "mindestunterhalt" not in params["unterhalt"]
+            and "unterhaltsvors_m" in processed_functions
+        ):
+            raise NotImplementedError(
+                """
+Unterhaltsvorschuss is not implemented yet prior to 2016, see
+https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
+
+        """
+            )
+
     results = tax_transfer_function(**input_data)
 
     # Prepare results.

--- a/src/_gettsim/transfers/unterhalt.py
+++ b/src/_gettsim/transfers/unterhalt.py
@@ -38,14 +38,6 @@ def unterhaltsvors_m(
 
     """
 
-    if "mindestunterhalt" not in unterhalt_params:
-        raise NotImplementedError(
-            """
-        Unterhaltsvorschuss is not implemented yet prior to 2016, see
-        https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
-
-        """
-        )
     altersgrenzen = sorted(unterhalt_params["mindestunterhalt"].keys())
     if (alter < altersgrenzen[0]) and alleinerz_tu:
         out = (


### PR DESCRIPTION
- Noted yesterday that the advanced usage tutorial did not show all plots
- The nicer error message implemented in #480 broke tests in #425, move it to a different place (fine for now, I think).