### PR TITLE
address bug in Regelsatz for ALG2.

### DIFF
--- a/src/_gettsim/demographic_vars.py
+++ b/src/_gettsim/demographic_vars.py
@@ -18,6 +18,8 @@ aggregation_demographic_vars = {
     "anz_kinder_bis_15_hh": {"source_col": "kind_bis_15", "aggr": "sum"},
     "anz_kinder_ab_7_bis_13_hh": {"source_col": "kind_ab_7_bis_13", "aggr": "sum"},
     "anz_kinder_ab_14_bis_24_hh": {"source_col": "kind_ab_14_bis_24", "aggr": "sum"},
+    "anz_kinder_ab_14_bis_17_hh": {"source_col": "kind_ab_14_bis_17", "aggr": "sum"},
+    "anz_kinder_ab_18_bis_24_hh": {"source_col": "kind_ab_18_bis_24", "aggr": "sum"},
     "anz_kinder_bis_10_tu": {"source_col": "kind_bis_10", "aggr": "sum"},
     "alleinerz_tu": {"source_col": "alleinerz", "aggr": "any"},
     "alleinerz_hh": {"source_col": "alleinerz", "aggr": "any"},
@@ -136,6 +138,36 @@ def kind_ab_14_bis_24(alter: int, kind: bool) -> bool:
 
     """
     out = kind and (14 <= alter <= 24)
+    return out
+
+
+def kind_ab_14_bis_17(alter: int, kind: bool) -> bool:
+    """Calculate if child between 14 and 17 years old.
+    Parameters
+    ----------
+    alter
+        See basic input variable :ref:`alter <alter>`.
+    kind
+        See basic input variable :ref:`kind <kind>`.
+    Returns
+    -------
+    """
+    out = kind and (14 <= alter <= 17)
+    return out
+
+
+def kind_ab_18_bis_24(alter: int, kind: bool) -> bool:
+    """Calculate if child between 18 and 24 years old.
+    Parameters
+    ----------
+    alter
+        See basic input variable :ref:`alter <alter>`.
+    kind
+        See basic input variable :ref:`kind <kind>`.
+    Returns
+    -------
+    """
+    out = kind and (18 <= alter <= 24)
     return out
 
 

--- a/src/_gettsim/transfers/arbeitsl_geld_2/arbeitsl_geld_2.py
+++ b/src/_gettsim/transfers/arbeitsl_geld_2/arbeitsl_geld_2.py
@@ -236,6 +236,7 @@ def arbeitsl_geld_2_regelsatz_m_hh_bis_2010(
     float with the sum in Euro.
 
     """
+    # Note that we, currently, do not support households with more than 2 adults.
     weitere_erwachsene = max(anz_erwachsene_hh - 2, 0)
     if anz_erwachsene_hh == 1:
         out = arbeitsl_geld_2_params["regelsatz"] * (

--- a/src/_gettsim/transfers/arbeitsl_geld_2/arbeitsl_geld_2.py
+++ b/src/_gettsim/transfers/arbeitsl_geld_2/arbeitsl_geld_2.py
@@ -163,7 +163,8 @@ def arbeitsl_geld_2_kindersatz_m_hh_bis_2010(
 def arbeitsl_geld_2_kindersatz_m_hh_ab_2011(
     anz_kinder_bis_6_hh: int,
     anz_kinder_ab_7_bis_13_hh: int,
-    anz_kinder_ab_14_bis_24_hh: int,
+    anz_kinder_ab_14_bis_17_hh: int,
+    anz_kinder_ab_18_bis_24_hh: int,
     arbeitsl_geld_2_params: dict,
 ) -> float:
     """Calculate basic monthly subsistence for children since 2011. Here the sum in euro
@@ -177,8 +178,10 @@ def arbeitsl_geld_2_kindersatz_m_hh_ab_2011(
         See :func:`anz_kinder_bis_6_hh`.
     anz_kinder_ab_7_bis_13_hh
         See :func:`anz_kinder_ab_7_bis_13_hh`.
-    anz_kinder_ab_14_bis_24_hh
-        See :func:`anz_kinder_ab_14_bis_24_hh`.
+    anz_kinder_ab_14_bis_17_hh
+        See :func:`anz_kinder_ab_14_bis_17_hh`.
+    anz_kinder_ab_18_bis_24_hh
+        See :func:`anz_kinder_ab_18_bis_24_hh`.
     arbeitsl_geld_2_params
         See params documentation :ref:`arbeitsl_geld_2_params <arbeitsl_geld_2_params>`.
 
@@ -192,12 +195,16 @@ def arbeitsl_geld_2_kindersatz_m_hh_ab_2011(
     out = (
         arbeitsl_geld_2_params["regelsatz"][6] * anz_kinder_bis_6_hh
         + arbeitsl_geld_2_params["regelsatz"][5] * anz_kinder_ab_7_bis_13_hh
-        + arbeitsl_geld_2_params["regelsatz"][4] * anz_kinder_ab_14_bis_24_hh
+        + arbeitsl_geld_2_params["regelsatz"][4] * anz_kinder_ab_14_bis_17_hh
+        + arbeitsl_geld_2_params["regelsatz"][3] * anz_kinder_ab_18_bis_24_hh
     )
 
     kindersofortzuschl = arbeitsl_geld_2_params.get("kindersofortzuschl", 0.0)
     out += kindersofortzuschl * (
-        anz_kinder_bis_6_hh + anz_kinder_ab_7_bis_13_hh + anz_kinder_ab_14_bis_24_hh
+        anz_kinder_bis_6_hh
+        + anz_kinder_ab_7_bis_13_hh
+        + anz_kinder_ab_14_bis_17_hh
+        + anz_kinder_ab_18_bis_24_hh
     )
 
     return float(out)


### PR DESCRIPTION
### What problem do you want to solve?

Addresses issue https://github.com/iza-institute-of-labor-economics/gettsim/issues/499. Currently, for the years since 2011, children aged 18 or older receive Regelsatz 4, even tough it is specified in the law that they should receive Regelsatz (see [here](4. Personenkreis nach § 20 Abs. 2 Satz 2 SGB II, 4. Personenkreis nach § 20 Abs. 2 Satz 2 SGB II).

This bug is now fixed and probably stems from the old regulation before 2010, where the same portion of the Regelsatz was applicable for children aged 14-24.
