### PR TITLE
Fix time conversion after rounding

### DIFF
--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -351,6 +351,11 @@ def _create_function_for_time_unit(
         return converter(x)
 
     if info is not None:
-        func.__info__ = info
+        # The derived function should not be rounded (see #712)
+        func.__info__ = {
+            key: value
+            for key, value in info.items()
+            if key != "rounding_params_key"
+        }
 
     return func

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -3,6 +3,8 @@ import datetime
 import pandas as pd
 import pytest
 import yaml
+from pandas._testing import assert_series_equal
+
 from _gettsim.config import (
     INTERNAL_PARAMS_GROUPS,
     PATHS_TO_INTERNAL_FUNCTIONS,
@@ -132,7 +134,7 @@ def test_rounding(base, direction, to_add_after_rounding, input_values, exp_outp
     calc_result = compute_taxes_and_transfers(
         data=data, params=rounding_specs, functions=[test_func], targets=["test_func"]
     )
-    np.array_equal(calc_result["test_func"].values, np.array(exp_output))
+    assert_series_equal(calc_result["test_func"], pd.Series(exp_output), check_names=False)
 
 
 @pytest.mark.parametrize(
@@ -161,9 +163,13 @@ def test_no_rounding(
         ] = to_add_after_rounding
 
     calc_result = compute_taxes_and_transfers(
-        data=data, params=rounding_specs, functions=[test_func], targets=["test_func"]
+        data=data,
+        params=rounding_specs,
+        functions=[test_func],
+        targets=["test_func"],
+        rounding=False
     )
-    np.array_equal(calc_result["test_func"].values, np.array(input_values_exp_output))
+    assert_series_equal(calc_result["test_func"], pd.Series(input_values_exp_output), check_names=False)
 
 
 @pytest.mark.parametrize(
@@ -187,7 +193,7 @@ def test_rounding_callable(
         to_add_after_rounding=to_add_after_rounding if to_add_after_rounding else 0,
     )(test_func)
 
-    np.array_equal(func_with_rounding(pd.Series(input_values)), np.array(exp_output))
+    assert_series_equal(func_with_rounding(pd.Series(input_values)), pd.Series(exp_output), check_names=False)
 
 
 def test_decorator_for_all_functions_with_rounding_spec():

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -137,6 +137,35 @@ def test_rounding(base, direction, to_add_after_rounding, input_values, exp_outp
     assert_series_equal(calc_result["test_func"], pd.Series(exp_output), check_names=False)
 
 
+def test_rounding_with_time_conversion():
+    """Check if rounding is correct for time-converted functions."""
+
+    # Define function that should be rounded
+    @add_rounding_spec(params_key="params_key_test")
+    def test_func_m(income):
+        return income
+
+    data = pd.DataFrame({
+        "p_id": [1, 2],
+        "income": [1.2, 1.5]
+    })
+    rounding_specs = {
+        "params_key_test": {
+            "rounding": {
+                "test_func_m": {
+                    "base": 1,
+                    "direction": "down",
+                }
+            }
+        }
+    }
+
+    calc_result = compute_taxes_and_transfers(
+        data=data, params=rounding_specs, functions=[test_func_m], targets=["test_func_y"]
+    )
+    assert_series_equal(calc_result["test_func_y"], pd.Series([12.0, 12.0]), check_names=False)
+
+
 @pytest.mark.parametrize(
     "base, direction, to_add_after_rounding, input_values_exp_output, _ignore",
     rounding_specs_and_exp_results,


### PR DESCRIPTION
### What problem do you want to solve?

Closes #712

Previously, deriving a time-converted function from a rounded function lead to the following error:

```txt
KeyError: Rounding specifications for function test_func_y are expected in the parameter dictionary 
at ['params_key_test']['rounding']['test_func_y']. These nested keys do not exist. 
If this function should not be rounded, remove the respective decorator.
```

This PR fixes this.

### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [ ] Document PR in CHANGES.md.
