### PR TITLE
feat: infer `columns_overriding_functions` from functions and data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
-- {gh}`639` Infer `columns_overriding_functions` for `compute_taxes_and_transfers` from functions and data ({ghuser}`lars-reimann`).
+- {gh}`639` Infer `columns_overriding_functions` for `compute_taxes_and_transfers` from
+  functions and data ({ghuser}`lars-reimann`).
 - {gh}`638` Don't use functions in `compute_taxes_and_transfers` that are not active
   ({ghuser}`lars-reimann`).
 - {gh}`618`, {gh}`623` Apply `@dates_active` decorator to Abgeltungssteuer, Midi- and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ versioning](https://semver.org/) and all releases are available on
 
 ## Unpublished
 
+- {gh}`639` Infer `columns_overriding_functions` for `compute_taxes_and_transfers` from functions and data ({ghuser}`lars-reimann`).
 - {gh}`618`, {gh}`623` Apply `@dates_active` decorator to Abgeltungssteuer, Midi- and
   Minijobs, Pflegeversicherung. ({ghuser}`hmgaudecker`).
 - {gh}`624` Don't create functions for other time units if this leads to a cycle in the

--- a/docs/tutorials/advanced_usage.ipynb
+++ b/docs/tutorials/advanced_usage.ipynb
@@ -417,7 +417,7 @@
    "source": [
     "### Columns Overriding Functions\n",
     "\n",
-    "Lastly, it is also possible to substitute internally computed variables using input columns in the data. To override an internal function, it is necessary to specify a column with the same name and pass it to `compute_taxes_and_transfers` using the argument `columns_overriding_functions`.\n",
+    "Lastly, it is also possible to substitute internally computed variables using input columns in the data.\n",
     "\n",
     "For instance, for this application we could override the internal function `kindergeld_m` and set the child benefit to 0. "
    ]
@@ -436,7 +436,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, we compute the child benefit and income tax by tax unit. The argument `columns_overriding_functions` also accepts lists of columns to overwrite multiple functions."
+    "Again, we compute the child benefit and income tax by tax unit."
    ]
   },
   {
@@ -450,7 +450,6 @@
     "    params=policy_params,\n",
     "    targets=[\"kindergeld_m_tu\", \"eink_st_y_tu\", \"bruttolohn_m_tu\"],\n",
     "    functions=policy_functions,\n",
-    "    columns_overriding_functions=[\"kindergeld_m\"],\n",
     ")"
    ]
   },
@@ -503,7 +502,7 @@
    "source": [
     "Retirement earnings (`ges_rente_m`) can be calculated by GETTSIM which requires several input variables including `entgeltp` or `grundr_zeiten`. \n",
     "\n",
-    "However, in most data sets (e.g. the SOEP) retirement earnings are observed and those input variables are not. For some applications, it is, hence, more straight-forward to specify `columns_overriding_functions=[\"ges_rente_m\"]` and use the measured retirement earnings directly. Then the pension-specific input variables like `entgeltp` or `grundr_zeiten` are not needed as input variables.\n",
+    "However, in most data sets (e.g. the SOEP) retirement earnings are observed and those input variables are not. For some applications, it is, hence, more straight-forward to specify `ges_rente_m` directly as an input variable. Then the pension-specific input variables like `entgeltp` or `grundr_zeiten` are not needed as input variables.\n",
     "\n"
    ]
   }

--- a/docs/tutorials/parameters.ipynb
+++ b/docs/tutorials/parameters.ipynb
@@ -249,7 +249,6 @@
     "    params=policy_params,\n",
     "    functions=policy_functions,\n",
     "    targets=[\"anz_erwachsene_tu\", \"_zu_verst_eink_mit_kinderfreib_y_tu\"],\n",
-    "    columns_overriding_functions=[\"anz_kinder_bis_17_hh\", \"sum_ges_rente_priv_rente_m\"],\n",
     ")\n",
     "\n",
     "kindergeld_status_quo"
@@ -266,7 +265,6 @@
     "    params=policy_params,\n",
     "    functions=policy_functions,\n",
     "    targets=\"kindergeld_m_tu\",\n",
-    "    columns_overriding_functions=[\"anz_kinder_bis_17_hh\", \"sum_ges_rente_priv_rente_m\"],\n",
     ")\n",
     "\n",
     "kindergeld_status_quo[[\"kindergeld_m_tu\"]]"
@@ -290,7 +288,6 @@
     "    functions=policy_functions,\n",
     "    params=policy_params_new,\n",
     "    targets=\"kindergeld_m_tu\",\n",
-    "    columns_overriding_functions=[\"anz_kinder_bis_17_hh\", \"sum_ges_rente_priv_rente_m\"],\n",
     ")\n",
     "kindergeld_new[[\"kindergeld_m_tu\"]]"
    ]

--- a/docs/tutorials/policy_functions.ipynb
+++ b/docs/tutorials/policy_functions.ipynb
@@ -202,7 +202,6 @@
     "        functions=policies[k],\n",
     "        params=policy_params,\n",
     "        targets=targets,\n",
-    "        columns_overriding_functions=[\"sum_ges_rente_priv_rente_m\"],\n",
     "    )\n",
     "    # Add earnings and index to result DataFrame.\n",
     "    result[\"bruttolohn_m\"] = data[\"bruttolohn_m\"]\n",
@@ -256,7 +255,6 @@
     "        \"kinderzuschl_m_hh\",\n",
     "        \"arbeitsl_geld_2_m_hh\",\n",
     "    ],\n",
-    "    columns_overriding_functions=[\"sum_ges_rente_priv_rente_m\"],\n",
     ")"
    ]
   },
@@ -358,7 +356,6 @@
     "        \"arbeitsl_geld_2_m_hh\",\n",
     "        \"kinderzuschl_m_hh\",\n",
     "    ],\n",
-    "    columns_overriding_functions=[\"sum_ges_rente_priv_rente_m\"],\n",
     ")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ filterwarnings = [
     "ignore:Repeated execution of the test suite",
     "ignore:Using or importing the ABCs from 'collections'",
     "ignore:'grouped_cumsum' is deprecated.",
