### PR TITLE
Optionally skip vectorization of a policy function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`721` Optionally skip vectorization of a policy function ({ghuser}`lars-reimann`).
 - {gh}`720` Combined decorator for policy information ({ghuser}`lars-reimann`).
 - {gh}`700` Data columns overwrite functions regardless of time unit
   ({ghuser}`lars-reimann`).

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -775,6 +775,10 @@ def _create_one_aggregate_by_p_id_func(
 
 
 def _vectorize_func(func):
+    # If the function is already vectorized, return it as is
+    if hasattr(func, "__info__") and func.__info__.get("is_vectorized", False):
+        return func
+
     # What should work once that Jax backend is fully supported
     signature = inspect.signature(func)
     func_vec = numpy.vectorize(func)

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -25,6 +25,7 @@ def policy_info(
     end_date: str = "9999-12-31",
     name_in_dag: str | None = None,
     params_key_for_rounding: str | None = None,
+    is_vectorized: bool = False,
 ) -> Callable:
     """
     A decorator to attach additional information to a policy function.
@@ -56,6 +57,8 @@ def policy_info(
         Key of the parameters dictionary where rounding specifications are found. For
         functions that are not user-written this is just the name of the respective
         .yaml file.
+    is_vectorized
+        Whether the function is already vectorized.
 
     Returns
     -------
@@ -87,6 +90,7 @@ def policy_info(
         func.__info__["name_in_dag"] = dag_key
         if params_key_for_rounding is not None:
             func.__info__["params_key_for_rounding"] = params_key_for_rounding
+        func.__info__["is_vectorized"] = is_vectorized
 
         # Register time-dependent function
         if dag_key not in TIME_DEPENDENT_FUNCTIONS:

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -25,7 +25,7 @@ def policy_info(
     end_date: str = "9999-12-31",
     name_in_dag: str | None = None,
     params_key_for_rounding: str | None = None,
-    is_vectorized: bool = False,
+    skip_vectorization: bool = False,
 ) -> Callable:
     """
     A decorator to attach additional information to a policy function.
@@ -57,8 +57,9 @@ def policy_info(
         Key of the parameters dictionary where rounding specifications are found. For
         functions that are not user-written this is just the name of the respective
         .yaml file.
-    is_vectorized
-        Whether the function is already vectorized.
+    skip_vectorization
+        Whether the function is already vectorized and, thus, should not be vectorized
+        again.
 
     Returns
     -------
@@ -90,7 +91,7 @@ def policy_info(
         func.__info__["name_in_dag"] = dag_key
         if params_key_for_rounding is not None:
             func.__info__["params_key_for_rounding"] = params_key_for_rounding
-        func.__info__["is_vectorized"] = is_vectorized
+        func.__info__["is_vectorized"] = skip_vectorization
 
         # Register time-dependent function
         if dag_key not in TIME_DEPENDENT_FUNCTIONS:

--- a/src/_gettsim_tests/test_functions_loader.py
+++ b/src/_gettsim_tests/test_functions_loader.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pytest
 from _gettsim.config import RESOURCE_DIR
-from _gettsim.functions_loader import _create_derived_functions, _load_functions
+from _gettsim.functions_loader import (
+    _create_derived_functions,
+    _load_functions,
+    _vectorize_func,
+)
+from _gettsim.shared import policy_info
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -81,3 +87,28 @@ def test_create_derived_functions(
 
     for name in targets:
         assert name in derived_functions
+
+
+# vectorize_func --------------------------------------------------------------
+
+
+def scalar_func(x: int) -> int:
+    return x * 2
+
+
+@policy_info(is_vectorized=True)
+def already_vectorized_func(x: np.ndarray) -> np.ndarray:
+    return np.asarray([xi * 2 for xi in x])
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        scalar_func,
+        already_vectorized_func,
+    ],
+)
+def test_vectorize_func(function: Callable) -> None:
+    vectorized_func = _vectorize_func(function)
+
+    assert np.array_equal(vectorized_func(np.array([1, 2, 3])), np.array([2, 4, 6]))

--- a/src/_gettsim_tests/test_functions_loader.py
+++ b/src/_gettsim_tests/test_functions_loader.py
@@ -96,7 +96,7 @@ def scalar_func(x: int) -> int:
     return x * 2
 
 
-@policy_info(is_vectorized=True)
+@policy_info(skip_vectorization=True)
 def already_vectorized_func(x: np.ndarray) -> np.ndarray:
     return np.asarray([xi * 2 for xi in x])
 


### PR DESCRIPTION
### What problem do you want to solve?

Related to #708

Add a new parameter `is_vectorized` to the `policy_info` decorator to indicate that a function is already vectorized. In that case, it is not vectorized again.


### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
