### PR TITLE
fix: don't use functions in `compute_taxes_and_transfers` that are not active

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
         args:
           - --wrap
           - '88'
-        files: (docs/.)
+        files: (docs/.|CHANGES.md|CODE_OF_CONDUCT.md)
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.4.1
     hooks:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ versioning](https://semver.org/) and all releases are available on
 
 ## Unpublished
 
+- {gh}`638` Don't use functions in `compute_taxes_and_transfers` that are not active ({ghuser}`lars-reimann`).
 - {gh}`618`, {gh}`623` Apply `@dates_active` decorator to Abgeltungssteuer, Midi- and
   Minijobs, Pflegeversicherung. ({ghuser}`hmgaudecker`).
 - {gh}`624` Don't create functions for other time units if this leads to a cycle in the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,20 +1,20 @@
 # Changes
 
-This is a record of all past `gettsim` releases and what went into them
-in reverse chronological order. We follow [semantic
-versioning](https://semver.org/) and all releases are available on
-[Anaconda.org](https://anaconda.org/gettsim/gettsim).
+This is a record of all past `gettsim` releases and what went into them in reverse
+chronological order. We follow [semantic versioning](https://semver.org/) and all
+releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsim).
 
 ## Unpublished
 
-- {gh}`638` Don't use functions in `compute_taxes_and_transfers` that are not active ({ghuser}`lars-reimann`).
+- {gh}`638` Don't use functions in `compute_taxes_and_transfers` that are not active
+  ({ghuser}`lars-reimann`).
 - {gh}`618`, {gh}`623` Apply `@dates_active` decorator to Abgeltungssteuer, Midi- and
   Minijobs, Pflegeversicherung. ({ghuser}`hmgaudecker`).
 - {gh}`624` Don't create functions for other time units if this leads to a cycle in the
   graph ({ghuser}`lars-reimann`).
 - {gh}`603` Add anz_eig_kind_bis_24 to synthetic ({ghuser}`ChristianZimpelmann`).
-- {gh}`593` Implement reform of gesetzliche Pflegepflegeversicherung effective
-  as of 2023-07-01 ({ghuser}`paulinaschroeder`).
+- {gh}`593` Implement reform of gesetzliche Pflegepflegeversicherung effective as of
+  2023-07-01 ({ghuser}`paulinaschroeder`).
 - {gh}`602` Correct `midijob_faktor_f` ({ghuser}`paulinaschroeder`).
 - {gh}`600` Extend the `access_different_date` functionality for `jahresanfang`.
   ({ghuser}`paulinaschroeder`).
@@ -33,8 +33,8 @@ versioning](https://semver.org/) and all releases are available on
 
 - {gh}`573` Fix bug in age groups of Bürgergeld. ({ghuser}`ChristianZimpelmann`).
 
-- {gh}`150` Implement Lohnsteuer / withholding tax.
-  ({ghuser}`Eric-Sommer`, {ghuser}`JakobWegmann`).
+- {gh}`150` Implement Lohnsteuer / withholding tax. ({ghuser}`Eric-Sommer`,
+  {ghuser}`JakobWegmann`).
 
 - {gh}`557` Apply @dates_active decorator in many cases. ({ghuser}`hmgaudecker`).
 
@@ -52,7 +52,6 @@ versioning](https://semver.org/) and all releases are available on
 - {gh}`551` Add rounding to Wohngeld. ({ghuser}`LauraGergeleit`).
 
 - {gh}`425` Add Jax backend ({ghuser}`timmens`).
-
 
 ## v0.6.0 — 2023-01-30
 
@@ -81,8 +80,10 @@ versioning](https://semver.org/) and all releases are available on
 - {gh}`470` Execute notebooks as part of the documentation build on readthedocs
   ({ghuser}`hmgaudecker`).
 
-- {gh}`440` Implement Bürgergeld, which reforms <span
-  class="title-ref">arbeitsl_geld_2</span> from 01/01/2023 ({ghuser}`LauraGergeleit`).
+- {gh}`440` Implement Bürgergeld, which reforms
+  <span
+  class="title-ref">arbeitsl_geld_2</span> from 01/01/2023
+  ({ghuser}`LauraGergeleit`).
 
 - {gh}`399` Use dags package to create the DAG ({ghuser}`ChristianZimpelmann`).
 
@@ -103,7 +104,8 @@ versioning](https://semver.org/) and all releases are available on
   cases in <span class="title-ref">test_interface.py</span> ({ghuser}`LauraGergeleit`,
   {ghuser}`ChristianZimpelmann`).
 
-- {gh}`403` Replace <span class="title-ref">Bokeh</span> with <span
+- {gh}`403` Replace <span class="title-ref">Bokeh</span> with
+  <span
   class="title-ref">plotly</span> for visualization.
   ({ghuser}`effieHAN`,{ghuser}`sofyaakimova`).
 
@@ -116,7 +118,8 @@ versioning](https://semver.org/) and all releases are available on
 - {gh}`385` Make `altersentlastungsbetrag` dependent on age not on current date
   ({ghuser}`m-pannier`, {ghuser}`lillyfischer`).
 
-- {gh}`392` Fix relative tolerance which was set too high for some tests. Rename <span
+- {gh}`392` Fix relative tolerance which was set too high for some tests. Rename
+  <span
   class="title-ref">vorsorge</span> to <span class="title-ref">vorsorgeaufw</span>
   ({ghuser}`LauraGergeleit`, {ghuser}`ChristianZimpelmann`).
 
@@ -141,13 +144,18 @@ versioning](https://semver.org/) and all releases are available on
   when calling <span class="title-ref">set_up_policy_environment</span>
   ({ghuser}`ChristianZimpelmann`).
 
-- {gh}`275` Implement Grundrente. Implement Grundsicherung im Alter. Remove <span
-  class="title-ref">ges_rente_m</span> as input. Rename <span
-  class="title-ref">gettsim.renten_anspr</span> to <span
-  class="title-ref">gettsim.transfers.rente</span>. Rename <span
-  class="title-ref">gettsim.social_insurance</span> to <span
-  class="title-ref">gettsim.social_insurance_contributions</span> ({ghuser}`davpahl`,
-  {ghuser}`ChristianZimpelmann`).
+- {gh}`275` Implement Grundrente. Implement Grundsicherung im Alter. Remove
+  <span
+  class="title-ref">ges_rente_m</span> as input. Rename
+  <span
+  class="title-ref">gettsim.renten_anspr</span> to
+  <span
+  class="title-ref">gettsim.transfers.rente</span>. Rename
+  <span
+  class="title-ref">gettsim.social_insurance</span> to
+  <span
+  class="title-ref">gettsim.social_insurance_contributions</span>
+  ({ghuser}`davpahl`, {ghuser}`ChristianZimpelmann`).
 
 - {gh}`307` Allow to specify order up to which ancestors and descendants are shown when
   plotting a dag ({ghuser}`ChristianZimpelmann`).
@@ -168,25 +176,31 @@ versioning](https://semver.org/) and all releases are available on
   adjustments for DAG backend ({ghuser}`hmgaudecker`).
 
 - {gh}`314` Enforce character limits from GEP-01 for all function names and input
-  variables. Make variable names more precise (e.g., <span
-  class="title-ref">ges\_</span> in front of all social insurance parameters that have
-  private counterparts, <span class="title-ref">eink_st</span> everywhere the income tax
-  is meant). Make variables consistent (e.g. <span
-  class="title-ref">kinderfreibetrag</span> had different abbreviations, now <span
+  variables. Make variable names more precise (e.g.,
+  <span
+  class="title-ref">ges\_</span> in front of all social insurance parameters that
+  have private counterparts, <span class="title-ref">eink_st</span> everywhere the
+  income tax is meant). Make variables consistent (e.g.
+  <span
+  class="title-ref">kinderfreibetrag</span> had different abbreviations, now
+  <span
   class="title-ref">kinderfreib</span> everywhere). ({ghuser}`hmgaudecker`,
   {ghuser}`ChristianZimpelmann`)
 
-- {gh}`343` New argument for \`compute_taxes_and_transfers\`: <span
-  class="title-ref">rounding</span>. If set to False, rounding of outputs is disabled.
-  Add rounding for <span class="title-ref">eink_st_tu</span>. Rounding for other
-  functions will be introduced in future PRs. ({ghuser}`ChristianZimpelmann`).
+- {gh}`343` New argument for \`compute_taxes_and_transfers\`:
+  <span
+  class="title-ref">rounding</span>. If set to False, rounding of outputs is
+  disabled. Add rounding for <span class="title-ref">eink_st_tu</span>. Rounding for
+  other functions will be introduced in future PRs. ({ghuser}`ChristianZimpelmann`).
 
 - {gh}`349` Create parameters for several hard coded numbers in code.
   ({ghuser}`LauraGergeleit`).
 
 - {gh}`355` Major renaming based on GEP 01, e.g.: correct use of `_m`-suffix;
-  `alleinerziehend` becomes `alleinerz`; rename <span
-  class="title-ref">ges_rentenv.yaml</span> to <span
+  `alleinerziehend` becomes `alleinerz`; rename
+  <span
+  class="title-ref">ges_rentenv.yaml</span> to
+  <span
   class="title-ref">ges_rente.yaml</span> ({ghuser}`hmgaudecker`,
   {ghuser}`ChristianZimpelmann`)
 
@@ -226,10 +240,14 @@ versioning](https://semver.org/) and all releases are available on
 ## v0.4.0 — 2020-11-11
 
 - {gh}`241` Renaming of directories: <span class="title-ref">gettsim.benefits</span> to
-  <span class="title-ref">gettsim.transfers</span>; <span
-  class="title-ref">gettsim.soz_vers</span> to <span
-  class="title-ref">gettsim.social_insurance</span>; <span
-  class="title-ref">gettsim.data</span> to <span
+  <span class="title-ref">gettsim.transfers</span>;
+  <span
+  class="title-ref">gettsim.soz_vers</span> to
+  <span
+  class="title-ref">gettsim.social_insurance</span>;
+  <span
+  class="title-ref">gettsim.data</span> to
+  <span
   class="title-ref">gettsim.parameters</span> ({ghuser}`MaxBlesch`,
   {ghuser}`ChristianZimpelmann`).
 
@@ -268,9 +286,9 @@ versioning](https://semver.org/) and all releases are available on
 
 ## v0.3.3 — 2020-06-27
 
-- {gh}`212` Improve the error message when reduced series could not be
-  expanded with an id variable and fixes a related error in the
-  internal functions ({ghuser}`hmgaudecker`, {ghuser}`tobiasraabe`).
+- {gh}`212` Improve the error message when reduced series could not be expanded with an
+  id variable and fixes a related error in the internal functions
+  ({ghuser}`hmgaudecker`, {ghuser}`tobiasraabe`).
 - {gh}`214` Add a check for missing root nodes ({ghuser}`tobiasraabe`).
 - {gh}`215` Add a check for duplicate `targets` ({ghuser}`tobiasraabe`).
 - {gh}`216` Fix calculation of kinderzuschlag and wohngeld. Changed check against
@@ -288,8 +306,8 @@ versioning](https://semver.org/) and all releases are available on
   ({ghuser}`tobiasraabe`).
 - {gh}`201` Improve the calculation of `hh_freib` and renames it to
   `alleinerziehend_freib` ({ghuser}`MaxBlesch`, {ghuser}`tobiasraabe`).
-- {gh}`202` Fix bugs that surfaced for negative incomes ({ghuser}`MaxBlesch`).
-  related transfers, calculating them at the appropriate (household) level
+- {gh}`202` Fix bugs that surfaced for negative incomes ({ghuser}`MaxBlesch`). related
+  transfers, calculating them at the appropriate (household) level
 - {gh}`206` Fix several bugs in <span class="title-ref">arbeitsl_geld_2</span> and
   ({ghuser}`MaxBlesch`).
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,116 +1,106 @@
 # Code of Conduct (CoC)
 
-The GETTSIM community is made up of members from around the globe with a
-diverse set of skills, personalities, and experiences. It is through
-these differences that our community experiences great successes and
-continued growth. When you're working with members of the community,
-this CoC will help steer your interactions and keep GETTSIM a positive,
-successful, and growing community.
+The GETTSIM community is made up of members from around the globe with a diverse set of
+skills, personalities, and experiences. It is through these differences that our
+community experiences great successes and continued growth. When you're working with
+members of the community, this CoC will help steer your interactions and keep GETTSIM a
+positive, successful, and growing community.
 
 ## Our Community
 
-Members of the GETTSIM community are open, considerate, and respectful.
-Behaviours that reinforce these values contribute to a positive
-environment, and include:
+Members of the GETTSIM community are open, considerate, and respectful. Behaviours that
+reinforce these values contribute to a positive environment, and include:
 
--   *Being open*. Members of the community are open to collaboration,
-    whether it's on feature requests, patches, problems, or otherwise.
--   *Focusing on what is best for the community*. We're respectful of
-    the processes set forth in the community, and we work within them.
--   *Acknowledging time and effort*. We're respectful of the volunteer
-    efforts that permeate the GETTSIM community. We're thoughtful when
-    addressing the efforts of others, keeping in mind that often times
-    the labor was completed simply for the good of the community.
--   *Being respectful of differing viewpoints and experiences*. We're
-    receptive to constructive comments and criticism, as the experiences
-    and skill sets of other members contribute to the whole of our
-    efforts.
--   *Showing empathy towards other community members*. We're attentive
-    in our communications, whether in person or online, and we're
-    tactful when approaching differing views.
--   *Being considerate*. Members of the community are considerate of
-    their peers -- other GETTSIM users.
--   *Being respectful*. We're respectful of others, their positions,
-    their skills, their commitments, and their efforts.
--   *Gracefully accepting constructive criticism*. When we disagree, we
-    are courteous in raising our issues.
--   *Using welcoming and inclusive language*. We're accepting of all who
-    wish to take part in our activities, fostering an environment where
-    anyone can participate and everyone can make a difference.
+- *Being open*. Members of the community are open to collaboration, whether it's on
+  feature requests, patches, problems, or otherwise.
+- *Focusing on what is best for the community*. We're respectful of the processes set
+  forth in the community, and we work within them.
+- *Acknowledging time and effort*. We're respectful of the volunteer efforts that
+  permeate the GETTSIM community. We're thoughtful when addressing the efforts of
+  others, keeping in mind that often times the labor was completed simply for the good
+  of the community.
+- *Being respectful of differing viewpoints and experiences*. We're receptive to
+  constructive comments and criticism, as the experiences and skill sets of other
+  members contribute to the whole of our efforts.
+- *Showing empathy towards other community members*. We're attentive in our
+  communications, whether in person or online, and we're tactful when approaching
+  differing views.
+- *Being considerate*. Members of the community are considerate of their peers -- other
+  GETTSIM users.
+- *Being respectful*. We're respectful of others, their positions, their skills, their
+  commitments, and their efforts.
+- *Gracefully accepting constructive criticism*. When we disagree, we are courteous in
+  raising our issues.
+- *Using welcoming and inclusive language*. We're accepting of all who wish to take part
+  in our activities, fostering an environment where anyone can participate and everyone
+  can make a difference.
 
 ## Our Standards
 
-Every member of our community has the right to have their identity
-respected. The GETTSIM community is dedicated to providing a positive
-experience for everyone, regardless of age, gender identity and
-expression, sexual orientation, disability, physical appearance, body
-size, ethnicity, nationality, race, or religion (or lack thereof),
-education, or socio-economic status.
+Every member of our community has the right to have their identity respected. The
+GETTSIM community is dedicated to providing a positive experience for everyone,
+regardless of age, gender identity and expression, sexual orientation, disability,
+physical appearance, body size, ethnicity, nationality, race, or religion (or lack
+thereof), education, or socio-economic status.
 
 ### Inappropriate Behavior
 
 Examples of unacceptable behavior by participants include:
 
--   Harassment of any participants in any form.
--   Deliberate intimidation, stalking, or following.
--   Logging or taking screenshots of online activity for harassment
-    purposes.
--   Publishing others' private information, such as a physical or
-    electronic address, without explicit permission.
--   Violent threats or language directed against another person.
--   Incitement of violence or harassment towards any individual,
-    including encouraging a person to commit suicide or to engage in
-    self-harm.
--   Creating additional online accounts in order to harass another
-    person or circumvent a ban.
--   Sexual language and imagery in online communities or in any
-    conference venue, including talks.
--   Insults, put downs, or jokes that are based upon stereotypes, that
-    are exclusionary, or that hold others up for ridicule.
--   Excessive swearing.
--   Unwelcome sexual attention or advances.
--   Unwelcome physical contact, including simulated physical contact
-    (eg, textual descriptions like "hug" or "backrub") without consent
-    or after a request to stop.
--   Pattern of inappropriate social contact, such as requesting/assuming
-    inappropriate levels of intimacy with others.
--   Sustained disruption of online community discussions, in-person
-    presentations, or other in-person events.
--   Continued one-on-one communication after requests to cease.
--   Other conduct that is inappropriate for a professional audience
-    including people of many different backgrounds.
+- Harassment of any participants in any form.
+- Deliberate intimidation, stalking, or following.
+- Logging or taking screenshots of online activity for harassment purposes.
+- Publishing others' private information, such as a physical or electronic address,
+  without explicit permission.
+- Violent threats or language directed against another person.
+- Incitement of violence or harassment towards any individual, including encouraging a
+  person to commit suicide or to engage in self-harm.
+- Creating additional online accounts in order to harass another person or circumvent a
+  ban.
+- Sexual language and imagery in online communities or in any conference venue,
+  including talks.
+- Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary,
+  or that hold others up for ridicule.
+- Excessive swearing.
+- Unwelcome sexual attention or advances.
+- Unwelcome physical contact, including simulated physical contact (eg, textual
+  descriptions like "hug" or "backrub") without consent or after a request to stop.
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate
+  levels of intimacy with others.
+- Sustained disruption of online community discussions, in-person presentations, or
+  other in-person events.
+- Continued one-on-one communication after requests to cease.
+- Other conduct that is inappropriate for a professional audience including people of
+  many different backgrounds.
 
-Community members asked to stop any inappropriate behavior are expected
-to comply immediately.
+Community members asked to stop any inappropriate behavior are expected to comply
+immediately.
 
 ## Consequences
 
-If a participant engages in behavior that violates this CoC, the GETTSIM
-community CoC team may take any action they deem appropriate, including
-editing/removing inappropriate content, warning the offender or
-expulsion from the community. The CoC team is made up of GETTSIM
-contributors and users and will react promptly to reports. The current
-team includes
+If a participant engages in behavior that violates this CoC, the GETTSIM community CoC
+team may take any action they deem appropriate, including editing/removing inappropriate
+content, warning the offender or expulsion from the community. The CoC team is made up
+of GETTSIM contributors and users and will react promptly to reports. The current team
+includes
 
--   [Boryana Ilieva](https://github.com/boryana-ilieva)
--   [Holger Stichnoth](https://github.com/stichnoth)
--   [Maximilian Blesch](https://github.com/MaxBlesch)
+- [Boryana Ilieva](https://github.com/boryana-ilieva)
+- [Holger Stichnoth](https://github.com/stichnoth)
+- [Maximilian Blesch](https://github.com/MaxBlesch)
 
-All complaints will be reviewed and investigated and will result in a
-response that is deemed necessary and appropriate to the circumstances.
-The GETTSIM CoC team is obligated to maintain confidentiality with
-regard to the reporter of an incident. In cases of conflicts of
-interest, CoC team members have to remove themselves from decision
-process without the need to further specify their conflict.
+All complaints will be reviewed and investigated and will result in a response that is
+deemed necessary and appropriate to the circumstances. The GETTSIM CoC team is obligated
+to maintain confidentiality with regard to the reporter of an incident. In cases of
+conflicts of interest, CoC team members have to remove themselves from decision process
+without the need to further specify their conflict.
 
 ## A Last Note
 
-Thank you for helping make this a welcoming, friendly community for
-everyone.
+Thank you for helping make this a welcoming, friendly community for everyone.
 
 ## Acknowledgment
 
-This CoC is derived if not copied from the [CoC of the Python Software
-Foundation (PSF)](https://www.python.org/psf/conduct/) and includes
-parts from the [CoC of
-pandas](https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md).
+This CoC is derived if not copied from the
+[CoC of the Python Software Foundation (PSF)](https://www.python.org/psf/conduct/) and
+includes parts from the
+[CoC of pandas](https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md).

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 
 
 def load_and_check_functions(
-    user_functions_raw,
+    functions_raw,
     columns_overriding_functions,
     targets,
     data_cols,
@@ -45,8 +45,7 @@ def load_and_check_functions(
 ):
     """Create the dict with all functions that may become part of the DAG by:
 
-    - merging user and internal functions
-    - vectorize all functions
+    - vectorizing all functions
     - adding time conversion functions, aggregation functions, and combinations
 
     Check that:
@@ -55,8 +54,8 @@ def load_and_check_functions(
 
     Parameters
     ----------
-    user_functions_raw : dict
-        A dictionary mapping column names to policy functions by the user.
+    functions_raw : dict
+        A dictionary mapping column names to policy functions.
     columns_overriding_functions : str list of str
         Names of columns in the data which are preferred over function defined in the
         tax and transfer system.
@@ -81,17 +80,17 @@ def load_and_check_functions(
     """
 
     # Load user and functions.
-    user_functions_raw = [] if user_functions_raw is None else user_functions_raw
-    user_functions = _load_functions(user_functions_raw)
+    functions_raw = [] if functions_raw is None else functions_raw
+    functions = _load_functions(functions_raw)
 
     # Vectorize functions.
-    vectorized_user_functions_functions = {
-        fn: _vectorize_func(f) for fn, f in user_functions.items()
+    vectorized_functions = {
+        fn: _vectorize_func(f) for fn, f in functions.items()
     }
 
     # Create derived functions
     time_conversion_functions, aggregation_functions = _create_derived_functions(
-        vectorized_user_functions_functions, targets, data_cols, aggregation_specs
+        vectorized_functions, targets, data_cols, aggregation_specs
     )
 
     # Check for implicit overlap of functions and data columns.
@@ -100,7 +99,7 @@ def load_and_check_functions(
     ]
     for funcs, name in zip(
         [
-            user_functions,
+            functions,
             aggregation_functions,
             time_conversion_functions,
         ],
@@ -110,7 +109,7 @@ def load_and_check_functions(
 
     all_functions = {
         **time_conversion_functions,
-        **vectorized_user_functions_functions,
+        **vectorized_functions,
         **aggregation_functions,
     }
 

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -80,7 +80,7 @@ def load_and_check_functions(
 
     """
 
-    # Load user and internal functions.
+    # Load user and functions.
     user_functions_raw = [] if user_functions_raw is None else user_functions_raw
     user_functions = _load_functions(user_functions_raw)
 

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -86,8 +86,7 @@ def load_and_check_functions(
 
     # Vectorize functions.
     vectorized_user_functions_functions = {
-        fn: _vectorize_func(f)
-        for fn, f in user_functions.items()
+        fn: _vectorize_func(f) for fn, f in user_functions.items()
     }
 
     # Create derived functions

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -79,7 +79,7 @@ def load_and_check_functions(
 
     """
 
-    # Load user and functions.
+    # Load functions.
     functions_raw = [] if functions_raw is None else functions_raw
     functions = _load_functions(functions_raw)
 

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -83,18 +83,16 @@ def load_and_check_functions(
     # Load user and internal functions.
     user_functions_raw = [] if user_functions_raw is None else user_functions_raw
     user_functions = _load_functions(user_functions_raw)
-    imports = _convert_paths_to_import_strings(PATHS_TO_INTERNAL_FUNCTIONS)
-    internal_functions = _load_functions(imports)
 
     # Vectorize functions.
-    user_and_internal_functions = {
+    vectorized_user_functions_functions = {
         fn: _vectorize_func(f)
-        for fn, f in {**internal_functions, **user_functions}.items()
+        for fn, f in user_functions.items()
     }
 
     # Create derived functions
     time_conversion_functions, aggregation_functions = _create_derived_functions(
-        user_and_internal_functions, targets, data_cols, aggregation_specs
+        vectorized_user_functions_functions, targets, data_cols, aggregation_specs
     )
 
     # Check for implicit overlap of functions and data columns.
@@ -103,18 +101,17 @@ def load_and_check_functions(
     ]
     for funcs, name in zip(
         [
-            internal_functions,
             user_functions,
             aggregation_functions,
             time_conversion_functions,
         ],
-        ["internal", "user", "aggregation", "time_conversion"],
+        ["user", "aggregation", "time_conversion"],
     ):
         _fail_if_functions_and_columns_overlap(data_cols_excl_overriding, funcs, name)
 
     all_functions = {
         **time_conversion_functions,
-        **user_and_internal_functions,
+        **vectorized_user_functions_functions,
         **aggregation_functions,
     }
 

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -101,7 +101,7 @@ def load_and_check_functions(
             aggregation_functions,
             time_conversion_functions,
         ],
-        ["user", "aggregation", "time_conversion"],
+        ["hard-coded", "aggregation", "time_conversion"],
     ):
         _fail_if_functions_and_columns_overlap(data_cols_excl_overriding, funcs, name)
 

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -84,9 +84,7 @@ def load_and_check_functions(
     functions = _load_functions(functions_raw)
 
     # Vectorize functions.
-    vectorized_functions = {
-        fn: _vectorize_func(f) for fn, f in functions.items()
-    }
+    vectorized_functions = {fn: _vectorize_func(f) for fn, f in functions.items()}
 
     # Create derived functions
     time_conversion_functions, aggregation_functions = _create_derived_functions(

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -91,7 +91,7 @@ def compute_taxes_and_transfers(  # noqa: PLR0913
         data=data, columns_overriding_functions=columns_overriding_functions
     )
     functions_not_overridden, functions_overridden = load_and_check_functions(
-        user_functions_raw=functions,
+        functions_raw=functions,
         columns_overriding_functions=columns_overriding_functions,
         targets=targets,
         data_cols=list(data),

--- a/src/_gettsim/policy_environment.py
+++ b/src/_gettsim/policy_environment.py
@@ -237,11 +237,12 @@ def load_functions_for_date(date):
     """
 
     # Using TIME_DEPENDENT_FUNCTIONS here leads to failing tests.
-    functions = {
-        f.__info__["dates_active_dag_key"]: f
-        for f in load_internal_functions().values()
-        if is_time_dependent(f) and is_active_at_date(f, date)
-    }
+    functions = {}
+    for f in load_internal_functions().values():
+        if not is_time_dependent(f) or is_active_at_date(f, date):
+            info = f.__info__ if hasattr(f, "__info__") else {}
+            name = info.get("dates_active_dag_key", f.__name__)
+            functions[name] = f
 
     return functions
 

--- a/src/_gettsim/taxes/soli_st.py
+++ b/src/_gettsim/taxes/soli_st.py
@@ -1,7 +1,47 @@
 from _gettsim.piecewise_functions import piecewise_polynomial
+from _gettsim.shared import dates_active
 
 
-def soli_st_y_tu(
+@dates_active(end="2008-12-31", change_name="soli_st_y_tu")
+def soli_st_y_tu_ohne_abgelt_st(
+    eink_st_mit_kinderfreib_y_tu: float,
+    anz_erwachsene_tu: int,
+    soli_st_params: dict,
+) -> float:
+    """Calculate the Solidarity Surcharge on tax unit level.
+
+    Solidaritätszuschlaggesetz (SolZG) in 1991 and 1992.
+    Solidaritätszuschlaggesetz 1995 (SolZG 1995) since 1995.
+
+    The Solidarity Surcharge is an additional tax on top of the income tax which
+    is the tax base. As opposed to the 'standard' income tax, child allowance is
+    always deducted for tax base calculation.
+
+    There is also Solidarity Surcharge on the Capital Income Tax, but always
+    with Solidarity Surcharge tax rate and no tax exempt level. §3 (3) S.2
+    SolzG 1995.
+
+    Parameters
+    ----------
+    eink_st_mit_kinderfreib_y_tu
+        See :func:`eink_st_mit_kinderfreib_y_tu`.
+    anz_erwachsene_tu
+        See :func:`anz_erwachsene_tu`.
+    soli_st_params
+        See params documentation :ref:`soli_st_params <soli_st_params>`.
+
+    Returns
+    -------
+
+    """
+    eink_st_per_individual = eink_st_mit_kinderfreib_y_tu / anz_erwachsene_tu
+    out = anz_erwachsene_tu * _soli_st_tarif(eink_st_per_individual, soli_st_params)
+
+    return out
+
+
+@dates_active(start="2009-01-01", change_name="soli_st_y_tu")
+def soli_st_y_tu_mit_abgelt_st(
     eink_st_mit_kinderfreib_y_tu: float,
     anz_erwachsene_tu: int,
     abgelt_st_y_tu: float,

--- a/src/_gettsim/taxes/zu_verst_eink/eink.py
+++ b/src/_gettsim/taxes/zu_verst_eink/eink.py
@@ -200,15 +200,24 @@ def kapitaleink_y(
 
 @dates_active(end="2008-12-31", change_name="sum_eink_y")
 def sum_eink_mit_kapital_eink_y(
-    sum_eink_ohne_kapital_eink_y: float,
+    eink_selbst_y: float,
+    _zu_verst_eink_abhängig_beschäftigt_y: float,
+    eink_vermietung_y: float,
+    eink_rente_zu_verst_y: float,
     kapitaleink_y: float,
 ) -> float:
     """Sum of gross incomes with capital income.
 
     Parameters
     ----------
-    sum_eink_ohne_kapital_eink_y
-        See :func:`sum_eink_ohne_kapital`.
+    eink_selbst_y
+        See :func:`eink_selbst_y`.
+    _zu_verst_eink_abhängig_beschäftigt_y
+        See :func:`_zu_verst_eink_abhängig_beschäftigt_y`.
+    eink_vermietung_y
+        See :func:`eink_vermietung_y`.
+    eink_rente_zu_verst_y
+        See :func:`eink_rente_zu_verst_y`.
     kapitaleink_y
         See :func:`kapitaleink_y`.
 
@@ -216,7 +225,14 @@ def sum_eink_mit_kapital_eink_y(
     -------
 
     """
-    return sum_eink_ohne_kapital_eink_y + kapitaleink_y
+    out = (
+        eink_selbst_y
+        + _zu_verst_eink_abhängig_beschäftigt_y
+        + eink_vermietung_y
+        + eink_rente_zu_verst_y
+        + kapitaleink_y
+    )
+    return out
 
 
 def rente_ertragsanteil(jahr_renteneintr: int, eink_st_params: dict) -> float:

--- a/src/_gettsim/visualization.py
+++ b/src/_gettsim/visualization.py
@@ -75,7 +75,7 @@ def plot_dag(
 
     # Load functions.
     functions_not_overridden, functions_overridden = load_and_check_functions(
-        user_functions_raw=functions,
+        functions_raw=functions,
         columns_overriding_functions=columns_overriding_functions,
         targets=targets,
         data_cols=list(TYPES_INPUT_VARIABLES),

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2008/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2008/hh_id_1.yaml
@@ -344,15 +344,5 @@ inputs:
       - 0.0
       - 0.0
       - 0.0
-    sum_eink_ohne_kapital_eink_y:
-      - 0.0
-      - 0.0
-      - 0.0
-      - 0.0
-    abgelt_st_y_tu:
-      - 0.0
-      - 0.0
-      - 0.0
-      - 0.0
   assumed: {}
 outputs: {}

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2008/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2008/hh_id_1.yaml
@@ -344,5 +344,15 @@ inputs:
       - 0.0
       - 0.0
       - 0.0
+    sum_eink_ohne_kapital_eink_y:
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
+    abgelt_st_y_tu:
+      - 0.0
+      - 0.0
+      - 0.0
+      - 0.0
   assumed: {}
 outputs: {}

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -15,7 +15,6 @@ from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_d
 OUT_COLS = [
     "eink_st_y_tu",
     "soli_st_y_tu",
-    "abgelt_st_y_tu",
     "ges_rentenv_beitr_m",
     "arbeitsl_v_beitr_m",
     "ges_krankenv_beitr_m",
@@ -44,6 +43,9 @@ def test_full_taxes_and_transfers(
     policy_params, policy_functions = cached_set_up_policy_environment(
         date=test_data.date
     )
+
+    out = OUT_COLS if test_data.date.year <= 2008 else OUT_COLS + ["abgelt_st_y_tu"]
+
     # TODO(@hmgaudecker): Remove again once unterhaltsvors_m is implemented
     #     for more years.
     # https://github.com/iza-institute-of-labor-economics/gettsim/issues/479
@@ -59,7 +61,7 @@ def test_full_taxes_and_transfers(
         data=df,
         params=policy_params,
         functions=policy_functions,
-        targets=OUT_COLS,
+        targets=out,
         columns_overriding_functions=columns_overriding_functions,
     )
 
@@ -74,6 +76,8 @@ def test_data_types(  # noqa: PLR0912
 ):
     imports = _convert_paths_to_import_strings(PATHS_TO_INTERNAL_FUNCTIONS)
     functions = _load_functions(imports)
+
+    out = OUT_COLS if test_data.date.year <= 2008 else OUT_COLS + ["abgelt_st_y_tu"]
 
     # Load all time dependent functions
     for y in range(1990, 2023):
@@ -99,7 +103,7 @@ def test_data_types(  # noqa: PLR0912
         data=df,
         params=policy_params,
         functions=policy_functions,
-        targets=OUT_COLS,
+        targets=out,
         debug=True,
         columns_overriding_functions=columns_overriding_functions,
     )

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -44,7 +44,7 @@ def test_full_taxes_and_transfers(
         date=test_data.date
     )
 
-    out = OUT_COLS if test_data.date.year <= 2008 else OUT_COLS + ["abgelt_st_y_tu"]
+    out = OUT_COLS if test_data.date.year <= 2008 else [*OUT_COLS, "abgelt_st_y_tu"]
 
     # TODO(@hmgaudecker): Remove again once unterhaltsvors_m is implemented
     #     for more years.
@@ -77,7 +77,7 @@ def test_data_types(  # noqa: PLR0912
     imports = _convert_paths_to_import_strings(PATHS_TO_INTERNAL_FUNCTIONS)
     functions = _load_functions(imports)
 
-    out = OUT_COLS if test_data.date.year <= 2008 else OUT_COLS + ["abgelt_st_y_tu"]
+    out = OUT_COLS if test_data.date.year <= 2008 else [*OUT_COLS, "abgelt_st_y_tu"]
 
     # Load all time dependent functions
     for y in range(1990, 2023):

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -15,6 +15,7 @@ from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_d
 OUT_COLS = [
     "eink_st_y_tu",
     "soli_st_y_tu",
+    "abgelt_st_y_tu",
     "ges_rentenv_beitr_m",
     "arbeitsl_v_beitr_m",
     "ges_krankenv_beitr_m",
@@ -44,7 +45,9 @@ def test_full_taxes_and_transfers(
         date=test_data.date
     )
 
-    out = OUT_COLS if test_data.date.year <= 2008 else [*OUT_COLS, "abgelt_st_y_tu"]
+    out = OUT_COLS.copy()
+    if test_data.date.year <= 2008:
+        out.remove("abgelt_st_y_tu")
 
     # TODO(@hmgaudecker): Remove again once unterhaltsvors_m is implemented
     #     for more years.
@@ -77,7 +80,9 @@ def test_data_types(  # noqa: PLR0912
     imports = _convert_paths_to_import_strings(PATHS_TO_INTERNAL_FUNCTIONS)
     functions = _load_functions(imports)
 
-    out = OUT_COLS if test_data.date.year <= 2008 else [*OUT_COLS, "abgelt_st_y_tu"]
+    out = OUT_COLS.copy()
+    if test_data.date.year <= 2008:
+        out.remove("abgelt_st_y_tu")
 
     # Load all time dependent functions
     for y in range(1990, 2023):

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -5,7 +5,8 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["eink_st_mit_kinderfreib_y_tu", "abgelt_st_y_tu"]
+OVERRIDE_COLS_UNTIL_2008 = ["eink_st_mit_kinderfreib_y_tu"]
+OVERRIDE_COLS_AFTER_2008 = ["eink_st_mit_kinderfreib_y_tu", "abgelt_st_y_tu"]
 
 data = load_policy_test_data("soli_st")
 
@@ -29,7 +30,7 @@ def test_soli_st(
         params=policy_params,
         functions=policy_functions,
         targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
+        columns_overriding_functions=OVERRIDE_COLS_UNTIL_2008 if test_data.date.year <= 2008 else OVERRIDE_COLS_AFTER_2008,
     )
 
     assert_series_equal(

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -30,7 +30,9 @@ def test_soli_st(
         params=policy_params,
         functions=policy_functions,
         targets=column,
-        columns_overriding_functions=OVERRIDE_COLS_UNTIL_2008 if test_data.date.year <= 2008 else OVERRIDE_COLS_AFTER_2008,
+        columns_overriding_functions=OVERRIDE_COLS_UNTIL_2008
+        if test_data.date.year <= 2008
+        else OVERRIDE_COLS_AFTER_2008,
     )
 
     assert_series_equal(

--- a/src/_gettsim_tests/test_visualizations.py
+++ b/src/_gettsim_tests/test_visualizations.py
@@ -114,7 +114,9 @@ def test_plot_dag():
 
 
 def test_should_fail_if_target_is_missing():
-    with pytest.raises(ValueError, match="The following targets have no corresponding function"):
+    with pytest.raises(
+        ValueError, match="The following targets have no corresponding function"
+    ):
         plot_dag(functions=[], targets=["erwachsene_alle_rentner_hh"])
 
 

--- a/src/_gettsim_tests/test_visualizations.py
+++ b/src/_gettsim_tests/test_visualizations.py
@@ -110,7 +110,12 @@ def test_select_nodes_in_dag(n_nodes, selectors, expected):
 
 def test_plot_dag():
     """Make sure that minimal example doesn't produce an error."""
-    plot_dag(functions=[], targets=["erwachsene_alle_rentner_hh"])
+    plot_dag(functions=policy_functions, targets=["erwachsene_alle_rentner_hh"])
+
+
+def test_should_fail_if_target_is_missing():
+    with pytest.raises(ValueError, match="The following targets have no corresponding function"):
+        plot_dag(functions=[], targets=["erwachsene_alle_rentner_hh"])
 
 
 def test_one_dot_plot_dag():


### PR DESCRIPTION
### What problem do you want to solve?

Closes #626
Closes partially #378

* Don't load any internal functions implicitly anymore.
* Also load functions that are not time-dependent into the policy environment.

### Todo

- [x] Pick an appropriate title.
- [x] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
