### PR TITLE
Erziehungsgeld

### DIFF
--- a/src/_gettsim/parameters/erziehungsgeld.yaml
+++ b/src/_gettsim/parameters/erziehungsgeld.yaml
@@ -1,0 +1,89 @@
+einkommensgrenze_bis_6m:
+  name:
+    de: 
+    en: 
+  description:
+    de: 
+    en: null
+  unit: Euro
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    alleinerz: 30000
+    paar: 23000
+einkommensgrenze_ab_7m:
+  name:
+    de: 
+    en: 
+  description:
+    de: 
+    en: null
+  unit: Euro
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    alleinerz: 13500
+    paar: 16500
+aufschlag_einkommen:
+  name:
+    de: 
+    en: 
+  description:
+    de: Erhöhung der Einkommensgrenze pro weiterem Kind
+    en: null
+  unit: Euro
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    alleinerz: 
+    paar: 3140
+erziehungsgeld_regelsatz:
+  name: 
+    de: Erziehungsgeld Regelsatz
+    en: 
+  description:
+    de: Höhe des Erziehungsgeldes
+    en: null
+  unit: Euro
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    scalar: 300
+reduzierung_erziehungsgeld:
+  name: 
+    de: >-
+      Faktor um den das Erziehungsgeld bei Überschreitung der Einkommensgrenze 
+      ab dem 7. Lebensmonat reduziert wird
+    en: 
+  description:
+    de: 
+    en: null
+  unit: faktor
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    scalar: 0.052
+pauschal_abzug_auf_einkommen:
+  name:
+    de: 
+    en: 
+  description:
+    de: 
+    en: null
+  unit: 
+  reference: >-
+    https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
+    BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
+    bl104s0206.pdf%27%5D__1685621730529
+  2004-02-09:
+    scalar: 0.76

--- a/src/_gettsim/parameters/erziehungsgeld.yaml
+++ b/src/_gettsim/parameters/erziehungsgeld.yaml
@@ -1,9 +1,10 @@
+---
 einkommensgrenze_bis_6m:
   name:
-    de: 
-    en: 
+    de: null
+    en: null
   description:
-    de: 
+    de: null
     en: null
   unit: Euro
   reference: >-
@@ -15,10 +16,10 @@ einkommensgrenze_bis_6m:
     paar: 23000
 einkommensgrenze_ab_7m:
   name:
-    de: 
-    en: 
+    de: null
+    en: null
   description:
-    de: 
+    de: null
     en: null
   unit: Euro
   reference: >-
@@ -30,8 +31,8 @@ einkommensgrenze_ab_7m:
     paar: 16500
 aufschlag_einkommen:
   name:
-    de: 
-    en: 
+    de: null
+    en: null
   description:
     de: Erhöhung der Einkommensgrenze pro weiterem Kind
     en: null
@@ -41,12 +42,12 @@ aufschlag_einkommen:
     BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg
     bl104s0206.pdf%27%5D__1685621730529
   2004-02-09:
-    alleinerz: 
+    alleinerz: null
     paar: 3140
 erziehungsgeld_regelsatz:
-  name: 
+  name:
     de: Erziehungsgeld Regelsatz
-    en: 
+    en: null
   description:
     de: Höhe des Erziehungsgeldes
     en: null
@@ -58,13 +59,13 @@ erziehungsgeld_regelsatz:
   2004-02-09:
     scalar: 300
 reduzierung_erziehungsgeld:
-  name: 
+  name:
     de: >-
-      Faktor um den das Erziehungsgeld bei Überschreitung der Einkommensgrenze 
-      ab dem 7. Lebensmonat reduziert wird
-    en: 
+      Faktor um den das Erziehungsgeld bei Überschreitung der Einkommensgrenze  ab dem 7.
+      Lebensmonat reduziert wird
+    en: null
   description:
-    de: 
+    de: null
     en: null
   unit: faktor
   reference: >-
