### PR TITLE
Use max() instead of explicit if

### DIFF
--- a/docs/geps/gep-04.md
+++ b/docs/geps/gep-04.md
@@ -112,8 +112,7 @@ def soli_st_y_tu(
     anz_erwachsene_tu: int,
     abgelt_st_y_tu: float,
     soli_st_params: dict,
-) -> float:
-    ...
+) -> float: ...
 ```
 
 may use `abgelt_st_y_tu` as an input argument. The DAG backend ensures that the function
@@ -259,8 +258,7 @@ By including `kindergeld_m_hh` as an argument in the definition of
 `arbeitsl_geld_2_m_bg` as follows:
 
 ```python
-def arbeitsl_geld_2_m_bg(kindergeld_m_hh, other_arguments):
-    ...
+def arbeitsl_geld_2_m_bg(kindergeld_m_hh, other_arguments): ...
 ```
 
 a node `kindergeld_m_hh` containing the household-level sum of `kindergeld_m` will be

--- a/src/_gettsim/taxes/zu_verst_eink/freibetraege.py
+++ b/src/_gettsim/taxes/zu_verst_eink/freibetraege.py
@@ -273,10 +273,7 @@ def eink_st_sonderausgaben_y_tu_mit_betreuung(
         * anz_erwachsene_tu
     )
 
-    if sonderausgaben_gesamt > pauschale:
-        out = sonderausgaben_gesamt
-    else:
-        out = pauschale
+    out = max(sonderausgaben_gesamt, pauschale)
 
     return float(out)
 


### PR DESCRIPTION
max() and min() are frequently used in the code base, so it would be more uniform to do the same here.

