### PR TITLE
Data columns overwrite functions regardless of time unit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
-- {gh}`700` Data columns overwrite functions regardless of time unit ({ghuser}`lars-reimann`).
+- {gh}`700` Data columns overwrite functions regardless of time unit
+  ({ghuser}`lars-reimann`).
 - {gh}`676` Add explicit parent-child links. ({ghuser}`MImmesberger`).
 - {gh}`684` New Issue template for yearly parameter updates. ({ghuser}`MImmesberger`).
 - {gh}`680` 2024 Parameter Update ({ghuser}`Eric-Sommer`, {ghuser}`MImmesberger`)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`700` Data columns overwrite functions regardless of time unit ({ghuser}`lars-reimann`).
 - {gh}`676` Add explicit parent-child links. ({ghuser}`MImmesberger`).
 - {gh}`684` New Issue template for yearly parameter updates. ({ghuser}`MImmesberger`).
 - {gh}`680` 2024 Parameter Update ({ghuser}`Eric-Sommer`, {ghuser}`MImmesberger`)

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -272,19 +272,23 @@ def create_time_conversion_functions(
 
     # Create time-conversions for existing functions
     for name, func in functions.items():
-        result.update({
-            name: func
-            for name, func in _create_time_conversion_functions(name, func).items()
-            if name not in functions and name not in data_cols
-        })
+        result.update(
+            {
+                name: func
+                for name, func in _create_time_conversion_functions(name, func).items()
+                if name not in functions and name not in data_cols
+            }
+        )
 
     # Create time-conversions for data columns and overwrite existing functions
     for name in data_cols:
-        result.update({
-            name: func
-            for name, func in _create_time_conversion_functions(name).items()
-            if name not in data_cols
-        })
+        result.update(
+            {
+                name: func
+                for name, func in _create_time_conversion_functions(name).items()
+                if name not in data_cols
+            }
+        )
 
     return result
 

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -270,17 +270,23 @@ def create_time_conversion_functions(
 
     result = {}
 
+    # Create time-conversions for existing functions
     for name, func in functions.items():
-        result.update(_create_time_conversion_functions(name, func))
+        result.update({
+            name: func
+            for name, func in _create_time_conversion_functions(name, func).items()
+            if name not in functions and name not in data_cols
+        })
 
+    # Create time-conversions for data columns and overwrite existing functions
     for name in data_cols:
-        result.update(_create_time_conversion_functions(name))
+        result.update({
+            name: func
+            for name, func in _create_time_conversion_functions(name).items()
+            if name not in data_cols
+        })
 
-    return {
-        name: func
-        for name, func in result.items()
-        if name not in functions and name not in data_cols
-    }
+    return result
 
 
 def _create_time_conversion_functions(

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -204,7 +204,7 @@ class TestCreateFunctionsForTimeUnits:
         for expected_name in expected:
             assert expected_name in time_conversion_functions
 
-    def test_should_not_create_functions_that_exist_already(self) -> None:
+    def test_should_not_create_functions_automatically_that_exist_already(self) -> None:
         time_conversion_functions = create_time_conversion_functions(
             {"test1_d": lambda: 1}, ["test2_y"]
         )
@@ -212,7 +212,7 @@ class TestCreateFunctionsForTimeUnits:
         assert "test1_d" not in time_conversion_functions
         assert "test2_y" not in time_conversion_functions
 
-    def test_should_overwrite_functions_with_data_cols(self) -> None:
+    def test_should_overwrite_functions_with_data_cols_that_only_differ_in_time_period(self) -> None:
         time_conversion_functions = create_time_conversion_functions(
             {"test_d": lambda: 1}, ["test_y"]
         )

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -212,7 +212,9 @@ class TestCreateFunctionsForTimeUnits:
         assert "test1_d" not in time_conversion_functions
         assert "test2_y" not in time_conversion_functions
 
-    def test_should_overwrite_functions_with_data_cols_that_only_differ_in_time_period(self) -> None:
+    def test_should_overwrite_functions_with_data_cols_that_only_differ_in_time_period(
+        self,
+    ) -> None:
         time_conversion_functions = create_time_conversion_functions(
             {"test_d": lambda: 1}, ["test_y"]
         )

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -206,11 +206,18 @@ class TestCreateFunctionsForTimeUnits:
 
     def test_should_not_create_functions_that_exist_already(self) -> None:
         time_conversion_functions = create_time_conversion_functions(
+            {"test1_d": lambda: 1}, ["test2_y"]
+        )
+
+        assert "test1_d" not in time_conversion_functions
+        assert "test2_y" not in time_conversion_functions
+
+    def test_should_overwrite_functions_with_data_cols(self) -> None:
+        time_conversion_functions = create_time_conversion_functions(
             {"test_d": lambda: 1}, ["test_y"]
         )
 
-        assert "test_y" not in time_conversion_functions
-        assert "test_d" not in time_conversion_functions
+        assert "test_d" in time_conversion_functions
 
 
 class TestCreateFunctionForTimeUnit:


### PR DESCRIPTION
### What problem do you want to solve?

Closes #699

Data columns now always overwrite policy functions regardless of their time unit. If, for example, the value `eink_st_y_sn` is needed, and a data column `eink_st_m_sn` and policy function `eink_st_y_sn` are provided, the converted data column is used.

### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
