### PR TITLE
test: cache the result of  `set_up_policy_environment`

### DIFF
--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -2,9 +2,14 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Union
 
-from _gettsim.policy_environment import set_up_policy_environment
+from _gettsim.policy_environment import set_up_policy_environment, _parse_date
+
+
+def cached_set_up_policy_environment(date: Union[int, str, datetime.date]) -> tuple[dict, dict]:
+    normalized_date = _parse_date(date)
+    return _cached_set_up_policy_environment(normalized_date)
 
 
 @lru_cache(maxsize=100)
-def cached_set_up_policy_environment(date: Union[int, str, datetime.date]) -> tuple[dict, dict]:
+def _cached_set_up_policy_environment(date: datetime.date) -> tuple[dict, dict]:
     return set_up_policy_environment(date)

--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def cached_set_up_policy_environment(
-    date: int | str | datetime.date
+    date: int | str | datetime.date,
 ) -> tuple[dict, dict]:
     normalized_date = _parse_date(date)
     return _cached_set_up_policy_environment(normalized_date)

--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -2,10 +2,12 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Union
 
-from _gettsim.policy_environment import set_up_policy_environment, _parse_date
+from _gettsim.policy_environment import _parse_date, set_up_policy_environment
 
 
-def cached_set_up_policy_environment(date: Union[int, str, datetime.date]) -> tuple[dict, dict]:
+def cached_set_up_policy_environment(
+    date: Union[int, str, datetime.date]
+) -> tuple[dict, dict]:
     normalized_date = _parse_date(date)
     return _cached_set_up_policy_environment(normalized_date)
 

--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -1,12 +1,15 @@
-from datetime import datetime
+from __future__ import annotations
 from functools import lru_cache
-from typing import Union
+from typing import Union, TYPE_CHECKING
 
 from _gettsim.policy_environment import _parse_date, set_up_policy_environment
 
+if TYPE_CHECKING:
+    import datetime
+
 
 def cached_set_up_policy_environment(
-    date: Union[int, str, datetime.date]
+        date: Union[int, str, datetime.date]
 ) -> tuple[dict, dict]:
     normalized_date = _parse_date(date)
     return _cached_set_up_policy_environment(normalized_date)

--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from functools import lru_cache
+from typing import Union
+
+from _gettsim.policy_environment import set_up_policy_environment
+
+
+@lru_cache(maxsize=100)
+def cached_set_up_policy_environment(date: Union[int, str, datetime.date]) -> tuple[dict, dict]:
+    return set_up_policy_environment(date)

--- a/src/_gettsim_tests/_helpers.py
+++ b/src/_gettsim_tests/_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
+
 from functools import lru_cache
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from _gettsim.policy_environment import _parse_date, set_up_policy_environment
 
@@ -9,7 +10,7 @@ if TYPE_CHECKING:
 
 
 def cached_set_up_policy_environment(
-        date: Union[int, str, datetime.date]
+    date: int | str | datetime.date
 ) -> tuple[dict, dict]:
     normalized_date = _parse_date(date)
     return _cached_set_up_policy_environment(normalized_date)

--- a/src/_gettsim_tests/test_arbeitsl_geld.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld.py
@@ -1,10 +1,10 @@
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -39,7 +39,7 @@ def test_arbeitsl_geld(
 ):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_arbeitsl_geld.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_arbeitsl_geld_2.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld_2.py