@@ -75,12 +76,12 @@ reduzierung_erziehungsgeld:
     scalar: 0.052
 pauschal_abzug_auf_einkommen:
   name:
-    de: 
-    en: 
-  description:
-    de: 
+    de: null
     en: null
-  unit: 
+  description:
+    de: null
+    en: null
+  unit: null
   reference: >-
     https://www.bgbl.de/xaver/bgbl/start.xav?startbk=Bundesanzeiger_
     BGBl&jumpTo=bgbl104s0206.pdf#__bgbl__%2F%2F*%5B%40attr_id%3D%27bg

--- a/src/_gettsim/transfers/erziehungsgeld.py
+++ b/src/_gettsim/transfers/erziehungsgeld.py
@@ -1,0 +1,111 @@
+from _gettsim.shared import dates_active
+
+aggregation_erziehungsgeld = {
+    "bruttolohn_vorj_m_tu": {
+        "source_col": "bruttolohn_vorj_m",
+        "aggr": "cumsum",
+    },
+    "anz_kinder_mit_kindergeld_tu": {
+        "source_col": "kindergeld_anspruch",
+        "aggr": "sum",
+    },
+}
+
+@dates_active(end="2006-12-31")
+def erziehungsgeld_m(
+        erziehungsgeld_params: dict,
+        erziehungsgeld_anspruch: bool,
+        erziehungsgeld_einkommen_relev: float,
+        erziehungsgeld_einkommensgrenze: float,
+        alter_monate_jüngstes_mitglied_hh: int,
+) -> float:
+    """
+    Todo: People can decide whether they want the "regelsatz" for up to 24 month
+          or a higher "budgetiertes Erziehungsgeld" for just 12 month
+    """
+    # if the income is higher than the threshold within the first 6 month there
+    # is no erziehungsgeld claim at all
+    if (erziehungsgeld_anspruch and 
+        alter_monate_jüngstes_mitglied_hh < 7 and
+        erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze):
+        out = 0.0
+    
+    elif (erziehungsgeld_anspruch and 
+        erziehungsgeld_einkommen_relev < erziehungsgeld_einkommensgrenze):
+        out = erziehungsgeld_params["erziehungsgeld_regelsatz"]
+    # if the income is higher than the threshold and the child is older than
+    # 7 month the Erziehungsgeld is reduced
+    elif (erziehungsgeld_anspruch and
+          alter_monate_jüngstes_mitglied_hh > 7 and
+          erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze):
+        
+        abzug = (erziehungsgeld_einkommen_relev * 
+                 erziehungsgeld_params["reduzierung_erziehungsgeld"])
+        out = max(erziehungsgeld_params["erziehungsgeld_regelsatz"]-abzug , 0.0)
+
+    return out
+
+
+def erziehungsgeld_anspruch(
+        arbeitsstunden_w: float,
+        hat_kinder: bool,
+        alter_monate_jüngstes_mitglied_hh: int,
+
+) -> bool:
+    """
+    
+    """
+    
+    out = (hat_kinder 
+           and alter_monate_jüngstes_mitglied_hh < 24
+           and arbeitsstunden_w <= 30)
+
+    return out
+
+def erziehungsgeld_einkommen_relev(
+        bruttolohn_vorj_m: float,
+        bruttolohn_vorj_m_tu: float,
+        erziehungsgeld_params: dict,
+        alleinerz: bool,
+        eink_st_abzuege_params: dict
+        
+) -> bool:
+    """
+    Todo: There is special rule for "Beamte, Soldaten und Richter" which is not
+          implemented yet
+    """
+ 
+    if alleinerz:
+        out = ((bruttolohn_vorj_m * 12  - eink_st_abzuege_params["werbungskostenpauschale"]) 
+                *  erziehungsgeld_params["pauschal_abzug_auf_einkommen"])
+    else:
+        out = ((bruttolohn_vorj_m_tu * 12 - eink_st_abzuege_params["werbungskostenpauschale"] * 2) 
+               *  erziehungsgeld_params["pauschal_abzug_auf_einkommen"])
+
+    return out
+
+def erziehungsgeld_einkommensgrenze(
+        erziehungsgeld_params: dict,
+        alleinerz: bool,
+        alter_monate_jüngstes_mitglied_hh: int,
+        anz_kinder_mit_kindergeld_tu: int,
+) -> float:
+    """
+    
+    """
+    # There are different income threshold depending on the age of the child
+    # the fact if a person is a single parent
+    if alter_monate_jüngstes_mitglied_hh < 7:
+        if alleinerz:
+            out = erziehungsgeld_params["einkommensgrenze_bis_6m"]["alleinerz"]
+        else:
+            out = erziehungsgeld_params["einkommensgrenze_bis_6m"]["paar"]
+    else:
+        if alleinerz:
+            out = erziehungsgeld_params["einkommensgrenze_ab_7m"]["alleinerz"]
+        else:
+            out = erziehungsgeld_params["einkommensgrenze_ab_7m"]["paar"]
+    # For every additional child the income threshold is increasing by a fixed amount
+    out += ((anz_kinder_mit_kindergeld_tu - 1) 
+            * erziehungsgeld_params["aufschlag_einkommen"])
+    return out

