### PR TITLE
Pin the dependencies of nbqa (black, ruff) to the same versions used on Python scripts.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,11 @@ repos:
     rev: 1.7.0
     hooks:
       - id: nbqa-black
+        additional_dependencies:
+          - black==23.7.0
       - id: nbqa-ruff
+        additional_dependencies:
+          - ruff==v0.0.281
         args:
           - --ignore=B018,T201
   - repo: https://github.com/executablebooks/mdformat


### PR DESCRIPTION
I got bitten time and again by messages like this when ruff added a few things:

```
error: TOML parse error at line 49, column 5
   |
49 |     "FIX002", # Line contains TODO -- Use stuff from TD area.
   |     ^^^^^^^^
Unknown rule selector: `FIX002`
```

Turns out that nbqa-ruff does not automatically update the ruff it uses, which might be different from plain ruff used on Python scripts. This PR makes sure both version are in sync.