@@ -10,11 +10,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -88,7 +88,7 @@ def input_data():
 def test_arbeitsl_geld_2(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_arbeitsl_geld_2.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld_2.py
@@ -10,9 +10,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_benefit_checks.py
+++ b/src/_gettsim_tests/test_benefit_checks.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -50,7 +50,7 @@ def test_benefit_checks(input_data, year, target):
         "arbeitsl_geld_2_eink_m_hh",
     ]
 
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
     result = compute_taxes_and_transfers(
         data=df,
         params=policy_params,

--- a/src/_gettsim_tests/test_benefit_checks.py
+++ b/src/_gettsim_tests/test_benefit_checks.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_eink_st.py
+++ b/src/_gettsim_tests/test_eink_st.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -40,7 +40,7 @@ def test_eink_st(
     year,
     column,
 ):
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()

--- a/src/_gettsim_tests/test_eink_st.py
+++ b/src/_gettsim_tests/test_eink_st.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_elterngeld.py
+++ b/src/_gettsim_tests/test_elterngeld.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "hh_id",
@@ -66,7 +66,7 @@ def test_elterngeld(
     """
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
     df["soli_st_tu"] = df["soli_st_m"].groupby(df["tu_id"]).transform("sum") * 12
     df["eink_st_tu"] = df["eink_st_m"].groupby(df["tu_id"]).transform("sum") * 12
 

--- a/src/_gettsim_tests/test_elterngeld.py
+++ b/src/_gettsim_tests/test_elterngeld.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_favorability_check.py
+++ b/src/_gettsim_tests/test_favorability_check.py
@@ -2,9 +2,9 @@ from itertools import product
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_favorability_check.py
+++ b/src/_gettsim_tests/test_favorability_check.py
@@ -2,11 +2,11 @@ from itertools import product
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "hh_id",
@@ -34,7 +34,7 @@ def input_data():
 def test_favorability_check(input_data, year, target):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
     columns_overriding_functions = [
         "eink_st_ohne_kinderfreib_tu",
         "eink_st_mit_kinderfreib_tu",

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -2,7 +2,6 @@ import datetime
 
 import pandas as pd
 import pytest
-
 from _gettsim.config import PATHS_TO_INTERNAL_FUNCTIONS, TYPES_INPUT_VARIABLES
 from _gettsim.functions_loader import _convert_paths_to_import_strings, _load_functions
 from _gettsim.gettsim_typing import check_series_has_expected_type
@@ -10,6 +9,7 @@ from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim.policy_environment import (
     load_functions_for_date,
 )
+
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -2,16 +2,16 @@ import datetime
 
 import pandas as pd
 import pytest
+
 from _gettsim.config import PATHS_TO_INTERNAL_FUNCTIONS, TYPES_INPUT_VARIABLES
 from _gettsim.functions_loader import _convert_paths_to_import_strings, _load_functions
 from _gettsim.gettsim_typing import check_series_has_expected_type
 from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim.policy_environment import (
     load_functions_for_date,
-    set_up_policy_environment,
 )
-
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 YEARS = [2019]
 INPUT_COLS = [*list(TYPES_INPUT_VARIABLES.keys()), "sum_ges_rente_priv_rente_m"]
@@ -47,7 +47,7 @@ def test_full_taxes_and_transfers(
 ):
     year_data = input_data[input_data["jahr"] == year].copy()
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     compute_taxes_and_transfers(
         data=df,
@@ -72,7 +72,7 @@ def test_data_types(
 
     year_data = input_data[input_data["jahr"] == year].copy()
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     data = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_grundrente.py
+++ b/src/_gettsim_tests/test_grundrente.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
@@ -55,7 +55,9 @@ def input_data():
 def test_grundrente(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
 
     calc_result = compute_taxes_and_transfers(
         data=df,
@@ -119,7 +121,9 @@ def input_data_proxy_rente():
 def test_proxy_rente_vorj(input_data_proxy_rente, year):
     year_data = input_data_proxy_rente[input_data_proxy_rente["jahr"] == year]
     df = year_data[INPUT_COLS_INCOME].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
     target = "rente_vorj_vor_grundr_proxy_m"
     calc_result = compute_taxes_and_transfers(
         data=df,
@@ -136,7 +140,9 @@ def test_proxy_rente_vorj(input_data_proxy_rente, year):
 def test_proxy_rente_vorj_comparison_last_year(input_data_proxy_rente, year):
     year_data = input_data_proxy_rente[input_data_proxy_rente["jahr"] == year]
     df = year_data[INPUT_COLS_INCOME].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_grundrente.py
+++ b/src/_gettsim_tests/test_grundrente.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -55,7 +55,7 @@ def input_data():
 def test_grundrente(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
 
     calc_result = compute_taxes_and_transfers(
         data=df,
@@ -119,7 +119,7 @@ def input_data_proxy_rente():
 def test_proxy_rente_vorj(input_data_proxy_rente, year):
     year_data = input_data_proxy_rente[input_data_proxy_rente["jahr"] == year]
     df = year_data[INPUT_COLS_INCOME].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
     target = "rente_vorj_vor_grundr_proxy_m"
     calc_result = compute_taxes_and_transfers(
         data=df,
@@ -136,7 +136,7 @@ def test_proxy_rente_vorj(input_data_proxy_rente, year):
 def test_proxy_rente_vorj_comparison_last_year(input_data_proxy_rente, year):
     year_data = input_data_proxy_rente[input_data_proxy_rente["jahr"] == year]
     df = year_data[INPUT_COLS_INCOME].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
 
     calc_result = compute_taxes_and_transfers(
         data=df,
@@ -146,7 +146,7 @@ def test_proxy_rente_vorj_comparison_last_year(input_data_proxy_rente, year):
     )
 
     # Calculate pension of last year
-    policy_params, policy_functions = set_up_policy_environment(
+    policy_params, policy_functions = cached_set_up_policy_environment(
         date=f"{year - 1}-07-01"
     )
     df["alter"] -= 1

--- a/src/_gettsim_tests/test_grunds_im_alter.py
+++ b/src/_gettsim_tests/test_grunds_im_alter.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -74,7 +74,7 @@ def input_data():
 def test_grunds_im_alter(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_grunds_im_alter.py
+++ b/src/_gettsim_tests/test_grunds_im_alter.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
@@ -74,7 +74,9 @@ def input_data():
 def test_grunds_im_alter(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_kindergeld.py
+++ b/src/_gettsim_tests/test_kindergeld.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "hh_id",
@@ -40,7 +40,7 @@ def input_data():
 def test_kindergeld(input_data, year, target):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     user_cols = ["_zu_verst_eink_ohne_kinderfreib_tu"]
     calc_result = compute_taxes_and_transfers(

--- a/src/_gettsim_tests/test_kindergeld.py
+++ b/src/_gettsim_tests/test_kindergeld.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_kinderzuschl.py
+++ b/src/_gettsim_tests/test_kinderzuschl.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_kinderzuschl.py
+++ b/src/_gettsim_tests/test_kinderzuschl.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -62,7 +62,7 @@ def test_kinderzuschl(
 ):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_renten_alter.py
+++ b/src/_gettsim_tests/test_renten_alter.py
@@ -4,9 +4,9 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
@@ -148,7 +148,9 @@ def input_data():
 def test_renten_alter(input_data, year, column):
     year_data = input_data.reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_renten_alter.py
+++ b/src/_gettsim_tests/test_renten_alter.py
@@ -4,11 +4,11 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -148,7 +148,7 @@ def input_data():
 def test_renten_alter(input_data, year, column):
     year_data = input_data.reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_renten_anspr.py
+++ b/src/_gettsim_tests/test_renten_anspr.py
@@ -7,11 +7,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -62,7 +62,7 @@ def input_data():
 def test_renten_anspr(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_renten_anspr.py
+++ b/src/_gettsim_tests/test_renten_anspr.py
@@ -7,9 +7,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
@@ -62,7 +62,9 @@ def input_data():
 def test_renten_anspr(input_data, year, column):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-07-01")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-07-01"
+    )
 
     calc_result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -1,10 +1,10 @@
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -33,7 +33,7 @@ def test_soli_st(
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
 
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     user_cols = ["eink_st_mit_kinderfreib_tu", "abgelt_st_tu"]
     results = compute_taxes_and_transfers(

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_sozialv_beitr.py
+++ b/src/_gettsim_tests/test_sozialv_beitr.py
@@ -2,10 +2,10 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -48,7 +48,7 @@ def input_data():
 def test_sozialv_beitr(input_data, year, target):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     results = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_sozialv_beitr.py
+++ b/src/_gettsim_tests/test_sozialv_beitr.py
@@ -2,8 +2,8 @@ import itertools
 
 import pandas as pd
 import pytest
-
 from _gettsim.interface import compute_taxes_and_transfers
+
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from _gettsim.config import numpy_or_jax as np
 from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from _gettsim.synthetic import create_synthetic_data
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 
 def test_synthetic():
@@ -44,6 +44,6 @@ def test_synthetic():
     assert incrange.notna().all().all()
 
     # finally, run through gettsim
-    policy_params, policy_functions = set_up_policy_environment(2020)
+    policy_params, policy_functions = cached_set_up_policy_environment(2020)
     results = compute_taxes_and_transfers(df, policy_params, policy_functions)
     assert len(results) == len(df)

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from _gettsim.config import numpy_or_jax as np
 from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim.synthetic import create_synthetic_data
+
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 

--- a/src/_gettsim_tests/test_unterhalt.py
+++ b/src/_gettsim_tests/test_unterhalt.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -32,7 +32,7 @@ def input_data():
 def test_unterhalt(input_data, column, year):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_unterhalt.py
+++ b/src/_gettsim_tests/test_unterhalt.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_unterhaltsvors.py
+++ b/src/_gettsim_tests/test_unterhaltsvors.py
@@ -1,10 +1,10 @@
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -47,7 +47,7 @@ def test_unterhaltsvors(input_data, column, year, month):
         (input_data["jahr"] == year) & (input_data["monat"] == month)
     ].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=f"{year}-{month}")
+    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-{month}")
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_unterhaltsvors.py
+++ b/src/_gettsim_tests/test_unterhaltsvors.py
@@ -1,8 +1,8 @@
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
@@ -47,7 +47,9 @@ def test_unterhaltsvors(input_data, column, year, month):
         (input_data["jahr"] == year) & (input_data["monat"] == month)
     ].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = cached_set_up_policy_environment(date=f"{year}-{month}")
+    policy_params, policy_functions = cached_set_up_policy_environment(
+        date=f"{year}-{month}"
+    )
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_visualizations.py
+++ b/src/_gettsim_tests/test_visualizations.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import pytest
-from _gettsim.policy_environment import set_up_policy_environment
+
 from _gettsim.visualization import (
     _get_selected_nodes,
     _kth_order_neighbors,
@@ -9,8 +9,9 @@ from _gettsim.visualization import (
     _select_nodes_in_dag,
     plot_dag,
 )
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
-policy_params, policy_functions = set_up_policy_environment(date=2020)
+policy_params, policy_functions = cached_set_up_policy_environment(date=2020)
 
 
 @pytest.mark.parametrize(

--- a/src/_gettsim_tests/test_visualizations.py
+++ b/src/_gettsim_tests/test_visualizations.py
@@ -1,6 +1,5 @@
 import networkx as nx
 import pytest
-
 from _gettsim.visualization import (
     _get_selected_nodes,
     _kth_order_neighbors,
@@ -9,6 +8,7 @@ from _gettsim.visualization import (
     _select_nodes_in_dag,
     plot_dag,
 )
+
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 policy_params, policy_functions = cached_set_up_policy_environment(date=2020)

--- a/src/_gettsim_tests/test_vorsorgeaufw.py
+++ b/src/_gettsim_tests/test_vorsorgeaufw.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -48,7 +48,7 @@ def test_vorsorgeaufw(
 ):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     result = compute_taxes_and_transfers(
         data=df,

--- a/src/_gettsim_tests/test_vorsorgeaufw.py
+++ b/src/_gettsim_tests/test_vorsorgeaufw.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_wohngeld.py
+++ b/src/_gettsim_tests/test_wohngeld.py
@@ -2,10 +2,10 @@ import itertools
 
 import pandas as pd
 import pytest
-from pandas.testing import assert_series_equal
-
 from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim.policy_environment import set_up_policy_environment
+from pandas.testing import assert_series_equal
+
 from _gettsim_tests import TEST_DATA_DIR
 
 # Variables for the standard wohngeld test.

--- a/src/_gettsim_tests/test_wohngeld.py
+++ b/src/_gettsim_tests/test_wohngeld.py
@@ -2,10 +2,10 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
+from _gettsim.policy_environment import set_up_policy_environment
 from _gettsim_tests import TEST_DATA_DIR
 
 # Variables for the standard wohngeld test.

--- a/src/_gettsim_tests/test_zu_verst_eink.py
+++ b/src/_gettsim_tests/test_zu_verst_eink.py
@@ -2,9 +2,9 @@ import itertools
 
 import pandas as pd
 import pytest
+from _gettsim.interface import compute_taxes_and_transfers
 from pandas.testing import assert_series_equal
 
-from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 

--- a/src/_gettsim_tests/test_zu_verst_eink.py
+++ b/src/_gettsim_tests/test_zu_verst_eink.py
@@ -2,11 +2,11 @@ import itertools
 
 import pandas as pd
 import pytest
-from _gettsim.interface import compute_taxes_and_transfers
-from _gettsim.policy_environment import set_up_policy_environment
 from pandas.testing import assert_series_equal
 
+from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests import TEST_DATA_DIR
+from _gettsim_tests._helpers import cached_set_up_policy_environment
 
 INPUT_COLS = [
     "p_id",
@@ -66,7 +66,7 @@ def test_zu_verst_eink(
 ):
     year_data = input_data[input_data["jahr"] == year].reset_index(drop=True)
     df = year_data[INPUT_COLS].copy()
-    policy_params, policy_functions = set_up_policy_environment(date=year)
+    policy_params, policy_functions = cached_set_up_policy_environment(date=year)
 
     result = compute_taxes_and_transfers(
         data=df,


### PR DESCRIPTION
### What problem do you want to solve?

Running all tests was quite slow (**6 min 12s** on my machine). This PR should offer a considerable speed increase by caching the results of calls to  `set_up_policy_environment`. Now tests run in **1 min 9s** on my system.

### Todo

- [x] Pick an appropriate title.
- [x] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md (omitted since the changes are not user-facing).