--- a/src/_gettsim/transfers/erziehungsgeld.py
+++ b/src/_gettsim/transfers/erziehungsgeld.py
@@ -11,13 +11,14 @@ aggregation_erziehungsgeld = {
     },
 }
 
+
 @dates_active(end="2006-12-31")
 def erziehungsgeld_m(
-        erziehungsgeld_params: dict,
-        erziehungsgeld_anspruch: bool,
-        erziehungsgeld_einkommen_relev: float,
-        erziehungsgeld_einkommensgrenze: float,
-        alter_monate_jüngstes_mitglied_hh: int,
+    erziehungsgeld_params: dict,
+    erziehungsgeld_anspruch: bool,
+    erziehungsgeld_einkommen_relev: float,
+    erziehungsgeld_einkommensgrenze: float,
+    alter_monate_jüngstes_mitglied_hh: int,
 ) -> float:
     """
     Todo: People can decide whether they want the "regelsatz" for up to 24 month
@@ -25,74 +26,80 @@ def erziehungsgeld_m(
     """
     # if the income is higher than the threshold within the first 6 month there
     # is no erziehungsgeld claim at all
-    if (erziehungsgeld_anspruch and 
-        alter_monate_jüngstes_mitglied_hh < 7 and
-        erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze):
+    if (
+        erziehungsgeld_anspruch
+        and alter_monate_jüngstes_mitglied_hh < 7
+        and erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze
+    ):
         out = 0.0
-    
-    elif (erziehungsgeld_anspruch and 
-        erziehungsgeld_einkommen_relev < erziehungsgeld_einkommensgrenze):
+
+    elif (
+        erziehungsgeld_anspruch
+        and erziehungsgeld_einkommen_relev < erziehungsgeld_einkommensgrenze
+    ):
         out = erziehungsgeld_params["erziehungsgeld_regelsatz"]
     # if the income is higher than the threshold and the child is older than
     # 7 month the Erziehungsgeld is reduced
-    elif (erziehungsgeld_anspruch and
-          alter_monate_jüngstes_mitglied_hh > 7 and
-          erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze):
-        
-        abzug = (erziehungsgeld_einkommen_relev * 
-                 erziehungsgeld_params["reduzierung_erziehungsgeld"])
-        out = max(erziehungsgeld_params["erziehungsgeld_regelsatz"]-abzug , 0.0)
+    elif (
+        erziehungsgeld_anspruch
+        and alter_monate_jüngstes_mitglied_hh > 7
+        and erziehungsgeld_einkommen_relev > erziehungsgeld_einkommensgrenze
+    ):
+        abzug = (
+            erziehungsgeld_einkommen_relev
+            * erziehungsgeld_params["reduzierung_erziehungsgeld"]
+        )
+        out = max(erziehungsgeld_params["erziehungsgeld_regelsatz"] - abzug, 0.0)
 
     return out
 
 
 def erziehungsgeld_anspruch(
-        arbeitsstunden_w: float,
-        hat_kinder: bool,
-        alter_monate_jüngstes_mitglied_hh: int,
-
+    arbeitsstunden_w: float,
+    hat_kinder: bool,
+    alter_monate_jüngstes_mitglied_hh: int,
 ) -> bool:
