### PR TITLE
fix: don't create functions for other time units if this leads to a cycle in the graph

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ versioning](https://semver.org/) and all releases are available on
 
 ## Unpublished
 
+- {gh}`624` Don't create functions for other time units if this leads to a loop ({ghuser}`lars-reimann`).
 - {gh}`603` Add anz_eig_kind_bis_24 to synthetic ({ghuser}`ChristianZimpelmann`).
 - {gh}`593` Implement reform of gesetzliche Pflegepflegeversicherung effective
   as of 2023-07-01 ({ghuser}`paulinaschroeder`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ versioning](https://semver.org/) and all releases are available on
 
 ## Unpublished
 
-- {gh}`624` Don't create functions for other time units if this leads to a loop ({ghuser}`lars-reimann`).
+- {gh}`624` Don't create functions for other time units if this leads to a cycle in the graph ({ghuser}`lars-reimann`).
 - {gh}`603` Add anz_eig_kind_bis_24 to synthetic ({ghuser}`ChristianZimpelmann`).
 - {gh}`593` Implement reform of gesetzliche Pflegepflegeversicherung effective
   as of 2023-07-01 ({ghuser}`paulinaschroeder`).

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -307,6 +307,16 @@ def _create_time_conversion_functions(
         missing_time_units = [unit for unit in all_time_units if unit != time_unit]
         for missing_time_unit in missing_time_units:
             new_name = f"{base_name}{missing_time_unit}{aggregation}"
+
+            # Without this check, we could create cycles in the DAG: Consider a
+            # hard-coded function `var_y` that takes `var_m` as an input, assuming it
+            # to be provided in the input data. If we create a function `var_m`, which
+            # would take `var_y` as input, we create a cycle. If `var_m` is actually
+            # provided as an input, `var_m` would be overwritten, removing the cycle.
+            # However, if `var_m` is not provided as an input, an error message would
+            # be shown that a cycle between `var_y` and `var_m` was detected. This
+            # hides the actual problem, which is that `var_m` is not provided as an
+            # input.
             if new_name in dependencies:
                 continue
 

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -318,6 +318,7 @@ def _create_time_conversion_functions(
 
     return result
 
+
 def _create_function_for_time_unit(
     function_name: str, info: dict | None, converter: Callable[[float], float]
 ) -> Callable[[float], float]:

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -314,14 +314,6 @@ def _create_time_conversion_functions(
 
     return result
 
-
-def _replace_suffix(name: str, old_suffix: str, new_suffix: str) -> str:
-    if not name.endswith(old_suffix):
-        return name
-
-    return name.removesuffix(old_suffix) + new_suffix
-
-
 def _create_function_for_time_unit(
     function_name: str, info: dict | None, converter: Callable[[float], float]
 ) -> Callable[[float], float]:

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -236,3 +236,12 @@ class TestCreateFunctionForTimeUnit:
         function = _create_function_for_time_unit("test", None, d_to_w)
 
         assert function(1) == 7
+
+
+# https://github.com/iza-institute-of-labor-economics/gettsim/issues/621
+def test_should_not_create_loops():
+    time_conversion_functions = create_time_conversion_functions(
+        {"test_d": lambda test_m: 1}, []
+    )
+
+    assert "test_m" not in time_conversion_functions

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -239,7 +239,7 @@ class TestCreateFunctionForTimeUnit:
 
 
 # https://github.com/iza-institute-of-labor-economics/gettsim/issues/621
-def test_should_not_create_loops():
+def test_should_not_create_cycle():
     time_conversion_functions = create_time_conversion_functions(
         {"test_d": lambda test_m: test_m}, []
     )

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -241,7 +241,7 @@ class TestCreateFunctionForTimeUnit:
 # https://github.com/iza-institute-of-labor-economics/gettsim/issues/621
 def test_should_not_create_loops():
     time_conversion_functions = create_time_conversion_functions(
-        {"test_d": lambda test_m: 1}, []
+        {"test_d": lambda test_m: test_m}, []
     )
 
     assert "test_m" not in time_conversion_functions

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -3,7 +3,6 @@ import inspect
 import pytest
 from _gettsim.time_conversion import (
     _create_function_for_time_unit,
-    _replace_suffix,
     create_time_conversion_functions,
     d_to_m,
     d_to_w,
@@ -212,19 +211,6 @@ class TestCreateFunctionsForTimeUnits:
 
         assert "test_y" not in time_conversion_functions
         assert "test_d" not in time_conversion_functions
-
-
-@pytest.mark.parametrize(
-    ("name", "old_suffix", "new_suffix", "expected"),
-    [
-        ("test.txt", ".txt", ".csv", "test.csv"),
-        ("test.yml", ".txt", ".csv", "test.yml"),
-    ],
-)
-def test_replace_suffix(
-    name: str, old_suffix: str, new_suffix: str, expected: str
-) -> None:
-    assert _replace_suffix(name, old_suffix, new_suffix) == expected
 
 
 class TestCreateFunctionForTimeUnit:


### PR DESCRIPTION
### What problem do you want to solve?

Closes #621

No longer create functions for other time units if this leads to a loop. This leads to better error messages, e.g. for the tests from #619:

**Before:** 

```txt
E           ValueError: The DAG contains one or more cycles:
E           
E           [
E               "['eink_selbst_y', 'eink_selbst_m']",
E           ]
```

**After:**

```txt
E           ValueError: The following data columns are missing.
E           
E           [
E               "eink_selbst_m",
E           ]
```

### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
