### PR TITLE
minor fixes to doc

### DIFF
--- a/docs/tutorials/advanced_usage.ipynb
+++ b/docs/tutorials/advanced_usage.ipynb
@@ -54,15 +54,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "policy_params[\"wohngeld\"]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/tutorials/basic_usage.ipynb
+++ b/docs/tutorials/basic_usage.ipynb
@@ -168,7 +168,7 @@
     "\n",
     "The data has to fulfill certain requirements in order for GETTSIM to be able to process it properly. Specifically, GETTSIM requires data to be specified as a [pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) with  columns marking different input variables. GETTSIM parses the column names, which means that the data columns must be named in a specific way for GETTSIM to recognize them as input variables.\n",
     "\n",
-    "There are a total of 45 input names that GETTSIM recognizes, as especially transfers in the German system depend on many different variables. There is a detailed list of them [here](https://gettsim.readthedocs.io/en/latest/gettsim_objects/variables.html). The information specified in these inputs can be used to compute taxes and transfers for the selected household, tax unit, or individual data. The required inputs depend on the desired outputs i.e. the data set does not necessarily have to contain all 45 input variables. A small example is illustrated below. \n",
+    "There are a total of 45 input names that GETTSIM recognizes, as especially transfers in the German system depend on many different variables. There is a detailed list of them [here](https://gettsim.readthedocs.io/en/latest/gettsim_objects/input_variables.html). The information specified in these inputs can be used to compute taxes and transfers for the selected household, tax unit, or individual data. The required inputs depend on the desired outputs i.e. the data set does not necessarily have to contain all 45 input variables. A small example is illustrated below. \n",
     "\n",
     "#### Exemplary Data Set\n",
     "\n",


### PR DESCRIPTION
### What problem do you want to solve?

- there was a dead link in the doc
- there was an unnecessary cell from my understanding of the docs
   - While the cell does show that kinderfreibetraege are used in wohngeld
the the rest of the documentation doesnt go into wohngeld at all.
imo this isn't helpful in understanding kindergeld and more importantly
distracting from the example.

also cool thanks for your work and having this be open source!