### PR TITLE
Fix #504

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,9 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        language_version: python3.10
+        # It is recommended to specify the latest version of Python
+        # supported by your project here
+        language_version: python3.11
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0
     hooks:


### PR DESCRIPTION
Use language_version=3.11 for black, see https://black.readthedocs.io/en/stable/integrations/source_version_control.html
