### PR TITLE
add anz_eig_kind_bis_24 to synthetic.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ versioning](https://semver.org/) and all releases are available on
 
 ## Unpublished
 
+- {gh}`603` Add anz_eig_kind_bis_24 to synthetic ({ghuser}`ChristianZimpelmann`).
 - {gh}`593` Implement reform of gesetzliche Pflegepflegeversicherung effective
   as of 2023-07-01 ({ghuser}`paulinaschroeder`).
 - {gh}`602` Correct `midijob_faktor_f` ({ghuser}`paulinaschroeder`).

--- a/src/_gettsim/social_insurance_contributions/ges_pflegev.py
+++ b/src/_gettsim/social_insurance_contributions/ges_pflegev.py
@@ -36,7 +36,7 @@ def ges_pflegev_beitr_satz_ohne_kinder_abschlag(
     ges_pflegev_zusatz_kinderlos: bool,
     sozialv_beitr_params: dict,
 ) -> float:
-    """Care insurance contribution rate before July 2023.
+    """Care insurance contribution rate until June 2023.
 
     Parameters
     ----------
@@ -64,7 +64,7 @@ def ges_pflegev_beitr_satz_mit_kinder_abschlag(
     ges_pflegev_zusatz_kinderlos: bool,
     sozialv_beitr_params: dict,
 ) -> float:
-    """Care insurance contribution rate after July 2023.
+    """Care insurance contribution rate since July 2023.
     For individuals with children younger than 25 rates are reduced.
 
     Parameters

--- a/src/_gettsim/synthetic.py
+++ b/src/_gettsim/synthetic.py
@@ -135,7 +135,10 @@ def create_basic_households(
             "hh_typ": [hh_typ_string] * (n_adults + n_children),
             "hat_kinder": hat_kinder,
             "alleinerz": alleinerziehend,
-            **specs_constant_over_households,
+            # Assumption: All children are biological children of the adults, children
+            # do not have children themselves
+            "anz_eig_kind_bis_24": [n_children] * n_adults
+            + [0] * n_children**specs_constant_over_households,
             **{v: k[i] for v, k in specs_heterogeneous.items()},
         }
         for i in range(n_households)

--- a/src/_gettsim/synthetic.py
+++ b/src/_gettsim/synthetic.py
@@ -137,8 +137,8 @@ def create_basic_households(
             "alleinerz": alleinerziehend,
             # Assumption: All children are biological children of the adults, children
             # do not have children themselves
-            "anz_eig_kind_bis_24": [n_children] * n_adults
-            + [0] * n_children**specs_constant_over_households,
+            "anz_eig_kind_bis_24": [n_children] * n_adults + [0] * n_children,
+            **specs_constant_over_households,
             **{v: k[i] for v, k in specs_heterogeneous.items()},
         }
         for i in range(n_households)

--- a/src/_gettsim/transfers/kindergeld.py
+++ b/src/_gettsim/transfers/kindergeld.py
@@ -55,7 +55,7 @@ def kindergeld_anspruch_nach_lohn(
 ) -> bool:
     """Determine kindergeld eligibility for an individual child depending on kids wage.
 
-    Before 2011, there was an income ceiling for children
+    Until 2011, there was an income ceiling for children
     returns a boolean variable whether a specific person is a child eligible for
     child benefit
 

--- a/src/_gettsim/transfers/wohngeld.py
+++ b/src/_gettsim/transfers/wohngeld.py
@@ -493,7 +493,7 @@ def wohngeld_miete_m_hh_ab_2009(  # noqa: PLR0912 (see #516)
             * params_max_miete["jede_weitere_person"][mietstufe]
         )
 
-    # Calc heating allowance. Before 2021, heating allowance was not
+    # Calc heating allowance. Until 2020, heating allowance was not
     # introduced yet. For this time frame, the respective parameter is
     # not part of wohngeld_params and heating allowance is set to 0.
     if "heizkostenentlastung_m" in wohngeld_params:
@@ -514,7 +514,7 @@ def wohngeld_miete_m_hh_ab_2009(  # noqa: PLR0912 (see #516)
     else:
         heating_allowance_m = 0
 
-    # Calc heating cost component. Before 2023, heating cost component was not
+    # Calc heating cost component. Until 2022, heating cost component was not
     # introduced yet. For this time frame, the respective parameter is not part
     # of wohngeld_params and heating cost component is set to 0.
     if "dauerhafte_heizkostenkomponente_m" in wohngeld_params:
@@ -539,7 +539,7 @@ def wohngeld_miete_m_hh_ab_2009(  # noqa: PLR0912 (see #516)
     else:
         heating_component_m = 0
 
-    # Calc climate component. Before 2023, climate component was not
+    # Calc climate component. Until 2022, climate component was not
     # introduced yet. For this time frame, the respective parameter is not
     # part of wohngeld_params and climate component is set to 0.
     if "klimakomponente_m" in wohngeld_params:


### PR DESCRIPTION
### What problem do you want to solve?

#595 added a new input variable, but we forgot to have the input variable created in `synthetic.py`.


### Todo

- [x] Add `anz_eig_kind_bis_24` to synthetic
- [x] Make sure GETTSIM with default targets can be run over data set created by synthetic (Should we maybe implement this as an automated test. @hmgaudecker, what do you think?)
- [x] Document PR in CHANGES.md.
- [x] While working on it, I also made some wording in the documentation with respect to time-varying policy functions more precise.