+    "ignore::_gettsim.interface.FunctionsAndColumnsOverlapWarning"
 ]
 markers = [
     "wip: Tests that are work-in-progress.",

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -86,7 +86,7 @@ def load_and_check_functions(functions_raw, targets, data_cols, aggregation_spec
         **aggregation_functions,
     }
 
-    _fail_if_targets_are_not_in_functions(all_functions, targets)
+    _fail_if_targets_are_not_among_functions(all_functions, targets)
 
     # Separate all functions by whether they will be used or not.
     functions_overridden = {}
@@ -593,8 +593,8 @@ def _vectorize_func(func):
     return wrapper_vectorize_func
 
 
-def _fail_if_targets_are_not_in_functions(functions, targets):
-    """Fail if targets are not in functions.
+def _fail_if_targets_are_not_among_functions(functions, targets):
+    """Fail if some target is not among functions.
 
     Parameters
     ----------
@@ -607,7 +607,7 @@ def _fail_if_targets_are_not_in_functions(functions, targets):
     Raises
     ------
     ValueError
-        Raised if ``targets`` are not in functions.
+        Raised if any member of `targets` is not among functions.
 
     """
     targets_not_in_functions = set(targets) - set(functions)

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -93,9 +93,7 @@ def load_and_check_functions(user_functions_raw, targets, data_cols, aggregation
         **aggregation_functions,
     }
 
-    _fail_if_targets_are_not_in_functions(
-        all_functions, targets
-    )
+    _fail_if_targets_are_not_in_functions(all_functions, targets)
 
     # Separate all functions by whether they will be used or not.
     functions_overridden = {}
@@ -110,10 +108,10 @@ def load_and_check_functions(user_functions_raw, targets, data_cols, aggregation
 
 
 def _create_derived_functions(
-        user_and_internal_functions: dict[str, Callable],
-        targets,
-        data_cols,
-        aggregation_specs,
+    user_and_internal_functions: dict[str, Callable],
+    targets,
+    data_cols,
+    aggregation_specs,
 ) -> tuple[dict[str, Callable], dict[str, Callable]]:
     """
     Create functions that are derived from the user and internal functions.
@@ -213,7 +211,7 @@ def _load_functions(sources, include_imported_functions=False):
             source = {source.__name__: source}  # noqa: PLW2901
 
         if isinstance(source, dict) and all(
-                inspect.isfunction(i) for i in source.values()
+            inspect.isfunction(i) for i in source.values()
         ):
             functions = {**functions, **source}
 
@@ -245,7 +243,7 @@ def _search_directories_recursively_for_python_files(sources):
 
 
 def _convert_paths_and_strings_to_dicts_of_functions(
-        sources, include_imported_functions
+    sources, include_imported_functions
 ):
     """Convert paths and strings to dictionaries of functions.
 
@@ -271,7 +269,7 @@ def _convert_paths_and_strings_to_dicts_of_functions(
                     out, lambda x: inspect.isfunction(x)
                 )
                 if include_imported_functions
-                   or _is_function_defined_in_module(func, out.__name__)
+                or _is_function_defined_in_module(func, out.__name__)
             }
         else:
             functions_defined_in_module = source
@@ -340,7 +338,7 @@ def _load_aggregation_combined_dict_from_strings(sources):
 
 
 def _create_aggregation_functions(
-        user_and_internal_functions, targets, data_cols, user_provided_aggregation_specs
+    user_and_internal_functions, targets, data_cols, user_provided_aggregation_specs
 ):
     """Create aggregation functions."""
     aggregation_dict = load_aggregation_dict()
@@ -360,8 +358,8 @@ def _create_aggregation_functions(
         col
         for col in potential_agg_cols
         if (col not in user_and_internal_functions)
-           and any(col.endswith(f"_{g}") for g in SUPPORTED_GROUPINGS)
-           and (remove_group_suffix(col) in potential_source_cols)
+        and any(col.endswith(f"_{g}") for g in SUPPORTED_GROUPINGS)
+        and (remove_group_suffix(col) in potential_source_cols)
     ]
     automated_sum_aggregation_specs = {
         agg_col: {"aggr": "sum", "source_col": remove_group_suffix(agg_col)}
@@ -426,7 +424,7 @@ def rename_arguments(func=None, mapper=None, annotations=None):
 
 
 def _create_one_aggregation_func(  # noqa: PLR0912
-        agg_col, agg_specs, user_and_internal_functions
+    agg_col, agg_specs, user_and_internal_functions
 ):
     """Create an aggregation function based on aggregation specification.
 
@@ -480,8 +478,8 @@ def _create_one_aggregation_func(  # noqa: PLR0912
         annotations["return"] = int
     else:
         if (
-                source_col in user_and_internal_functions
-                and "return" in user_and_internal_functions[source_col].__annotations__
+            source_col in user_and_internal_functions
+            and "return" in user_and_internal_functions[source_col].__annotations__
         ):
             annotations[source_col] = user_and_internal_functions[
                 source_col
@@ -602,9 +600,7 @@ def _vectorize_func(func):
     return wrapper_vectorize_func
 
 
-def _fail_if_targets_are_not_in_functions(
-        functions, targets
-):
+def _fail_if_targets_are_not_in_functions(functions, targets):
     """Fail if targets are not in functions.
 
     Parameters
@@ -621,9 +617,7 @@ def _fail_if_targets_are_not_in_functions(
         Raised if ``targets`` are not in functions.
 
     """
-    targets_not_in_functions = (
-            set(targets) - set(functions)
-    )
+    targets_not_in_functions = set(targets) - set(functions)
     if targets_not_in_functions:
         formatted = format_list_linewise(targets_not_in_functions)
         raise ValueError(

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -43,8 +43,7 @@ def load_and_check_functions(user_functions_raw, targets, data_cols, aggregation
     - adding time conversion functions, aggregation functions, and combinations
 
     Check that:
-    - all targets are in set of functions or in columns_overriding_functions
-    - columns_overriding_functions are in set of functions
+    - all targets are in set of functions or in data_cols
 
     Parameters
     ----------

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -387,7 +387,27 @@ def _warn_if_functions_and_columns_overlap(
             option for each column that appears in the list above.'''}
             """
         )
-        warnings.warn(f"{first_part}\n{formatted}\n{second_part}", stacklevel=2)
+        how_to_ignore = format_errors_and_warnings(
+            """
+            If you want to ignore this warning, add the following code to your script
+            before calling GETTSIM:
+
+                import warnings
+                warnings.filterwarnings(
+                    "ignore",
+                    category=FunctionsAndColumnsOverlapWarning
+                )
+            """
+        )
+        warnings.warn(
+            f"{first_part}\n{formatted}\n{second_part}\n{how_to_ignore}",
+            category=FunctionsAndColumnsOverlapWarning,
+            stacklevel=2,
+        )
+
+
+class FunctionsAndColumnsOverlapWarning(UserWarning):
+    pass
 
 
 def _fail_if_duplicates_in_columns(data):

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -401,6 +401,7 @@ class FunctionsAndColumnsOverlapWarning(UserWarning):
 
                 import warnings
                 from gettsim import FunctionsAndColumnsOverlapWarning
+
                 warnings.filterwarnings(
                     "ignore",
                     category=FunctionsAndColumnsOverlapWarning

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -400,6 +400,7 @@ class FunctionsAndColumnsOverlapWarning(UserWarning):
             before calling GETTSIM:
 
                 import warnings
+                from gettsim import FunctionsAndColumnsOverlapWarning
                 warnings.filterwarnings(
                     "ignore",
                     category=FunctionsAndColumnsOverlapWarning

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -22,7 +22,7 @@ from _gettsim.shared import (
 )
 
 
-def compute_taxes_and_transfers( # noqa: PLR0913
+def compute_taxes_and_transfers(  # noqa: PLR0913
     data,
     params,
     functions,

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -22,8 +22,16 @@ from _gettsim.shared import (
 )
 
 
-def compute_taxes_and_transfers(data, params, functions, aggregation_specs=None, targets=None,
-                                check_minimal_specification="ignore", rounding=True, debug=False):
+def compute_taxes_and_transfers(
+    data,
+    params,
+    functions,
+    aggregation_specs=None,
+    targets=None,
+    check_minimal_specification="ignore",
+    rounding=True,
+    debug=False,
+):
     """Compute taxes and transfers.
 
     Parameters
@@ -72,12 +80,13 @@ def compute_taxes_and_transfers(data, params, functions, aggregation_specs=None,
     aggregation_specs = {} if aggregation_specs is None else aggregation_specs
 
     # Process data and load dictionaries with functions.
-    data = _process_and_check_data(
-        data=data
+    data = _process_and_check_data(data=data)
+    functions_not_overridden, functions_overridden = load_and_check_functions(
+        user_functions_raw=functions,
+        targets=targets,
+        data_cols=list(data),
+        aggregation_specs=aggregation_specs,
     )
-    functions_not_overridden, functions_overridden = load_and_check_functions(user_functions_raw=functions,
-                                                                              targets=targets, data_cols=list(data),
-                                                                              aggregation_specs=aggregation_specs)
     data = _convert_data_to_correct_types(data, functions_overridden)
     columns_overriding_functions = set(functions_overridden)
     print(columns_overriding_functions)
@@ -117,8 +126,8 @@ def compute_taxes_and_transfers(data, params, functions, aggregation_specs=None,
 
     if "unterhalt" in params:
         if (
-                "mindestunterhalt" not in params["unterhalt"]
-                and "unterhaltsvors_m" in processed_functions
+            "mindestunterhalt" not in params["unterhalt"]
+            and "unterhaltsvors_m" in processed_functions
         ):
             raise NotImplementedError(
                 """
@@ -137,10 +146,10 @@ https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
 
 
 def set_up_dag(
-        all_functions,
-        targets,
-        columns_overriding_functions,
-        check_minimal_specification,
+    all_functions,
+    targets,
+    columns_overriding_functions,
+    check_minimal_specification,
 ):
     """Set up the DAG. Partial functions before that and add rounding afterwards.
 
@@ -199,7 +208,7 @@ def _process_and_check_data(data):
     elif isinstance(data, pd.Series):
         data = {data.name: data}
     elif isinstance(data, dict) and all(
-            isinstance(i, pd.Series) for i in data.values()
+        isinstance(i, pd.Series) for i in data.values()
     ):
         pass
     else:
@@ -256,8 +265,8 @@ def _convert_data_to_correct_types(data, functions_overridden):
         if column_name in TYPES_INPUT_VARIABLES:
             internal_type = TYPES_INPUT_VARIABLES[column_name]
         elif (
-                column_name in functions_overridden
-                and "return" in functions_overridden[column_name].__annotations__
+            column_name in functions_overridden
+            and "return" in functions_overridden[column_name].__annotations__
         ):
             internal_type = functions_overridden[column_name].__annotations__["return"]
 
@@ -279,13 +288,13 @@ def _convert_data_to_correct_types(data, functions_overridden):
     if len(collected_errors) > 1:
         raise ValueError(
             "\n".join(collected_errors) + "\n" + "\n" + "Note that conversion"
-                                                        " from floating point to integers or Booleans inherently suffers from"
-                                                        " approximation error. It might well be that your data seemingly obey the"
-                                                        " restrictions when scrolling through them, but in fact they do not"
-                                                        " (for example, because 1e-15 is displayed as 0.0)."
+            " from floating point to integers or Booleans inherently suffers from"
+            " approximation error. It might well be that your data seemingly obey the"
+            " restrictions when scrolling through them, but in fact they do not"
+            " (for example, because 1e-15 is displayed as 0.0)."
             + "\n"
             + "The best solution is to convert all columns"
-              " to the expected data types yourself."
+            " to the expected data types yourself."
         )
 
     # Otherwise raise warning which lists all successful conversions
@@ -298,11 +307,11 @@ def _convert_data_to_correct_types(data, functions_overridden):
 
 
 def _create_input_data(
-        data,
-        processed_functions,
-        targets,
-        columns_overriding_functions,
-        check_minimal_specification="ignore",
+    data,
+    processed_functions,
+    targets,
+    columns_overriding_functions,
+    check_minimal_specification="ignore",
 ):
     """Create input data for use in the calculation of taxes and transfers by:
 
@@ -411,7 +420,7 @@ def _fail_if_root_nodes_are_missing(root_nodes, data, functions):
         if len(
             [a for a in inspect.signature(func).parameters if not a.endswith("_params")]
         )
-           == 0
+        == 0
     ]
 
     missing_nodes = [
@@ -511,9 +520,9 @@ def _add_rounding_to_functions(functions, params):
 
             # Check if there are any rounding specifications.
             if not (
-                    params_key in params
-                    and "rounding" in params[params_key]
-                    and func_name in params[params_key]["rounding"]
+                params_key in params
+                and "rounding" in params[params_key]
+                and func_name in params[params_key]["rounding"]
             ):
                 raise KeyError(
                     KeyErrorMessage(
@@ -598,7 +607,7 @@ def _add_rounding_to_one_function(base, direction):
 
 
 def _fail_if_columns_overriding_functions_are_not_in_dag(
-        dag, columns_overriding_functions, check_minimal_specification
+    dag, columns_overriding_functions, check_minimal_specification
 ):
     """Fail if ``columns_overriding_functions`` are not in the DAG.
 

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -359,7 +359,9 @@ def _create_input_data(
     return input_data
 
 
-def _warn_if_functions_and_columns_overlap(columns_overriding_functions: set[str]) -> None:
+def _warn_if_functions_and_columns_overlap(
+    columns_overriding_functions: set[str],
+) -> None:
     """Warn if functions which compute columns overlap with existing columns.
 
     Parameters
@@ -386,6 +388,7 @@ def _warn_if_functions_and_columns_overlap(columns_overriding_functions: set[str
             """
         )
         warnings.warn(f"{first_part}\n{formatted}\n{second_part}", stacklevel=2)
+
 
 def _fail_if_duplicates_in_columns(data):
     """Check that all column names are unique."""

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -22,7 +22,7 @@ from _gettsim.shared import (
 )
 
 
-def compute_taxes_and_transfers(
+def compute_taxes_and_transfers( # noqa: PLR0913
     data,
     params,
     functions,
@@ -89,7 +89,6 @@ def compute_taxes_and_transfers(
     )
     data = _convert_data_to_correct_types(data, functions_overridden)
     columns_overriding_functions = set(functions_overridden)
-    print(columns_overriding_functions)
 
     # Select necessary nodes by creating a preliminary DAG.
     nodes = set_up_dag(

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -22,17 +22,8 @@ from _gettsim.shared import (
 )
 
 
-def compute_taxes_and_transfers(  # noqa: PLR0913
-    data,
-    params,
-    functions,
-    aggregation_specs=None,
-    targets=None,
-    columns_overriding_functions=None,
-    check_minimal_specification="ignore",
-    rounding=True,
-    debug=False,
-):
+def compute_taxes_and_transfers(data, params, functions, aggregation_specs=None, targets=None,
+                                check_minimal_specification="ignore", rounding=True, debug=False):
     """Compute taxes and transfers.
 
     Parameters
@@ -56,9 +47,6 @@ def compute_taxes_and_transfers(  # noqa: PLR0913
         String or list of strings with names of functions whose output is actually
         needed by the user. By default, ``targets`` is ``None`` and all key outputs as
         defined by `gettsim.config.DEFAULT_TARGETS` are returned.
-    columns_overriding_functions : str list of str
-        Names of columns in the data which are preferred over function defined in the
-        tax and transfer system.
     check_minimal_specification : {"ignore", "warn", "raise"}, default "ignore"
         Indicator for whether checks which ensure the most minimal configuration should
         be silenced, emitted as warnings or errors.
@@ -80,24 +68,19 @@ def compute_taxes_and_transfers(  # noqa: PLR0913
 
     targets = DEFAULT_TARGETS if targets is None else targets
     targets = parse_to_list_of_strings(targets, "targets")
-    columns_overriding_functions = parse_to_list_of_strings(
-        columns_overriding_functions, "columns_overriding_functions"
-    )
     params = {} if params is None else params
     aggregation_specs = {} if aggregation_specs is None else aggregation_specs
 
     # Process data and load dictionaries with functions.
     data = _process_and_check_data(
-        data=data, columns_overriding_functions=columns_overriding_functions
+        data=data
     )
-    functions_not_overridden, functions_overridden = load_and_check_functions(
-        user_functions_raw=functions,
-        columns_overriding_functions=columns_overriding_functions,
-        targets=targets,
-        data_cols=list(data),
-        aggregation_specs=aggregation_specs,
-    )
+    functions_not_overridden, functions_overridden = load_and_check_functions(user_functions_raw=functions,
+                                                                              targets=targets, data_cols=list(data),
+                                                                              aggregation_specs=aggregation_specs)
     data = _convert_data_to_correct_types(data, functions_overridden)
+    columns_overriding_functions = set(functions_overridden)
+    print(columns_overriding_functions)
 
     # Select necessary nodes by creating a preliminary DAG.
     nodes = set_up_dag(
@@ -134,8 +117,8 @@ def compute_taxes_and_transfers(  # noqa: PLR0913
 
     if "unterhalt" in params:
         if (
-            "mindestunterhalt" not in params["unterhalt"]
-            and "unterhaltsvors_m" in processed_functions
+                "mindestunterhalt" not in params["unterhalt"]
+                and "unterhaltsvors_m" in processed_functions
         ):
             raise NotImplementedError(
                 """
@@ -154,10 +137,10 @@ https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
 
 
 def set_up_dag(
-    all_functions,
-    targets,
-    columns_overriding_functions,
-    check_minimal_specification,
+        all_functions,
+        targets,
+        columns_overriding_functions,
+        check_minimal_specification,
 ):
     """Set up the DAG. Partial functions before that and add rounding afterwards.
 
@@ -197,16 +180,13 @@ def set_up_dag(
     return dag
 
 
-def _process_and_check_data(data, columns_overriding_functions):
+def _process_and_check_data(data):
     """Process data and perform several checks.
 
     Parameters
     ----------
     data : pandas.Series or pandas.DataFrame or dict of pandas.Series
         Data provided by the user.
-    columns_overriding_functions : str list of str
-        Names of columns in the data which are preferred over function defined in the
-        tax and transfer system.
 
     Returns
     -------
@@ -219,7 +199,7 @@ def _process_and_check_data(data, columns_overriding_functions):
     elif isinstance(data, pd.Series):
         data = {data.name: data}
     elif isinstance(data, dict) and all(
-        isinstance(i, pd.Series) for i in data.values()
+            isinstance(i, pd.Series) for i in data.values()
     ):
         pass
     else:
@@ -240,9 +220,6 @@ def _process_and_check_data(data, columns_overriding_functions):
             not data["tu_id"].groupby(data["hh_id"]).std().max() > 0
         ), "We currently allow for only one tax unit within each household"
 
-    _fail_if_columns_overriding_functions_are_not_in_data(
-        list(data), columns_overriding_functions
-    )
     _fail_if_pid_is_non_unique(data)
 
     return data
@@ -279,8 +256,8 @@ def _convert_data_to_correct_types(data, functions_overridden):
         if column_name in TYPES_INPUT_VARIABLES:
             internal_type = TYPES_INPUT_VARIABLES[column_name]
         elif (
-            column_name in functions_overridden
-            and "return" in functions_overridden[column_name].__annotations__
+                column_name in functions_overridden
+                and "return" in functions_overridden[column_name].__annotations__
         ):
             internal_type = functions_overridden[column_name].__annotations__["return"]
 
@@ -302,13 +279,13 @@ def _convert_data_to_correct_types(data, functions_overridden):
     if len(collected_errors) > 1:
         raise ValueError(
             "\n".join(collected_errors) + "\n" + "\n" + "Note that conversion"
-            " from floating point to integers or Booleans inherently suffers from"
-            " approximation error. It might well be that your data seemingly obey the"
-            " restrictions when scrolling through them, but in fact they do not"
-            " (for example, because 1e-15 is displayed as 0.0)."
+                                                        " from floating point to integers or Booleans inherently suffers from"
+                                                        " approximation error. It might well be that your data seemingly obey the"
+                                                        " restrictions when scrolling through them, but in fact they do not"
+                                                        " (for example, because 1e-15 is displayed as 0.0)."
             + "\n"
             + "The best solution is to convert all columns"
-            " to the expected data types yourself."
+              " to the expected data types yourself."
         )
 
     # Otherwise raise warning which lists all successful conversions
@@ -321,11 +298,11 @@ def _convert_data_to_correct_types(data, functions_overridden):
 
 
 def _create_input_data(
-    data,
-    processed_functions,
-    targets,
-    columns_overriding_functions,
-    check_minimal_specification="ignore",
+        data,
+        processed_functions,
+        targets,
+        columns_overriding_functions,
+        check_minimal_specification="ignore",
 ):
     """Create input data for use in the calculation of taxes and transfers by:
 
@@ -411,54 +388,6 @@ def _fail_if_group_variables_not_constant_within_groups(data):
     return data
 
 
-def _fail_if_columns_overriding_functions_are_not_in_data(data_cols, columns):
-    """Fail if functions which compute columns overlap with existing columns.
-
-    Parameters
-    ----------
-    data_cols : list
-        Columns of the input data.
-    columns : list of str
-        List of column names.
-
-    Raises
-    ------
-    ValueError
-        Fail if functions which compute columns overlap with existing columns.
-
-    """
-    unused_columns_overriding_functions = sorted(
-        c for c in set(columns) if c not in data_cols
-    )
-    n_cols = len(unused_columns_overriding_functions)
-
-    column_sg_pl = "column" if n_cols == 1 else "columns"
-
-    if unused_columns_overriding_functions:
-        first_part = format_errors_and_warnings(
-            f"You passed the following user {column_sg_pl}:"
-        )
-        list_ = format_list_linewise(unused_columns_overriding_functions)
-
-        second_part = format_errors_and_warnings(
-            f"""
-            {'This' if n_cols == 1 else 'These'} {column_sg_pl} cannot be found in the
-            data.
-
-            If you want {'this' if n_cols == 1 else 'a'} data column to be used
-            instead of calculating it within GETTSIM, please add it to *data*.
-
-            If you want {'this' if n_cols == 1 else 'a'} data column to be calculated
-            internally by GETTSIM, remove it from the *columns_overriding_functions* you
-            pass to GETTSIM.
-
-            {'' if n_cols == 1 else '''You need to pick one option for each column that
-            appears in the list above.'''}
-            """
-        )
-        raise ValueError(f"{first_part}\n{list_}\n{second_part}")
-
-
 def _fail_if_pid_is_non_unique(data):
     """Check that pid is unique."""
     if "p_id" not in data:
@@ -482,7 +411,7 @@ def _fail_if_root_nodes_are_missing(root_nodes, data, functions):
         if len(
             [a for a in inspect.signature(func).parameters if not a.endswith("_params")]
         )
-        == 0
+           == 0
     ]
 
     missing_nodes = [
@@ -582,9 +511,9 @@ def _add_rounding_to_functions(functions, params):
 
             # Check if there are any rounding specifications.
             if not (
-                params_key in params
-                and "rounding" in params[params_key]
-                and func_name in params[params_key]["rounding"]
+                    params_key in params
+                    and "rounding" in params[params_key]
+                    and func_name in params[params_key]["rounding"]
             ):
                 raise KeyError(
                     KeyErrorMessage(
@@ -669,7 +598,7 @@ def _add_rounding_to_one_function(base, direction):
 
 
 def _fail_if_columns_overriding_functions_are_not_in_dag(
-    dag, columns_overriding_functions, check_minimal_specification
+        dag, columns_overriding_functions, check_minimal_specification
 ):
     """Fail if ``columns_overriding_functions`` are not in the DAG.
 

--- a/src/_gettsim/visualization.py
+++ b/src/_gettsim/visualization.py
@@ -74,13 +74,10 @@ def plot_dag(
     )
 
     # Load functions.
-    functions_not_overridden, functions_overridden = load_and_check_functions(
-        user_functions_raw=functions,
-        columns_overriding_functions=columns_overriding_functions,
-        targets=targets,
-        data_cols=list(TYPES_INPUT_VARIABLES),
-        aggregation_specs={},
-    )
+    functions_not_overridden, functions_overridden = load_and_check_functions(user_functions_raw=functions,
+                                                                              targets=targets,
+                                                                              data_cols=list(TYPES_INPUT_VARIABLES),
+                                                                              aggregation_specs={})
 
     # Select necessary nodes by creating a preliminary DAG.
     nodes = set_up_dag(

--- a/src/_gettsim/visualization.py
+++ b/src/_gettsim/visualization.py
@@ -74,10 +74,12 @@ def plot_dag(
     )
 
     # Load functions.
-    functions_not_overridden, functions_overridden = load_and_check_functions(user_functions_raw=functions,
-                                                                              targets=targets,
-                                                                              data_cols=list(TYPES_INPUT_VARIABLES),
-                                                                              aggregation_specs={})
+    functions_not_overridden, functions_overridden = load_and_check_functions(
+        user_functions_raw=functions,
+        targets=targets,
+        data_cols=list(TYPES_INPUT_VARIABLES),
+        aggregation_specs={},
+    )
 
     # Select necessary nodes by creating a preliminary DAG.
     nodes = set_up_dag(

--- a/src/_gettsim_tests/test_arbeitsl_geld.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld.py
@@ -22,12 +22,7 @@ def test_arbeitsl_geld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     # to prevent errors from rounding, allow deviations after the 3rd digit.
     assert_series_equal(

--- a/src/_gettsim_tests/test_arbeitsl_geld.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld.py
@@ -22,7 +22,9 @@ def test_arbeitsl_geld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     # to prevent errors from rounding, allow deviations after the 3rd digit.
     assert_series_equal(

--- a/src/_gettsim_tests/test_arbeitsl_geld_2.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld_2.py
@@ -31,7 +31,9 @@ def test_arbeitsl_geld_2(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     if column in [
         "arbeitsl_geld_2_vor_vorrang_m_hh",

--- a/src/_gettsim_tests/test_arbeitsl_geld_2.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld_2.py
@@ -14,18 +14,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "arbeitsl_geld_m",
-    "soli_st_y_tu",
-    "kindergeld_m_hh",
-    "unterhaltsvors_m",
-    "elterngeld_m",
-    "eink_st_y_tu",
-    "sozialv_beitr_m",
-    "sum_ges_rente_priv_rente_m",
-    "wohngeld_vor_vermög_check_m_hh",
-]
-
 data = load_policy_test_data("arbeitsl_geld_2")
 
 
@@ -43,13 +31,7 @@ def test_arbeitsl_geld_2(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     if column in [
         "arbeitsl_geld_2_vor_vorrang_m_hh",

--- a/src/_gettsim_tests/test_benefit_checks.py
+++ b/src/_gettsim_tests/test_benefit_checks.py
@@ -5,15 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "_kinderzuschl_vor_vermög_check_m_tu",
-    "wohngeld_vor_vermög_check_m_hh",
-    "arbeitsl_geld_2_regelbedarf_m_hh",
-    "kindergeld_m_hh",
-    "unterhaltsvors_m_hh",
-    "arbeitsl_geld_2_eink_m_hh",
-]
-
 data = load_policy_test_data("benefit_checks")
 
 
@@ -31,13 +22,7 @@ def test_benefit_checks(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_benefit_checks.py
+++ b/src/_gettsim_tests/test_benefit_checks.py
@@ -22,7 +22,9 @@ def test_benefit_checks(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_eink_st.py
+++ b/src/_gettsim_tests/test_eink_st.py
@@ -31,7 +31,9 @@ def test_eink_st(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=1, rtol=0

--- a/src/_gettsim_tests/test_eink_st.py
+++ b/src/_gettsim_tests/test_eink_st.py
@@ -5,12 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "_zu_verst_eink_ohne_kinderfreib_y_tu",
-    "_zu_verst_eink_mit_kinderfreib_y_tu",
-    "kapitaleink_brutto_y",
-]
-
 data = load_policy_test_data("eink_st")
 
 
@@ -37,13 +31,7 @@ def test_eink_st(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=1, rtol=0

--- a/src/_gettsim_tests/test_elterngeld.py
+++ b/src/_gettsim_tests/test_elterngeld.py
@@ -5,13 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "soli_st_y_tu",
-    "sozialv_beitr_m",
-    "eink_st_y_tu",
-]
-
-
 data = load_policy_test_data("elterngeld")
 
 
@@ -40,13 +33,7 @@ def test_elterngeld(
     df["soli_st_y_tu"] = df["soli_st_m"].groupby(df["tu_id"]).transform("sum") * 12
     df["eink_st_y_tu"] = df["eink_st_m"].groupby(df["tu_id"]).transform("sum") * 12
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_elterngeld.py
+++ b/src/_gettsim_tests/test_elterngeld.py
@@ -33,7 +33,9 @@ def test_elterngeld(
     df["soli_st_y_tu"] = df["soli_st_m"].groupby(df["tu_id"]).transform("sum") * 12
     df["eink_st_y_tu"] = df["eink_st_m"].groupby(df["tu_id"]).transform("sum") * 12
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_favorability_check.py
+++ b/src/_gettsim_tests/test_favorability_check.py
@@ -22,7 +22,9 @@ def test_favorability_check(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_favorability_check.py
+++ b/src/_gettsim_tests/test_favorability_check.py
@@ -5,15 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "eink_st_ohne_kinderfreib_y_tu",
-    "eink_st_mit_kinderfreib_y_tu",
-    "abgelt_st_y_tu",
-    "kindergeld_m",
-    "_zu_verst_eink_mit_kinderfreib_y_tu",
-    "_zu_verst_eink_ohne_kinderfreib_y_tu",
-]
-
 data = load_policy_test_data("favorability_check")
 
 
@@ -31,13 +22,7 @@ def test_favorability_check(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -43,7 +43,9 @@ def test_full_taxes_and_transfers(
     policy_params, policy_functions = cached_set_up_policy_environment(
         date=test_data.date
     )
-    compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=OUT_COLS)
+    compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=OUT_COLS
+    )
 
 
 @pytest.mark.parametrize(
@@ -51,7 +53,7 @@ def test_full_taxes_and_transfers(
     data.test_data,
     ids=str,
 )
-def test_data_types(  # noqa: PLR0912
+def test_data_types(
     test_data: PolicyTestData,
 ):
     imports = _convert_paths_to_import_strings(PATHS_TO_INTERNAL_FUNCTIONS)
@@ -66,8 +68,13 @@ def test_data_types(  # noqa: PLR0912
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=OUT_COLS,
-                                         debug=True)
+    result = compute_taxes_and_transfers(
+        data=df,
+        params=policy_params,
+        functions=policy_functions,
+        targets=OUT_COLS,
+        debug=True,
+    )
     for column_name, series in result.items():
         if series.empty:
             pass

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -27,7 +27,6 @@ OUT_COLS = [
     "wohngeld_m_hh",
     "unterhaltsvors_m_hh",
 ]
-OVERRIDE_COLS = ["sum_ges_rente_priv_rente_m"]
 
 data = load_policy_test_data("full_taxes_and_transfers")
 
@@ -44,24 +43,7 @@ def test_full_taxes_and_transfers(
     policy_params, policy_functions = cached_set_up_policy_environment(
         date=test_data.date
     )
-    # TODO(@hmgaudecker): Remove again once unterhaltsvors_m is implemented
-    #     for more years.
-    # https://github.com/iza-institute-of-labor-economics/gettsim/issues/479
-    if test_data.date.year < 2016:
-        columns_overriding_functions = [
-            *OVERRIDE_COLS,
-            "unterhaltsvors_m",
-            "elterngeld_m",
-        ]
-    else:
-        columns_overriding_functions = OVERRIDE_COLS
-    compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=OUT_COLS,
-        columns_overriding_functions=columns_overriding_functions,
-    )
+    compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=OUT_COLS)
 
 
 @pytest.mark.parametrize(
@@ -83,26 +65,9 @@ def test_data_types(  # noqa: PLR0912
     policy_params, policy_functions = cached_set_up_policy_environment(
         date=test_data.date
     )
-    # TODO(@hmgaudecker): Remove again once unterhaltsvors_m is implemented
-    #     for more years.
-    # https://github.com/iza-institute-of-labor-economics/gettsim/issues/479
-    if test_data.date.year < 2016:
-        columns_overriding_functions = [
-            *OVERRIDE_COLS,
-            "unterhaltsvors_m",
-            "elterngeld_m",
-        ]
-    else:
-        columns_overriding_functions = OVERRIDE_COLS
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=OUT_COLS,
-        debug=True,
-        columns_overriding_functions=columns_overriding_functions,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=OUT_COLS,
+                                         debug=True)
     for column_name, series in result.items():
         if series.empty:
             pass

--- a/src/_gettsim_tests/test_grundrente.py
+++ b/src/_gettsim_tests/test_grundrente.py
@@ -32,7 +32,9 @@ def test_grundrente(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     tol = OUT_COLS_TOL[column]
     assert_series_equal(
@@ -87,7 +89,9 @@ def test_proxy_rente_vorj(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column].astype(float),
@@ -108,16 +112,24 @@ def test_proxy_rente_vorj_comparison_last_year(test_data: PolicyTestData):
     date = test_data.date
     policy_params, policy_functions = cached_set_up_policy_environment(date)
 
-    calc_result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions,
-                                              targets="rente_vorj_vor_grundr_proxy_m")
+    calc_result = compute_taxes_and_transfers(
+        data=df,
+        params=policy_params,
+        functions=policy_functions,
+        targets="rente_vorj_vor_grundr_proxy_m",
+    )
 
     # Calculate pension of last year
     policy_params, policy_functions = cached_set_up_policy_environment(
         date - timedelta(days=365)
     )
     df["alter"] -= 1
-    calc_result_last_year = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions,
-                                                        targets=["ges_rente_vor_grundr_m"])
+    calc_result_last_year = compute_taxes_and_transfers(
+        data=df,
+        params=policy_params,
+        functions=policy_functions,
+        targets=["ges_rente_vor_grundr_m"],
+    )
     assert_series_equal(
         calc_result["rente_vorj_vor_grundr_proxy_m"],
         calc_result_last_year["ges_rente_vor_grundr_m"] + df["priv_rente_m"],

--- a/src/_gettsim_tests/test_grundrente.py
+++ b/src/_gettsim_tests/test_grundrente.py
@@ -15,15 +15,6 @@ OUT_COLS_TOL = {
     "grundr_zuschlag_m": 1,
     "ges_rente_m": 1,
 }
-
-OVERRIDE_COLS = [
-    "rente_vorj_vor_grundr_proxy_m",
-    "eink_selbst_y",
-    "eink_vermietung_y",
-    "kapitaleink_y",
-    "ges_rente_zugangsfaktor",
-]
-
 data = load_policy_test_data("grundrente")
 
 
@@ -41,13 +32,7 @@ def test_grundrente(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     tol = OUT_COLS_TOL[column]
     assert_series_equal(
@@ -102,12 +87,7 @@ def test_proxy_rente_vorj(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column].astype(float),
@@ -128,24 +108,16 @@ def test_proxy_rente_vorj_comparison_last_year(test_data: PolicyTestData):
     date = test_data.date
     policy_params, policy_functions = cached_set_up_policy_environment(date)
 
-    calc_result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets="rente_vorj_vor_grundr_proxy_m",
-    )
+    calc_result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions,
+                                              targets="rente_vorj_vor_grundr_proxy_m")
 
     # Calculate pension of last year
     policy_params, policy_functions = cached_set_up_policy_environment(
         date - timedelta(days=365)
     )
     df["alter"] -= 1
-    calc_result_last_year = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=["ges_rente_vor_grundr_m"],
-    )
+    calc_result_last_year = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions,
+                                                        targets=["ges_rente_vor_grundr_m"])
     assert_series_equal(
         calc_result["rente_vorj_vor_grundr_proxy_m"],
         calc_result_last_year["ges_rente_vor_grundr_m"] + df["priv_rente_m"],

--- a/src/_gettsim_tests/test_grunds_im_alter.py
+++ b/src/_gettsim_tests/test_grunds_im_alter.py
@@ -22,7 +22,9 @@ def test_grunds_im_alter(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_grunds_im_alter.py
+++ b/src/_gettsim_tests/test_grunds_im_alter.py
@@ -5,17 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "eink_st_y_tu",
-    "soli_st_y_tu",
-    "sozialv_beitr_m",
-    "kindergeld_m_hh",
-    "unterhaltsvors_m",
-    "elterngeld_m",
-    "ges_rente_m",
-    "arbeitsl_geld_m",
-]
-
 data = load_policy_test_data("grunds_im_alter")
 
 
@@ -33,13 +22,7 @@ def test_grunds_im_alter(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from _gettsim.gettsim_typing import convert_series_to_internal_type
 from _gettsim.interface import (
+    FunctionsAndColumnsOverlapWarning,
     _convert_data_to_correct_types,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_pid_is_non_unique,
@@ -41,21 +42,25 @@ func_after_partial = _round_and_partial_parameters_to_functions(
 )["test_func"]
 
 
-@pytest.mark.parametrize(
-    "columns_overriding_functions",
-    [
-        {"dupl"},
-    ],
-)
-def test_warn_if_functions_and_columns_overlap(columns_overriding_functions: set[str]):
-    with pytest.warns(UserWarning, match="Your data provides the column"):
-        _warn_if_functions_and_columns_overlap(columns_overriding_functions)
+def test_warn_if_functions_and_columns_overlap():
+    with pytest.warns(FunctionsAndColumnsOverlapWarning):
+        _warn_if_functions_and_columns_overlap({"dupl"})
 
 
 def test_dont_warn_if_functions_and_columns_dont_overlap():
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.filterwarnings("error", category=FunctionsAndColumnsOverlapWarning)
         _warn_if_functions_and_columns_overlap(set())
+
+
+def test_recipe_to_ignore_warning_if_functions_and_columns_overlap():
+    with warnings.catch_warnings(
+        category=FunctionsAndColumnsOverlapWarning, record=True
+    ) as warning_list:
+        warnings.filterwarnings("ignore", category=FunctionsAndColumnsOverlapWarning)
+        _warn_if_functions_and_columns_overlap({"dupl"})
+
+    assert len(warning_list) == 0
 
 
 def test_fail_if_pid_does_not_exist():

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -57,7 +57,7 @@ def test_dont_warn_if_functions_and_columns_dont_overlap():
         compute_taxes_and_transfers(
             data=pd.DataFrame({"p_id": [0]}),
             params={},
-            functions={"dupl": lambda x: x},
+            functions={"some_func": lambda x: x},
             targets=[],
         )
 

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -9,11 +9,9 @@ from _gettsim.interface import (
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_pid_is_non_unique,
     _round_and_partial_parameters_to_functions,
-    _warn_if_functions_and_columns_overlap,
     compute_taxes_and_transfers,
 )
 from _gettsim.shared import add_rounding_spec
-
 from gettsim import FunctionsAndColumnsOverlapWarning
 
 
@@ -45,13 +43,23 @@ func_after_partial = _round_and_partial_parameters_to_functions(
 
 def test_warn_if_functions_and_columns_overlap():
     with pytest.warns(FunctionsAndColumnsOverlapWarning):
-        _warn_if_functions_and_columns_overlap({"dupl"})
+        compute_taxes_and_transfers(
+            data=pd.DataFrame({"p_id": [0], "dupl": [1]}),
+            params={},
+            functions={"dupl": lambda x: x},
+            targets=[],
+        )
 
 
 def test_dont_warn_if_functions_and_columns_dont_overlap():
     with warnings.catch_warnings():
         warnings.filterwarnings("error", category=FunctionsAndColumnsOverlapWarning)
-        _warn_if_functions_and_columns_overlap(set())
+        compute_taxes_and_transfers(
+            data=pd.DataFrame({"p_id": [0]}),
+            params={},
+            functions={"dupl": lambda x: x},
+            targets=[],
+        )
 
 
 def test_recipe_to_ignore_warning_if_functions_and_columns_overlap():
@@ -59,7 +67,12 @@ def test_recipe_to_ignore_warning_if_functions_and_columns_overlap():
         category=FunctionsAndColumnsOverlapWarning, record=True
     ) as warning_list:
         warnings.filterwarnings("ignore", category=FunctionsAndColumnsOverlapWarning)
-        _warn_if_functions_and_columns_overlap({"dupl"})
+        compute_taxes_and_transfers(
+            data=pd.DataFrame({"p_id": [0], "dupl": [1]}),
+            params={},
+            functions={"dupl": lambda x: x},
+            targets=[],
+        )
 
     assert len(warning_list) == 0
 

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -361,7 +361,7 @@ def test_user_provided_aggregation_specs_function():
         }
     )
     aggregation_specs = {
-        "arbeitsl_geld_2_m_double_hh": {
+        "arbeitsl_geld_2_double_m_hh": {
             "source_col": "arbeitsl_geld_2_m_double",
             "aggr": "max",
         }
@@ -376,11 +376,11 @@ def test_user_provided_aggregation_specs_function():
         {},
         functions=[arbeitsl_geld_2_m_double],
         aggregation_specs=aggregation_specs,
-        targets="arbeitsl_geld_2_m_double_hh",
+        targets="arbeitsl_geld_2_double_m_hh",
     )
 
     numpy.testing.assert_array_almost_equal(
-        out["arbeitsl_geld_2_m_double_hh"], expected_res
+        out["arbeitsl_geld_2_double_m_hh"], expected_res
     )
 
 
@@ -393,7 +393,7 @@ def test_aggregation_specs_missing_group_sufix():
         }
     )
     aggregation_specs = {
-        "arbeitsl_geld_2_m_agg": {
+        "arbeitsl_geld_2_agg_m": {
             "source_col": "arbeitsl_geld_2_m",
             "aggr": "sum",
         }
@@ -407,7 +407,7 @@ def test_aggregation_specs_missing_group_sufix():
             {},
             functions=[],
             aggregation_specs=aggregation_specs,
-            targets="arbeitsl_geld_2_m_agg",
+            targets="arbeitsl_geld_2_agg_m",
         )
 
 

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 from _gettsim.gettsim_typing import convert_series_to_internal_type
 from _gettsim.interface import (
-    FunctionsAndColumnsOverlapWarning,
     _convert_data_to_correct_types,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_pid_is_non_unique,
@@ -14,6 +13,8 @@ from _gettsim.interface import (
     compute_taxes_and_transfers,
 )
 from _gettsim.shared import add_rounding_spec
+
+from gettsim import FunctionsAndColumnsOverlapWarning
 
 
 @pytest.fixture(scope="module")

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -3,14 +3,9 @@ from contextlib import ExitStack as does_not_raise  # noqa: N813
 import numpy
 import pandas as pd
 import pytest
-from _gettsim.functions_loader import (
-    _fail_if_columns_overriding_functions_are_not_in_functions,
-    _fail_if_functions_and_columns_overlap,
-)
 from _gettsim.gettsim_typing import convert_series_to_internal_type
 from _gettsim.interface import (
     _convert_data_to_correct_types,
-    _fail_if_columns_overriding_functions_are_not_in_data,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_pid_is_non_unique,
     _round_and_partial_parameters_to_functions,
@@ -43,52 +38,6 @@ func_after_partial = _round_and_partial_parameters_to_functions(
     {"arbeitsl_geld_2": {"test_param_1": 1}},
     rounding=False,
 )["test_func"]
-
-
-@pytest.mark.parametrize(
-    "data, columns_overriding_functions, expectation",
-    [
-        ({}, ["not_in_data"], pytest.raises(ValueError)),
-        ({"in_data": None}, ["in_data"], does_not_raise()),
-    ],
-)
-def test_fail_if_columns_overriding_functions_are_not_in_data(
-    data, columns_overriding_functions, expectation
-):
-    with expectation:
-        _fail_if_columns_overriding_functions_are_not_in_data(
-            data, columns_overriding_functions
-        )
-
-
-@pytest.mark.parametrize(
-    "columns_overriding_functions, functions, expectation",
-    [
-        (["not_in_functions"], {}, pytest.raises(ValueError)),
-        (["in_functions"], {"in_functions": None}, does_not_raise()),
-    ],
-)
-def test_fail_if_columns_overriding_functions_are_not_in_functions(
-    columns_overriding_functions, functions, expectation
-):
-    with expectation:
-        _fail_if_columns_overriding_functions_are_not_in_functions(
-            columns_overriding_functions, functions
-        )
-
-
-@pytest.mark.parametrize(
-    "columns, functions, type_, expectation",
-    [
-        ({"dupl": None}, {"dupl": None}, "internal", pytest.raises(ValueError)),
-        ({}, {}, "internal", does_not_raise()),
-        ({"dupl": None}, {"dupl": None}, "user", pytest.raises(ValueError)),
-        ({}, {}, "user", does_not_raise()),
-    ],
-)
-def test_fail_if_functions_and_columns_overlap(columns, functions, type_, expectation):
-    with expectation:
-        _fail_if_functions_and_columns_overlap(columns, functions, type_)
 
 
 def test_fail_if_pid_does_not_exist():
@@ -129,9 +78,7 @@ def test_missing_root_nodes_raises_error(minimal_input_data):
         ValueError,
         match="The following data columns are missing",
     ):
-        compute_taxes_and_transfers(
-            minimal_input_data, {}, functions=[b, c], targets="c"
-        )
+        compute_taxes_and_transfers(minimal_input_data, {}, functions=[b, c], targets="c")
 
 
 def test_data_as_series():
@@ -141,12 +88,7 @@ def test_data_as_series():
     data = pd.Series([1, 2, 3])
     data.name = "p_id"
 
-    compute_taxes_and_transfers(
-        data,
-        {},
-        functions=[c],
-        targets="c",
-    )
+    compute_taxes_and_transfers(data, {}, functions=[c], targets="c")
 
 
 def test_data_as_dict():
@@ -159,12 +101,7 @@ def test_data_as_dict():
         "b": pd.Series([100, 200, 300]),
     }
 
-    compute_taxes_and_transfers(
-        data,
-        {},
-        functions=[c],
-        targets="c",
-    )
+    compute_taxes_and_transfers(data, {}, functions=[c], targets="c")
 
 
 def test_wrong_data_type():
@@ -179,11 +116,7 @@ def test_wrong_data_type():
             "pd.Series or a dictionary of pd.Series."
         ),
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            [c],
-        )
+        compute_taxes_and_transfers(data, {}, [c])
 
 
 def test_check_minimal_spec_data():
@@ -202,13 +135,7 @@ def test_check_minimal_spec_data():
         ValueError,
         match="The following columns in 'data' are unused",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[c],
-            targets="c",
-            check_minimal_specification="raise",
-        )
+        compute_taxes_and_transfers(data, {}, functions=[c], targets="c", check_minimal_specification="raise")
 
 
 def test_check_minimal_spec_data_warn():
@@ -227,13 +154,7 @@ def test_check_minimal_spec_data_warn():
         UserWarning,
         match="The following columns in 'data' are unused",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[c],
-            targets="c",
-            check_minimal_specification="warn",
-        )
+        compute_taxes_and_transfers(data, {}, functions=[c], targets="c", check_minimal_specification="warn")
 
 
 def test_check_minimal_spec_columns_overriding():
@@ -255,14 +176,7 @@ def test_check_minimal_spec_columns_overriding():
         ValueError,
         match="The following 'columns_overriding_functions' are unused",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[b, c],
-            targets="c",
-            columns_overriding_functions=["b"],
-            check_minimal_specification="raise",
-        )
+        compute_taxes_and_transfers(data, {}, functions=[b, c], targets="c", check_minimal_specification="raise")
 
 
 def test_check_minimal_spec_columns_overriding_warn():
@@ -284,14 +198,7 @@ def test_check_minimal_spec_columns_overriding_warn():
         UserWarning,
         match="The following 'columns_overriding_functions' are unused",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[b, c],
-            targets="c",
-            columns_overriding_functions=["b"],
-            check_minimal_specification="warn",
-        )
+        compute_taxes_and_transfers(data, {}, functions=[b, c], targets="c", check_minimal_specification="warn")
 
 
 def test_function_without_data_dependency_is_not_mistaken_for_data(minimal_input_data):
@@ -311,12 +218,7 @@ def test_fail_if_targets_are_not_in_functions_or_in_columns_overriding_functions
         ValueError,
         match="The following targets have no corresponding function",
     ):
-        compute_taxes_and_transfers(
-            minimal_input_data,
-            {},
-            functions=[],
-            targets="unknown_target",
-        )
+        compute_taxes_and_transfers(minimal_input_data, {}, functions=[], targets="unknown_target")
 
 
 def test_fail_if_missing_pid(minimal_input_data):
@@ -409,13 +311,8 @@ def test_user_provided_aggregation_specs():
     }
     expected_res = pd.Series([200, 200, 100])
 
-    out = compute_taxes_and_transfers(
-        data,
-        {},
-        functions=[],
-        targets="arbeitsl_geld_2_m_hh",
-        aggregation_specs=aggregation_specs,
-    )
+    out = compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
+                                      targets="arbeitsl_geld_2_m_hh")
 
     numpy.testing.assert_array_almost_equal(out["arbeitsl_geld_2_m_hh"], expected_res)
 
@@ -439,13 +336,8 @@ def test_user_provided_aggregation_specs_function():
     def arbeitsl_geld_2_m_double(arbeitsl_geld_2_m):
         return 2 * arbeitsl_geld_2_m
 
-    out = compute_taxes_and_transfers(
-        data,
-        {},
-        functions=[arbeitsl_geld_2_m_double],
-        targets="arbeitsl_geld_2_m_double_hh",
-        aggregation_specs=aggregation_specs,
-    )
+    out = compute_taxes_and_transfers(data, {}, functions=[arbeitsl_geld_2_m_double],
+                                      aggregation_specs=aggregation_specs, targets="arbeitsl_geld_2_m_double_hh")
 
     numpy.testing.assert_array_almost_equal(
         out["arbeitsl_geld_2_m_double_hh"], expected_res
@@ -470,13 +362,8 @@ def test_aggregation_specs_missing_group_sufix():
         ValueError,
         match="Name of aggregated column needs to have a suffix",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[],
-            targets="arbeitsl_geld_2_m_agg",
-            aggregation_specs=aggregation_specs,
-        )
+        compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
+                                    targets="arbeitsl_geld_2_m_agg")
 
 
 def test_aggregation_specs_agg_not_impl():
@@ -497,13 +384,8 @@ def test_aggregation_specs_agg_not_impl():
         ValueError,
         match="Aggr aggr_not_implemented is not implemented, yet.",
     ):
-        compute_taxes_and_transfers(
-            data,
-            {},
-            functions=[],
-            targets="arbeitsl_geld_2_m_hh",
-            aggregation_specs=aggregation_specs,
-        )
+        compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
+                                    targets="arbeitsl_geld_2_m_hh")
 
 
 @pytest.mark.parametrize(

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -9,7 +9,8 @@ from _gettsim.interface import (
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_pid_is_non_unique,
     _round_and_partial_parameters_to_functions,
-    compute_taxes_and_transfers, _warn_if_functions_and_columns_overlap,
+    _warn_if_functions_and_columns_overlap,
+    compute_taxes_and_transfers,
 )
 from _gettsim.shared import add_rounding_spec
 
@@ -92,8 +93,8 @@ def test_missing_root_nodes_raises_error(minimal_input_data):
         return b
 
     with pytest.raises(
-            ValueError,
-            match="The following data columns are missing",
+        ValueError,
+        match="The following data columns are missing",
     ):
         compute_taxes_and_transfers(
             minimal_input_data, {}, functions=[b, c], targets="c"
@@ -129,11 +130,11 @@ def test_wrong_data_type():
 
     data = "not_a_data_object"
     with pytest.raises(
-            NotImplementedError,
-            match=(
-                    "'data' is not a pd.DataFrame or a "
-                    "pd.Series or a dictionary of pd.Series."
-            ),
+        NotImplementedError,
+        match=(
+            "'data' is not a pd.DataFrame or a "
+            "pd.Series or a dictionary of pd.Series."
+        ),
     ):
         compute_taxes_and_transfers(data, {}, [c])
 
@@ -151,8 +152,8 @@ def test_check_minimal_spec_data():
         }
     )
     with pytest.raises(
-            ValueError,
-            match="The following columns in 'data' are unused",
+        ValueError,
+        match="The following columns in 'data' are unused",
     ):
         compute_taxes_and_transfers(
             data, {}, functions=[c], targets="c", check_minimal_specification="raise"
@@ -172,8 +173,8 @@ def test_check_minimal_spec_data_warn():
         }
     )
     with pytest.warns(
-            UserWarning,
-            match="The following columns in 'data' are unused",
+        UserWarning,
+        match="The following columns in 'data' are unused",
     ):
         compute_taxes_and_transfers(
             data, {}, functions=[c], targets="c", check_minimal_specification="warn"
@@ -196,8 +197,8 @@ def test_check_minimal_spec_columns_overriding():
         }
     )
     with pytest.raises(
-            ValueError,
-            match="The following 'columns_overriding_functions' are unused",
+        ValueError,
+        match="The following 'columns_overriding_functions' are unused",
     ):
         compute_taxes_and_transfers(
             data, {}, functions=[b, c], targets="c", check_minimal_specification="raise"
@@ -220,8 +221,8 @@ def test_check_minimal_spec_columns_overriding_warn():
         }
     )
     with pytest.warns(
-            UserWarning,
-            match="The following 'columns_overriding_functions' are unused",
+        UserWarning,
+        match="The following 'columns_overriding_functions' are unused",
     ):
         compute_taxes_and_transfers(
             data, {}, functions=[b, c], targets="c", check_minimal_specification="warn"
@@ -239,11 +240,11 @@ def test_function_without_data_dependency_is_not_mistaken_for_data(minimal_input
 
 
 def test_fail_if_targets_are_not_in_functions_or_in_columns_overriding_functions(
-        minimal_input_data,
+    minimal_input_data,
 ):
     with pytest.raises(
-            ValueError,
-            match="The following targets have no corresponding function",
+        ValueError,
+        match="The following targets have no corresponding function",
     ):
         compute_taxes_and_transfers(
             minimal_input_data, {}, functions=[], targets="unknown_target"
@@ -254,8 +255,8 @@ def test_fail_if_missing_pid(minimal_input_data):
     data = minimal_input_data.drop("p_id", axis=1).copy()
 
     with pytest.raises(
-            ValueError,
-            match="The input data must contain the column p_id",
+        ValueError,
+        match="The input data must contain the column p_id",
     ):
         compute_taxes_and_transfers(data, {}, functions=[], targets=[])
 
@@ -265,8 +266,8 @@ def test_fail_if_non_unique_pid(minimal_input_data):
     data["p_id"] = 1
 
     with pytest.raises(
-            ValueError,
-            match="The following p_ids are non-unique",
+        ValueError,
+        match="The following p_ids are non-unique",
     ):
         compute_taxes_and_transfers(data, {}, functions=[], targets=[])
 
@@ -276,8 +277,8 @@ def test_fail_if_non_unique_cols(minimal_input_data):
     data["temp"] = data["hh_id"]
     data = data.rename(columns={"temp": "hh_id"})
     with pytest.raises(
-            ValueError,
-            match="The following columns are non-unique",
+        ValueError,
+        match="The following columns are non-unique",
     ):
         compute_taxes_and_transfers(data, {}, functions=[], targets=[])
 
@@ -299,8 +300,8 @@ def test_partial_parameters_to_functions():
 def test_partial_parameters_to_functions_removes_argument():
     # Fails if params is added to partial function
     with pytest.raises(
-            TypeError,
-            match=("got multiple values for argument "),
+        TypeError,
+        match=("got multiple values for argument "),
     ):
         func_after_partial(2, {"test_param_1": 1})
 
@@ -398,8 +399,8 @@ def test_aggregation_specs_missing_group_sufix():
         }
     }
     with pytest.raises(
-            ValueError,
-            match="Name of aggregated column needs to have a suffix",
+        ValueError,
+        match="Name of aggregated column needs to have a suffix",
     ):
         compute_taxes_and_transfers(
             data,
@@ -425,8 +426,8 @@ def test_aggregation_specs_agg_not_impl():
         }
     }
     with pytest.raises(
-            ValueError,
-            match="Aggr aggr_not_implemented is not implemented, yet.",
+        ValueError,
+        match="Aggr aggr_not_implemented is not implemented, yet.",
     ):
         compute_taxes_and_transfers(
             data,
@@ -449,7 +450,7 @@ def test_aggregation_specs_agg_not_impl():
     ],
 )
 def test_convert_series_to_internal_types(
-        input_data, expected_type, expected_output_data
+    input_data, expected_type, expected_output_data
 ):
     adjusted_input = convert_series_to_internal_type(input_data, expected_type)
     pd.testing.assert_series_equal(adjusted_input, expected_output_data)
@@ -459,84 +460,84 @@ def test_convert_series_to_internal_types(
     "input_data, expected_type, error_match",
     [
         (
-                pd.Series(["Hallo", 200, 325]),
-                float,
-                "Conversion from input type object to float failed.",
+            pd.Series(["Hallo", 200, 325]),
+            float,
+            "Conversion from input type object to float failed.",
         ),
         (
-                pd.Series([True, False]),
-                float,
-                "Conversion from input type bool to float failed.",
+            pd.Series([True, False]),
+            float,
+            "Conversion from input type bool to float failed.",
         ),
         (
-                pd.Series(["a", "b", "c"]).astype("category"),
-                float,
-                "Conversion from input type category to float failed.",
+            pd.Series(["a", "b", "c"]).astype("category"),
+            float,
+            "Conversion from input type category to float failed.",
         ),
         (
-                pd.Series(["2.0", "3.0"]),
-                int,
-                "Conversion from input type object to int failed.",
+            pd.Series(["2.0", "3.0"]),
+            int,
+            "Conversion from input type object to int failed.",
         ),
         (
-                pd.Series([1.5, 1.0, 2.9]),
-                int,
-                "Conversion from input type float64 to int failed.",
+            pd.Series([1.5, 1.0, 2.9]),
+            int,
+            "Conversion from input type float64 to int failed.",
         ),
         (
-                pd.Series(["a", "b", "c"]).astype("category"),
-                int,
-                "Conversion from input type category to int failed.",
+            pd.Series(["a", "b", "c"]).astype("category"),
+            int,
+            "Conversion from input type category to int failed.",
         ),
         (
-                pd.Series([5, 2, 3]),
-                bool,
-                "Conversion from input type int64 to bool failed.",
+            pd.Series([5, 2, 3]),
+            bool,
+            "Conversion from input type int64 to bool failed.",
         ),
         (
-                pd.Series([1.5, 1.0, 35.0]),
-                bool,
-                "Conversion from input type float64 to bool failed.",
+            pd.Series([1.5, 1.0, 35.0]),
+            bool,
+            "Conversion from input type float64 to bool failed.",
         ),
         (
-                pd.Series(["a", "b", "c"]).astype("category"),
-                bool,
-                "Conversion from input type category to bool failed.",
+            pd.Series(["a", "b", "c"]).astype("category"),
+            bool,
+            "Conversion from input type category to bool failed.",
         ),
         (
-                pd.Series(["richtig"]),
-                bool,
-                "Conversion from input type object to bool failed.",
+            pd.Series(["richtig"]),
+            bool,
+            "Conversion from input type object to bool failed.",
         ),
         (
-                pd.Series(["True", "False", ""]),
-                bool,
-                "Conversion from input type object to bool failed.",
+            pd.Series(["True", "False", ""]),
+            bool,
+            "Conversion from input type object to bool failed.",
         ),
         (
-                pd.Series(["true"]),
-                bool,
-                "Conversion from input type object to bool failed.",
+            pd.Series(["true"]),
+            bool,
+            "Conversion from input type object to bool failed.",
         ),
         (
-                pd.Series(["zweitausendzwanzig"]),
-                numpy.datetime64,
-                "Conversion from input type object to datetime64 failed.",
+            pd.Series(["zweitausendzwanzig"]),
+            numpy.datetime64,
+            "Conversion from input type object to datetime64 failed.",
         ),
         (
-                pd.Series([True, True]),
-                numpy.datetime64,
-                "Conversion from input type bool to datetime64 failed.",
+            pd.Series([True, True]),
+            numpy.datetime64,
+            "Conversion from input type bool to datetime64 failed.",
         ),
         (
-                pd.Series([2020]),
-                str,
-                "The internal type <class 'str'> is not yet supported.",
+            pd.Series([2020]),
+            str,
+            "The internal type <class 'str'> is not yet supported.",
         ),
     ],
 )
 def test_fail_if_cannot_be_converted_to_internal_type(
-        input_data, expected_type, error_match
+    input_data, expected_type, error_match
 ):
     with pytest.raises(ValueError, match=error_match):
         convert_series_to_internal_type(input_data, expected_type)
@@ -546,49 +547,49 @@ def test_fail_if_cannot_be_converted_to_internal_type(
     "data, functions_overridden, error_match",
     [
         (
-                pd.DataFrame({"hh_id": [1, 1.1, 2]}),
-                {},
-                "The data types of the following columns are invalid: \n"
-                "\n - hh_id: Conversion from input type float64 to int failed."
-                " This conversion is only supported if all decimal places of input"
-                " data are equal to 0.",
+            pd.DataFrame({"hh_id": [1, 1.1, 2]}),
+            {},
+            "The data types of the following columns are invalid: \n"
+            "\n - hh_id: Conversion from input type float64 to int failed."
+            " This conversion is only supported if all decimal places of input"
+            " data are equal to 0.",
         ),
         (
-                pd.DataFrame({"wohnort_ost": [1.1, 0.0, 1.0]}),
-                {},
-                "The data types of the following columns are invalid: \n"
-                "\n - wohnort_ost: Conversion from input type float64 to bool failed."
-                " This conversion is only supported if input data exclusively contains"
-                " the values 1.0 and 0.0.",
+            pd.DataFrame({"wohnort_ost": [1.1, 0.0, 1.0]}),
+            {},
+            "The data types of the following columns are invalid: \n"
+            "\n - wohnort_ost: Conversion from input type float64 to bool failed."
+            " This conversion is only supported if input data exclusively contains"
+            " the values 1.0 and 0.0.",
         ),
         (
-                pd.DataFrame({"wohnort_ost": [2, 0, 1], "hh_id": [1.0, 2.0, 3.0]}),
-                {},
-                "The data types of the following columns are invalid: \n"
-                "\n - wohnort_ost: Conversion from input type int64 to bool failed."
-                " This conversion is only supported if input data exclusively contains"
-                " the values 1 and 0.",
+            pd.DataFrame({"wohnort_ost": [2, 0, 1], "hh_id": [1.0, 2.0, 3.0]}),
+            {},
+            "The data types of the following columns are invalid: \n"
+            "\n - wohnort_ost: Conversion from input type int64 to bool failed."
+            " This conversion is only supported if input data exclusively contains"
+            " the values 1 and 0.",
         ),
         (
-                pd.DataFrame({"wohnort_ost": ["True", "False"]}),
-                {},
-                "The data types of the following columns are invalid: \n"
-                "\n - wohnort_ost: Conversion from input type object to bool failed."
-                " Object type is not supported as input.",
+            pd.DataFrame({"wohnort_ost": ["True", "False"]}),
+            {},
+            "The data types of the following columns are invalid: \n"
+            "\n - wohnort_ost: Conversion from input type object to bool failed."
+            " Object type is not supported as input.",
         ),
         (
-                pd.DataFrame({"hh_id": [1, "1", 2], "bruttolohn_m": ["2000", 3000, 4000]}),
-                {},
-                "The data types of the following columns are invalid: \n"
-                "\n - hh_id: Conversion from input type object to int failed. "
-                "Object type is not supported as input."
-                "\n - bruttolohn_m: Conversion from input type object to float failed."
-                " Object type is not supported as input.",
+            pd.DataFrame({"hh_id": [1, "1", 2], "bruttolohn_m": ["2000", 3000, 4000]}),
+            {},
+            "The data types of the following columns are invalid: \n"
+            "\n - hh_id: Conversion from input type object to int failed. "
+            "Object type is not supported as input."
+            "\n - bruttolohn_m: Conversion from input type object to float failed."
+            " Object type is not supported as input.",
         ),
     ],
 )
 def test_fail_if_cannot_be_converted_to_correct_type(
-        data, functions_overridden, error_match
+    data, functions_overridden, error_match
 ):
     with pytest.raises(ValueError, match=error_match):
         _convert_data_to_correct_types(data, functions_overridden)

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -1,4 +1,3 @@
-from contextlib import ExitStack as does_not_raise  # noqa: N813
 
 import numpy
 import pandas as pd
@@ -78,7 +77,9 @@ def test_missing_root_nodes_raises_error(minimal_input_data):
         ValueError,
         match="The following data columns are missing",
     ):
-        compute_taxes_and_transfers(minimal_input_data, {}, functions=[b, c], targets="c")
+        compute_taxes_and_transfers(
+            minimal_input_data, {}, functions=[b, c], targets="c"
+        )
 
 
 def test_data_as_series():
@@ -135,7 +136,9 @@ def test_check_minimal_spec_data():
         ValueError,
         match="The following columns in 'data' are unused",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[c], targets="c", check_minimal_specification="raise")
+        compute_taxes_and_transfers(
+            data, {}, functions=[c], targets="c", check_minimal_specification="raise"
+        )
 
 
 def test_check_minimal_spec_data_warn():
@@ -154,7 +157,9 @@ def test_check_minimal_spec_data_warn():
         UserWarning,
         match="The following columns in 'data' are unused",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[c], targets="c", check_minimal_specification="warn")
+        compute_taxes_and_transfers(
+            data, {}, functions=[c], targets="c", check_minimal_specification="warn"
+        )
 
 
 def test_check_minimal_spec_columns_overriding():
@@ -176,7 +181,9 @@ def test_check_minimal_spec_columns_overriding():
         ValueError,
         match="The following 'columns_overriding_functions' are unused",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[b, c], targets="c", check_minimal_specification="raise")
+        compute_taxes_and_transfers(
+            data, {}, functions=[b, c], targets="c", check_minimal_specification="raise"
+        )
 
 
 def test_check_minimal_spec_columns_overriding_warn():
@@ -198,7 +205,9 @@ def test_check_minimal_spec_columns_overriding_warn():
         UserWarning,
         match="The following 'columns_overriding_functions' are unused",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[b, c], targets="c", check_minimal_specification="warn")
+        compute_taxes_and_transfers(
+            data, {}, functions=[b, c], targets="c", check_minimal_specification="warn"
+        )
 
 
 def test_function_without_data_dependency_is_not_mistaken_for_data(minimal_input_data):
@@ -218,7 +227,9 @@ def test_fail_if_targets_are_not_in_functions_or_in_columns_overriding_functions
         ValueError,
         match="The following targets have no corresponding function",
     ):
-        compute_taxes_and_transfers(minimal_input_data, {}, functions=[], targets="unknown_target")
+        compute_taxes_and_transfers(
+            minimal_input_data, {}, functions=[], targets="unknown_target"
+        )
 
 
 def test_fail_if_missing_pid(minimal_input_data):
@@ -311,8 +322,13 @@ def test_user_provided_aggregation_specs():
     }
     expected_res = pd.Series([200, 200, 100])
 
-    out = compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
-                                      targets="arbeitsl_geld_2_m_hh")
+    out = compute_taxes_and_transfers(
+        data,
+        {},
+        functions=[],
+        aggregation_specs=aggregation_specs,
+        targets="arbeitsl_geld_2_m_hh",
+    )
 
     numpy.testing.assert_array_almost_equal(out["arbeitsl_geld_2_m_hh"], expected_res)
 
@@ -336,8 +352,13 @@ def test_user_provided_aggregation_specs_function():
     def arbeitsl_geld_2_m_double(arbeitsl_geld_2_m):
         return 2 * arbeitsl_geld_2_m
 
-    out = compute_taxes_and_transfers(data, {}, functions=[arbeitsl_geld_2_m_double],
-                                      aggregation_specs=aggregation_specs, targets="arbeitsl_geld_2_m_double_hh")
+    out = compute_taxes_and_transfers(
+        data,
+        {},
+        functions=[arbeitsl_geld_2_m_double],
+        aggregation_specs=aggregation_specs,
+        targets="arbeitsl_geld_2_m_double_hh",
+    )
 
     numpy.testing.assert_array_almost_equal(
         out["arbeitsl_geld_2_m_double_hh"], expected_res
@@ -362,8 +383,13 @@ def test_aggregation_specs_missing_group_sufix():
         ValueError,
         match="Name of aggregated column needs to have a suffix",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
-                                    targets="arbeitsl_geld_2_m_agg")
+        compute_taxes_and_transfers(
+            data,
+            {},
+            functions=[],
+            aggregation_specs=aggregation_specs,
+            targets="arbeitsl_geld_2_m_agg",
+        )
 
 
 def test_aggregation_specs_agg_not_impl():
@@ -384,8 +410,13 @@ def test_aggregation_specs_agg_not_impl():
         ValueError,
         match="Aggr aggr_not_implemented is not implemented, yet.",
     ):
-        compute_taxes_and_transfers(data, {}, functions=[], aggregation_specs=aggregation_specs,
-                                    targets="arbeitsl_geld_2_m_hh")
+        compute_taxes_and_transfers(
+            data,
+            {},
+            functions=[],
+            aggregation_specs=aggregation_specs,
+            targets="arbeitsl_geld_2_m_hh",
+        )
 
 
 @pytest.mark.parametrize(

--- a/src/_gettsim_tests/test_interface.py
+++ b/src/_gettsim_tests/test_interface.py
@@ -1,4 +1,3 @@
-
 import numpy
 import pandas as pd
 import pytest

--- a/src/_gettsim_tests/test_kindergeld.py
+++ b/src/_gettsim_tests/test_kindergeld.py
@@ -22,7 +22,9 @@ def test_kindergeld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_kindergeld.py
+++ b/src/_gettsim_tests/test_kindergeld.py
@@ -5,8 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["_zu_verst_eink_ohne_kinderfreib_y_tu"]
-
 data = load_policy_test_data("kindergeld")
 
 
@@ -24,13 +22,7 @@ def test_kindergeld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_kinderzuschl.py
+++ b/src/_gettsim_tests/test_kinderzuschl.py
@@ -22,7 +22,9 @@ def test_kinderzuschl(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_kinderzuschl.py
+++ b/src/_gettsim_tests/test_kinderzuschl.py
@@ -5,15 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "_arbeitsl_geld_2_alleinerz_mehrbedarf_m_hh",
-    "kindergeld_m_hh",
-    "unterhaltsvors_m",
-    "kinderzuschl_bruttoeink_eltern_m",
-    "kinderzuschl_eink_eltern_m",
-    "kindergeld_anspruch",
-]
-
 data = load_policy_test_data("kinderzuschl")
 
 
@@ -31,13 +22,7 @@ def test_kinderzuschl(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_lohn_st.py
+++ b/src/_gettsim_tests/test_lohn_st.py
@@ -26,11 +26,6 @@ OUT_COLS = [
     # "soli_st_lohnst_m"
 ]
 
-OVERRIDE_COLS = [
-    "ges_krankenv_zusatzbeitr_satz",
-    "ges_pflegev_zusatz_kinderlos",
-]
-
 YEARS = [2022]
 
 data = load_policy_test_data("lohn_st")
@@ -50,13 +45,7 @@ def test_lohnsteuer(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=2
     )

--- a/src/_gettsim_tests/test_lohn_st.py
+++ b/src/_gettsim_tests/test_lohn_st.py
@@ -45,7 +45,9 @@ def test_lohnsteuer(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=2
     )

--- a/src/_gettsim_tests/test_renten_alter.py
+++ b/src/_gettsim_tests/test_renten_alter.py
@@ -28,12 +28,8 @@ def test_renten_alter(
         date=f"{year}-07-01"
     )
 
-    calc_result = compute_taxes_and_transfers(
-        data=merged_input_df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=targets,
-    )
+    calc_result = compute_taxes_and_transfers(data=merged_input_df, params=policy_params, functions=policy_functions,
+                                              targets=targets)
     assert_series_equal(
         calc_result[target], merged_output_df[target], atol=1e-1, rtol=0
     )

--- a/src/_gettsim_tests/test_renten_alter.py
+++ b/src/_gettsim_tests/test_renten_alter.py
@@ -28,8 +28,12 @@ def test_renten_alter(
         date=f"{year}-07-01"
     )
 
-    calc_result = compute_taxes_and_transfers(data=merged_input_df, params=policy_params, functions=policy_functions,
-                                              targets=targets)
+    calc_result = compute_taxes_and_transfers(
+        data=merged_input_df,
+        params=policy_params,
+        functions=policy_functions,
+        targets=targets,
+    )
     assert_series_equal(
         calc_result[target], merged_output_df[target], atol=1e-1, rtol=0
     )

--- a/src/_gettsim_tests/test_renten_anspr.py
+++ b/src/_gettsim_tests/test_renten_anspr.py
@@ -28,6 +28,8 @@ def test_renten_anspr(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(result[column], test_data.output_df[column], atol=1e-1, rtol=0)

--- a/src/_gettsim_tests/test_renten_anspr.py
+++ b/src/_gettsim_tests/test_renten_anspr.py
@@ -28,11 +28,6 @@ def test_renten_anspr(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(result[column], test_data.output_df[column], atol=1e-1, rtol=0)

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -48,8 +48,12 @@ def test_no_rounding_specs(rounding_specs):
         def test_func():
             return 0
 
-        compute_taxes_and_transfers(data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]), params=rounding_specs,
-                                    functions=[test_func], targets=["test_func"])
+        compute_taxes_and_transfers(
+            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
+            params=rounding_specs,
+            functions=[test_func],
+            targets=["test_func"],
+        )
 
 
 @pytest.mark.parametrize(
@@ -69,8 +73,12 @@ def test_rounding_specs_wrong_format(base, direction):
             }
         }
 
-        compute_taxes_and_transfers(data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]), params=rounding_specs,
-                                    functions=[test_func], targets=["test_func"])
+        compute_taxes_and_transfers(
+            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
+            params=rounding_specs,
+            functions=[test_func],
+            targets=["test_func"],
+        )
 
 
 @pytest.mark.parametrize(
@@ -93,8 +101,9 @@ def test_rounding(base, direction, input_values, exp_output):
         }
     }
 
-    calc_result = compute_taxes_and_transfers(data=data, params=rounding_specs, functions=[test_func],
-                                              targets=["test_func"])
+    calc_result = compute_taxes_and_transfers(
+        data=data, params=rounding_specs, functions=[test_func], targets=["test_func"]
+    )
     np.array_equal(calc_result["test_func"].values, np.array(exp_output))
 
 
@@ -116,8 +125,9 @@ def test_no_rounding(base, direction, input_values_exp_output, _ignore):
         }
     }
 
-    calc_result = compute_taxes_and_transfers(data=data, params=rounding_specs, functions=[test_func],
-                                              targets=["test_func"])
+    calc_result = compute_taxes_and_transfers(
+        data=data, params=rounding_specs, functions=[test_func], targets=["test_func"]
+    )
     np.array_equal(calc_result["test_func"].values, np.array(input_values_exp_output))
 
 

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -48,12 +48,8 @@ def test_no_rounding_specs(rounding_specs):
         def test_func():
             return 0
 
-        compute_taxes_and_transfers(
-            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
-            functions=[test_func],
-            params=rounding_specs,
-            targets=["test_func"],
-        )
+        compute_taxes_and_transfers(data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]), params=rounding_specs,
+                                    functions=[test_func], targets=["test_func"])
 
 
 @pytest.mark.parametrize(
@@ -73,12 +69,8 @@ def test_rounding_specs_wrong_format(base, direction):
             }
         }
 
-        compute_taxes_and_transfers(
-            data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]),
-            functions=[test_func],
-            params=rounding_specs,
-            targets=["test_func"],
-        )
+        compute_taxes_and_transfers(data=pd.DataFrame([{"p_id": 1}, {"p_id": 2}]), params=rounding_specs,
+                                    functions=[test_func], targets=["test_func"])
 
 
 @pytest.mark.parametrize(
@@ -101,12 +93,8 @@ def test_rounding(base, direction, input_values, exp_output):
         }
     }
 
-    calc_result = compute_taxes_and_transfers(
-        data=data,
-        functions=[test_func],
-        params=rounding_specs,
-        targets=["test_func"],
-    )
+    calc_result = compute_taxes_and_transfers(data=data, params=rounding_specs, functions=[test_func],
+                                              targets=["test_func"])
     np.array_equal(calc_result["test_func"].values, np.array(exp_output))
 
 
@@ -128,12 +116,8 @@ def test_no_rounding(base, direction, input_values_exp_output, _ignore):
         }
     }
 
-    calc_result = compute_taxes_and_transfers(
-        data=data,
-        functions=[test_func],
-        params=rounding_specs,
-        targets=["test_func"],
-    )
+    calc_result = compute_taxes_and_transfers(data=data, params=rounding_specs, functions=[test_func],
+                                              targets=["test_func"])
     np.array_equal(calc_result["test_func"].values, np.array(input_values_exp_output))
 
 

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -22,7 +22,9 @@ def test_soli_st(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -5,8 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["eink_st_mit_kinderfreib_y_tu", "abgelt_st_y_tu"]
-
 data = load_policy_test_data("soli_st")
 
 
@@ -24,13 +22,7 @@ def test_soli_st(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_sozialv_beitr.py
+++ b/src/_gettsim_tests/test_sozialv_beitr.py
@@ -5,8 +5,6 @@ from _gettsim.interface import compute_taxes_and_transfers
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["sum_ges_rente_priv_rente_m"]
-
 data = load_policy_test_data("sozialv_beitr")
 
 
@@ -24,13 +22,7 @@ def test_sozialv_beitr(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     pd.testing.assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_sozialv_beitr.py
+++ b/src/_gettsim_tests/test_sozialv_beitr.py
@@ -22,7 +22,9 @@ def test_sozialv_beitr(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     pd.testing.assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_unterhalt.py
+++ b/src/_gettsim_tests/test_unterhalt.py
@@ -22,7 +22,9 @@ def test_unterhalt(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_unterhalt.py
+++ b/src/_gettsim_tests/test_unterhalt.py
@@ -5,8 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["kindergeld_m"]
-
 data = load_policy_test_data("unterhalt")
 
 
@@ -24,13 +22,7 @@ def test_unterhalt(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_unterhaltsvors.py
+++ b/src/_gettsim_tests/test_unterhaltsvors.py
@@ -22,7 +22,9 @@ def test_unterhaltsvors(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_unterhaltsvors.py
+++ b/src/_gettsim_tests/test_unterhaltsvors.py
@@ -5,8 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = ["arbeitsl_geld_m", "sum_ges_rente_priv_rente_m"]
-
 data = load_policy_test_data("unterhaltsvors")
 
 
@@ -24,13 +22,7 @@ def test_unterhaltsvors(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], check_dtype=False, atol=0, rtol=0

--- a/src/_gettsim_tests/test_vorsorgeaufw.py
+++ b/src/_gettsim_tests/test_vorsorgeaufw.py
@@ -22,7 +22,9 @@ def test_vorsorgeaufw(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column], test_data.output_df[column], atol=1, rtol=0, check_dtype=False

--- a/src/_gettsim_tests/test_vorsorgeaufw.py
+++ b/src/_gettsim_tests/test_vorsorgeaufw.py
@@ -5,13 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "ges_krankenv_beitr_m",
-    "arbeitsl_v_beitr_m",
-    "ges_pflegev_beitr_m",
-    "ges_rentenv_beitr_m",
-]
-
 data = load_policy_test_data("vorsorgeaufw")
 
 
@@ -29,13 +22,7 @@ def test_vorsorgeaufw(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column], test_data.output_df[column], atol=1, rtol=0, check_dtype=False

--- a/src/_gettsim_tests/test_wohngeld.py
+++ b/src/_gettsim_tests/test_wohngeld.py
@@ -22,7 +22,9 @@ def test_wohngeld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     if column == "wohngeld_eink_m":
         result[column] = result[column].round(1)

--- a/src/_gettsim_tests/test_wohngeld.py
+++ b/src/_gettsim_tests/test_wohngeld.py
@@ -5,21 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "elterngeld_m",
-    "arbeitsl_geld_m",
-    "rente_ertragsanteil",
-    "eink_abhängig_beschäftigt_y",
-    "eink_st_y_tu",
-    "ges_krankenv_beitr_m",
-    "ges_rentenv_beitr_m",
-    "kindergeld_anspruch",
-    "sum_ges_rente_priv_rente_m",
-    "kapitaleink_brutto_y",
-    "haushaltsgröße_hh",
-    "unterhaltsvors_m",
-]
-
 data = load_policy_test_data("wohngeld")
 
 
@@ -37,13 +22,7 @@ def test_wohngeld(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     if column == "wohngeld_eink_m":
         result[column] = result[column].round(1)

--- a/src/_gettsim_tests/test_zu_verst_eink.py
+++ b/src/_gettsim_tests/test_zu_verst_eink.py
@@ -22,7 +22,9 @@ def test_zu_verst_eink(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
+    result = compute_taxes_and_transfers(
+        data=df, params=policy_params, functions=policy_functions, targets=column
+    )
 
     assert_series_equal(
         result[column],

--- a/src/_gettsim_tests/test_zu_verst_eink.py
+++ b/src/_gettsim_tests/test_zu_verst_eink.py
@@ -5,11 +5,6 @@ from pandas.testing import assert_series_equal
 from _gettsim_tests._helpers import cached_set_up_policy_environment
 from _gettsim_tests._policy_test_utils import PolicyTestData, load_policy_test_data
 
-OVERRIDE_COLS = [
-    "sum_ges_rente_priv_rente_m",
-    "vorsorgeaufw_y_tu",
-]
-
 data = load_policy_test_data("zu_verst_eink")
 
 
@@ -27,13 +22,7 @@ def test_zu_verst_eink(
         date=test_data.date
     )
 
-    result = compute_taxes_and_transfers(
-        data=df,
-        params=policy_params,
-        functions=policy_functions,
-        targets=column,
-        columns_overriding_functions=OVERRIDE_COLS,
-    )
+    result = compute_taxes_and_transfers(data=df, params=policy_params, functions=policy_functions, targets=column)
 
     assert_series_equal(
         result[column],

--- a/src/gettsim/__init__.py
+++ b/src/gettsim/__init__.py
@@ -24,7 +24,10 @@ from _gettsim import (
     transfers,
     visualization,
 )
-from _gettsim.interface import compute_taxes_and_transfers
+from _gettsim.interface import (
+    FunctionsAndColumnsOverlapWarning,
+    compute_taxes_and_transfers,
+)
 from _gettsim.policy_environment import set_up_policy_environment
 from _gettsim.synthetic import create_synthetic_data
 from _gettsim.visualization import plot_dag
@@ -49,6 +52,7 @@ def test(*args):
 
 __all__ = [
     "__version__",
+    "FunctionsAndColumnsOverlapWarning",
     "compute_taxes_and_transfers",
     "set_up_policy_environment",
     "plot_dag",


### PR DESCRIPTION
### What problem do you want to solve?

Relates to #378.

Previously, users had to explicitly pass the `columns_overriding_functions` to `compute_taxes_and_transfers`. They had to follow some rules, however:

1. All columns that were in the `data` and in `functions` (or one of the derived functions for other time units #583 or groupings #601) must be included.
2. Only columns that were in the `data` must be included.
3. Only columns that were in `functions` (or one of the derived functions for other time units #583 or groupings #601) must be included.

The result was that the user had to specify exactly the columns in the data that clash with any function; otherwise an error would be raised. Once that user had succeeded with this guessing game, which became more difficult with the introduction of derived functions, the result would be that the values in the column would be used, and the corresponding function would not be executed. 

It was also difficult to specify `columns_overriding_functions` for our tests that target many different years. During some periods, a function might not exist yet, so we needed to manually create different `columns_overriding_functions` lists for those different periods (e.g. https://github.com/iza-institute-of-labor-economics/gettsim/blob/91b36477c861bb9c4fe3ede4a5924f24dcc20ef2/src/_gettsim_tests/test_full_taxes_and_transfers.py#L90)

This PR removes the `columns_overriding_functions` parameter from `compute_taxes_and_transfers` and instead derives it automatically using the rules defined above.

See also: https://github.com/iza-institute-of-labor-economics/gettsim/issues/378#issuecomment-1613164091

### Todo

- [x] Pick an appropriate title.
- [x] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