-    """
-    
-    """
-    
-    out = (hat_kinder 
-           and alter_monate_jüngstes_mitglied_hh < 24
-           and arbeitsstunden_w <= 30)
+    """ """
+
+    out = (
+        hat_kinder and alter_monate_jüngstes_mitglied_hh < 24 and arbeitsstunden_w <= 30
+    )
 
     return out
 
+
 def erziehungsgeld_einkommen_relev(
-        bruttolohn_vorj_m: float,
-        bruttolohn_vorj_m_tu: float,
-        erziehungsgeld_params: dict,
-        alleinerz: bool,
-        eink_st_abzuege_params: dict
-        
+    bruttolohn_vorj_m: float,
+    bruttolohn_vorj_m_tu: float,
+    erziehungsgeld_params: dict,
+    alleinerz: bool,
+    eink_st_abzuege_params: dict,
 ) -> bool:
     """
     Todo: There is special rule for "Beamte, Soldaten und Richter" which is not
           implemented yet
     """
- 
+
     if alleinerz:
-        out = ((bruttolohn_vorj_m * 12  - eink_st_abzuege_params["werbungskostenpauschale"]) 
-                *  erziehungsgeld_params["pauschal_abzug_auf_einkommen"])
+        out = (
+            bruttolohn_vorj_m * 12 - eink_st_abzuege_params["werbungskostenpauschale"]
+        ) * erziehungsgeld_params["pauschal_abzug_auf_einkommen"]
     else:
-        out = ((bruttolohn_vorj_m_tu * 12 - eink_st_abzuege_params["werbungskostenpauschale"] * 2) 
-               *  erziehungsgeld_params["pauschal_abzug_auf_einkommen"])
+        out = (
+            bruttolohn_vorj_m_tu * 12
+            - eink_st_abzuege_params["werbungskostenpauschale"] * 2
+        ) * erziehungsgeld_params["pauschal_abzug_auf_einkommen"]
 
     return out
 
+
 def erziehungsgeld_einkommensgrenze(
-        erziehungsgeld_params: dict,
-        alleinerz: bool,
-        alter_monate_jüngstes_mitglied_hh: int,
-        anz_kinder_mit_kindergeld_tu: int,
+    erziehungsgeld_params: dict,
+    alleinerz: bool,
+    alter_monate_jüngstes_mitglied_hh: int,
+    anz_kinder_mit_kindergeld_tu: int,
 ) -> float:
-    """
-    
-    """
+    """ """
     # There are different income threshold depending on the age of the child
     # the fact if a person is a single parent
     if alter_monate_jüngstes_mitglied_hh < 7:
@@ -106,6 +113,7 @@ def erziehungsgeld_einkommensgrenze(
         else:
             out = erziehungsgeld_params["einkommensgrenze_ab_7m"]["paar"]
     # For every additional child the income threshold is increasing by a fixed amount
-    out += ((anz_kinder_mit_kindergeld_tu - 1) 
-            * erziehungsgeld_params["aufschlag_einkommen"])
+    out += (anz_kinder_mit_kindergeld_tu - 1) * erziehungsgeld_params[
+        "aufschlag_einkommen"
+    ]
     return out


### PR DESCRIPTION
### What problem do you want to solve?

Implementation of the „Erziehungsgeld“

The “Erziehungsgeld" existed until 2006 and was then replaced by the “Elterngeld” which is already implemented. This change in legislation makes it interesting to look at. Accordingly, only the period from the last change in the "Bundeserziehungsgeldgesetz" in 2004 to the abolition in 2006 was considered.  



### Todo

