### PR TITLE
Consider self-employed income for Elterngeld

### DIFF
--- a/src/_gettsim/transfers/elterngeld.py
+++ b/src/_gettsim/transfers/elterngeld.py
@@ -265,8 +265,9 @@ def _elterngeld_anz_mehrlinge_anspruch(
     return out
 
 
-def elterngeld_nettolohn_m(
+def elterngeld_nettoeink_m(  # noqa: PLR0913
     bruttolohn_m: float,
+    eink_selbst_m: float,
     eink_st_y_tu: float,
     soli_st_y_tu: float,
     anz_erwachsene_tu: int,
@@ -281,6 +282,8 @@ def elterngeld_nettolohn_m(
     ----------
     bruttolohn_m
         See basic input variable :ref:`bruttolohn_m <bruttolohn_m>`.
+    eink_selbst_m
+        See basic input variable :ref:`eink_selbst_m <eink_selbst_m>`.
     eink_st_y_tu
         See :func:`eink_st_y_tu`.
     soli_st_y_tu
@@ -294,8 +297,10 @@ def elterngeld_nettolohn_m(
     -------
 
     """
+
     out = (
         bruttolohn_m
+        + eink_selbst_m
         - (eink_st_y_tu / anz_erwachsene_tu / 12)
         - (soli_st_y_tu / anz_erwachsene_tu / 12)
         - sozialv_beitr_m
@@ -306,7 +311,7 @@ def elterngeld_nettolohn_m(
 
 def elterngeld_eink_relev_m(
     _elterngeld_proxy_eink_vorj_elterngeld_m: float,
-    elterngeld_nettolohn_m: float,
+    elterngeld_nettoeink_m: float,
 ) -> float:
     """Calculating the relevant wage for the calculation of elterngeld.
 
@@ -318,14 +323,14 @@ def elterngeld_eink_relev_m(
     ----------
     _elterngeld_proxy_eink_vorj_elterngeld_m
         See :func:`_elterngeld_proxy_eink_vorj_elterngeld_m`.
-    elterngeld_nettolohn_m
-        See :func:`elterngeld_nettolohn_m`.
+    elterngeld_nettoeink_m
+        See :func:`elterngeld_nettoeink_m`.
 
     Returns
     -------
 
     """
-    return _elterngeld_proxy_eink_vorj_elterngeld_m - elterngeld_nettolohn_m
+    return _elterngeld_proxy_eink_vorj_elterngeld_m - elterngeld_nettoeink_m
 
 
 def elterngeld_anteil_eink_erlass(

--- a/src/_gettsim_tests/test_data/elterngeld/2017/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2017/hh_id_2.yaml
@@ -14,6 +14,8 @@ inputs:
       - false
     bruttolohn_m:
       - 1800.0
+    eink_selbst_m:
+      - 0.0
     bruttolohn_vorj_m:
       - 1800.0
     wohnort_ost:

--- a/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_1.yaml
@@ -14,6 +14,8 @@ inputs:
       - false
     bruttolohn_m:
       - 0.0
+    eink_selbst_m:
+      - 0.0
     bruttolohn_vorj_m:
       - 0.0
     wohnort_ost:

--- a/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_2.yaml
@@ -19,6 +19,9 @@ inputs:
     bruttolohn_m:
       - 100.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 1800.0
       - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_3.yaml
@@ -19,6 +19,9 @@ inputs:
     bruttolohn_m:
       - 900.0
       - 3400.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 900.0
       - 3600.0

--- a/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_4.yaml
@@ -19,6 +19,9 @@ inputs:
     bruttolohn_m:
       - 0.0
       - 3600.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 0.0
       - 3400.0

--- a/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018/hh_id_6.yaml
@@ -14,6 +14,8 @@ inputs:
       - false
     bruttolohn_m:
       - 900.0
+    eink_selbst_m:
+      - 0.0
     bruttolohn_vorj_m:
       - 900.0
     wohnort_ost:

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_1.yaml
@@ -19,6 +19,9 @@ inputs:
     bruttolohn_m:
       - 0.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 0.0
       - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_3.yaml
@@ -24,6 +24,10 @@ inputs:
       - 0.0
       - 0.0
       - 3600.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 900.0
       - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_5.yaml
@@ -19,6 +19,9 @@ inputs:
     bruttolohn_m:
       - 0.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 3600.0
       - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_6.yaml
@@ -24,6 +24,10 @@ inputs:
       - 0.0
       - 0.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 0.0
       - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_7.yaml
@@ -24,6 +24,10 @@ inputs:
       - 0.0
       - 0.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 1800.0
       - 1800.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019/hh_id_8.yaml
@@ -29,6 +29,11 @@ inputs:
       - 0.0
       - 0.0
       - 0.0
+    eink_selbst_m:
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
     bruttolohn_vorj_m:
       - 0.0
       - 0.0


### PR DESCRIPTION
### What problem do you want to solve?

Fixing #613 by considering `eink_selbst_m` for Elterngeld (not fully done, _elterngeld_proxy_eink_vorj_elterngeld_m yet unchanged)
