### PR TITLE
Filter `PolicyTestSet`

### DIFF
--- a/src/_gettsim_tests/_policy_test_utils.py
+++ b/src/_gettsim_tests/_policy_test_utils.py
@@ -30,8 +30,11 @@ class PolicyTestSet:
         return pd.concat([test.output_df for test in self.test_data], ignore_index=True)
 
     def filter_test_data(
-        self, *, test_name: str | None = None, date: datetime.date | None = None
+        self, *, test_name: str | None = None, date: datetime.date | str | None = None
     ) -> PolicyTestSet:
+        if isinstance(date, str):
+            date = _parse_date(date)
+
         filtered_test_data = [
             test
             for test in self.test_data

--- a/src/_gettsim_tests/_policy_test_utils.py
+++ b/src/_gettsim_tests/_policy_test_utils.py
@@ -32,6 +32,34 @@ class PolicyTestSet:
     def filter_test_data(
         self, *, test_name: str | None = None, date: datetime.date | str | None = None
     ) -> PolicyTestSet:
+        """
+        Filter the test data in this PolicyTestSet.
+
+        Note that you must pass all arguments of this function by name (and not by
+        position).
+
+        Parameters
+        ----------
+        test_name : str | None
+            If provided, only instances of `PolicyTestData` with this name are included
+            in the result. If None, no filtering is done on test name.
+        date : datetime.date | str | None
+            If provided, only instances of `PolicyTestData` with this date are
+            included in the result. If None, no filtering is done on date.
+
+        Returns
+        -------
+        PolicyTestSet
+            A new PolicyTestSet with the filtered test data.
+
+        Examples
+        --------
+        >>> data = load_policy_test_data("soli_st")
+        >>> filtered_by_name = data.filter_test_data(test_name="hh_id_2")
+
+        >>> filtered_by_date = data.filter_test_data(date="1991")
+        """
+
         if isinstance(date, str):
             date = _parse_date(date)
 

--- a/src/_gettsim_tests/_policy_test_utils.py
+++ b/src/_gettsim_tests/_policy_test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import pandas as pd
 import yaml
@@ -32,19 +32,19 @@ class PolicyTestSet:
 
 class PolicyTestData:
     def __init__(  # noqa: PLR0913
-        self,
-        policy_name: str,
-        test_file: Path,
-        household_name: str,
-        date: str,
-        inputs_provided: _ValueDict,
-        inputs_assumed: _ValueDict,
-        outputs: _ValueDict,
+            self,
+            policy_name: str,
+            test_file: Path,
+            test_name: str,
+            date: str,
+            inputs_provided: _ValueDict,
+            inputs_assumed: _ValueDict,
+            outputs: _ValueDict,
     ):
         self.policy_name = policy_name
         self.test_file = test_file
-        self.household_name = household_name
-        self.date: date = _parse_date(date)
+        self.test_name = test_name
+        self.date = _parse_date(date)
         self._inputs_provided = inputs_provided
         self._inputs_assumed = inputs_assumed
         self._outputs = outputs
@@ -62,7 +62,7 @@ class PolicyTestData:
     def __repr__(self) -> str:
         return (
             f"PolicyTestData({self.policy_name}, {self.test_file.name}, "
-            f"{self.household_name})"
+            f"{self.test_name})"
         )
 
     def __str__(self) -> str:
@@ -83,21 +83,21 @@ def load_policy_test_data(policy_name: str) -> PolicyTestSet:
             continue
 
         with test_file.open("r", encoding="utf-8") as file:
-            household_data: dict[str, dict] = yaml.safe_load(file)
+            test_data: dict[str, dict] = yaml.safe_load(file)
 
         date = test_file.parent.name
-        household_name = test_file.stem
+        test_name = test_file.stem
 
-        inputs: dict[str, dict] = household_data["inputs"]
+        inputs: dict[str, dict] = test_data["inputs"]
         inputs_provided: _ValueDict = inputs["provided"]
         inputs_assumed: _ValueDict = inputs["assumed"]
-        outputs: _ValueDict = household_data["outputs"]
+        outputs: _ValueDict = test_data["outputs"]
 
         out.append(
             PolicyTestData(
                 policy_name=policy_name,
                 test_file=test_file,
-                household_name=household_name,
+                test_name=test_name,
                 date=date,
                 inputs_provided=inputs_provided,
                 inputs_assumed=inputs_assumed,

--- a/src/_gettsim_tests/_policy_test_utils.py
+++ b/src/_gettsim_tests/_policy_test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import yaml
@@ -29,17 +29,29 @@ class PolicyTestSet:
     def merged_output_df(self) -> pd.DataFrame:
         return pd.concat([test.output_df for test in self.test_data], ignore_index=True)
 
+    def filter_test_data(
+        self, *, test_name: str | None = None, date: datetime.date | None = None
+    ) -> PolicyTestSet:
+        filtered_test_data = [
+            test
+            for test in self.test_data
+            if (test_name is None or test.test_name == test_name)
+            and (date is None or test.date == date)
+        ]
+
+        return PolicyTestSet(self.policy_name, filtered_test_data)
+
 
 class PolicyTestData:
     def __init__(  # noqa: PLR0913
-            self,
-            policy_name: str,
-            test_file: Path,
-            test_name: str,
-            date: str,
-            inputs_provided: _ValueDict,
-            inputs_assumed: _ValueDict,
-            outputs: _ValueDict,
+        self,
+        policy_name: str,
+        test_file: Path,
+        test_name: str,
+        date: str,
+        inputs_provided: _ValueDict,
+        inputs_assumed: _ValueDict,
+        outputs: _ValueDict,
     ):
         self.policy_name = policy_name
         self.test_file = test_file


### PR DESCRIPTION
### What problem do you want to solve?

* Add a function to filter a `PolicyTestSet` by `test_name` and/or `date`.
* Rename `household_name` to `test_name`.

See also: [Zulip discussion
](https://gettsim.zulipchat.com/#narrow/stream/224837-High-Level-Architecture/topic/tests/near/353133153)

### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [X] Document PR in CHANGES.md. (omitted since changes are not user-facing)