### PR TITLE
Join columns to make target columns available at source level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`722` Join columns to make target columns available at source level
+  ({ghuser}`lars-reimann`).
 - {gh}`732` Change wealth input variable to individual-level (`vermögen_bedürft`)
   ({ghuser}`ChristianZimpelmann`).
 - {gh}`730` Add argument to create_synthetic_data on whether adults are married.

--- a/src/_gettsim/functions_loader.py
+++ b/src/_gettsim/functions_loader.py
@@ -776,7 +776,7 @@ def _create_one_aggregate_by_p_id_func(
 
 def _vectorize_func(func):
     # If the function is already vectorized, return it as is
-    if hasattr(func, "__info__") and func.__info__.get("is_vectorized", False):
+    if hasattr(func, "__info__") and func.__info__.get("skip_vectorization", False):
         return func
 
     # What should work once that Jax backend is fully supported

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -292,8 +292,8 @@ def join_numpy(
     """
     if len(np.unique(primary_key)) != len(primary_key):
         keys, counts = np.unique(primary_key, return_counts=True)
-        duplicate_foreign_keys = keys[counts > 1]
-        raise ValueError(f"Duplicate primary keys: {duplicate_foreign_keys}")
+        duplicate_primary_keys = keys[counts > 1]
+        raise ValueError(f"Duplicate primary keys: {duplicate_primary_keys}")
 
     try:
         sorter = np.argsort(primary_key)

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -94,7 +94,7 @@ def policy_info(
         func.__info__["name_in_dag"] = dag_key
         if params_key_for_rounding is not None:
             func.__info__["params_key_for_rounding"] = params_key_for_rounding
-        func.__info__["is_vectorized"] = skip_vectorization
+        func.__info__["skip_vectorization"] = skip_vectorization
 
         # Register time-dependent function
         if dag_key not in TIME_DEPENDENT_FUNCTIONS:

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -5,14 +5,6 @@ import numpy as np
 
 from _gettsim.shared import join_numpy, policy_info
 
-aggregate_by_group_id_unterhaltsvors = {
-    "_unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg": {
-        "group_id_to_aggregate_by": "fg_id",
-        "source_col": "_unterhaltsvorschuss_eink_above_income_threshold",
-        "aggr": "any",
-    },
-}
-
 aggregate_by_p_id_unterhaltsvors = {
     "_unterhaltsvors_anspruch_eltern_m": {
         "p_id_to_aggregate_by": "p_id_kindergeld_empf",
@@ -112,7 +104,7 @@ def _kindergeld_erstes_kind_gestaffelt_m(
 
 def _unterhaltsvors_anspruch_pro_kind_m(
     alter: int,
-    _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg: bool,
+    _unterhaltsvorschuss_empf_eink_above_income_threshold: bool,
     _kindergeld_erstes_kind_m: float,
     unterhalt_params: dict,
     unterhaltsvors_params: dict,
@@ -123,8 +115,8 @@ def _unterhaltsvors_anspruch_pro_kind_m(
     ----------
     alter
         See basic input variable :ref:`alter <alter>`.
-    _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg
-        See :func:`_unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg`.
+    _unterhaltsvorschuss_empf_eink_above_income_threshold
+        See :func:`_unterhaltsvorschuss_empf_eink_above_income_threshold`.
     _kindergeld_erstes_kind_m
         See :func:`_kindergeld_erstes_kind_m`.
     unterhalt_params
@@ -152,7 +144,7 @@ def _unterhaltsvors_anspruch_pro_kind_m(
     if (
         out > 0
         and (alter >= unterhaltsvors_params["altersgrenze_mindesteinkommen"])
-        and (not _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg)
+        and (not _unterhaltsvorschuss_empf_eink_above_income_threshold)
     ):
         out = 0.0
 
@@ -160,11 +152,25 @@ def _unterhaltsvors_anspruch_pro_kind_m(
 
 
 @policy_info(skip_vectorization=True)
-def _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg(
+def _unterhaltsvorschuss_empf_eink_above_income_threshold(
     p_id_kindergeld_empf: np.ndarray[int],
     p_id: np.ndarray[int],
     _unterhaltsvorschuss_eink_above_income_threshold: np.ndarray[bool],
 ) -> np.ndarray[bool]:
+    """Income of Unterhaltsvorschuss recipient above threshold.
+
+    Parameters
+    ----------
+    p_id_kindergeld_empf
+        See basic input variable :ref:`p_id_kindergeld_empf`.
+    p_id
+        See basic input variable :ref:`p_id`.
+    _unterhaltsvorschuss_eink_above_income_threshold
+        See :func:`_unterhaltsvorschuss_eink_above_income_threshold`.
+
+    Returns
+    -------
+    """
     return join_numpy(
         p_id_kindergeld_empf, p_id, _unterhaltsvorschuss_eink_above_income_threshold
     )

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -1,10 +1,11 @@
 """This module provides functions to compute advance alimony payments
 (Unterhaltsvorschuss)."""
+import numpy as np
 
-from _gettsim.shared import policy_info
+from _gettsim.shared import join_numpy, policy_info
 
 aggregate_by_group_id_unterhaltsvors = {
-    "_unterhaltsvorschuss_eink_above_income_threshold_fg": {
+    "_unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg": {
         "group_id_to_aggregate_by": "fg_id",
         "source_col": "_unterhaltsvorschuss_eink_above_income_threshold",
         "aggr": "any",
@@ -110,7 +111,7 @@ def _kindergeld_erstes_kind_gestaffelt_m(
 
 def _unterhaltsvors_anspruch_pro_kind_m(
     alter: int,
-    _unterhaltsvorschuss_eink_above_income_threshold_fg: bool,
+    _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg: bool,
     _kindergeld_erstes_kind_m: float,
     unterhalt_params: dict,
     unterhaltsvors_params: dict,
@@ -121,8 +122,8 @@ def _unterhaltsvors_anspruch_pro_kind_m(
     ----------
     alter
         See basic input variable :ref:`alter <alter>`.
-    _unterhaltsvorschuss_eink_above_income_threshold_fg
-        See :func:`_unterhaltsvorschuss_eink_above_income_threshold_fg`.
+    _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg
+        See :func:`_unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg`.
     _kindergeld_erstes_kind_m
         See :func:`_kindergeld_erstes_kind_m`.
     unterhalt_params
@@ -150,11 +151,24 @@ def _unterhaltsvors_anspruch_pro_kind_m(
     if (
         out > 0
         and (alter >= unterhaltsvors_params["altersgrenze_mindesteinkommen"])
-        and (not _unterhaltsvorschuss_eink_above_income_threshold_fg)
+        and (not _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg)
     ):
         out = 0.0
 
     return out
+
+
+@policy_info(skip_vectorization=True)
+def _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg(
+    p_id_kindergeld_empf: np.ndarray[int],
+    p_id: np.ndarray[int],
+    _unterhaltsvorschuss_eink_above_income_threshold: np.ndarray[bool]
+) -> np.ndarray[bool]:
+    return join_numpy(
+        p_id_kindergeld_empf,
+        p_id,
+        _unterhaltsvorschuss_eink_above_income_threshold
+    )
 
 
 def _unterhaltsvorschuss_eink_above_income_threshold(

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -1,5 +1,6 @@
 """This module provides functions to compute advance alimony payments
 (Unterhaltsvorschuss)."""
+
 import numpy as np
 
 from _gettsim.shared import join_numpy, policy_info
@@ -162,12 +163,10 @@ def _unterhaltsvors_anspruch_pro_kind_m(
 def _unterhaltsvorschuss_kindergeld_empf_eink_above_income_threshold_fg(
     p_id_kindergeld_empf: np.ndarray[int],
     p_id: np.ndarray[int],
-    _unterhaltsvorschuss_eink_above_income_threshold: np.ndarray[bool]
+    _unterhaltsvorschuss_eink_above_income_threshold: np.ndarray[bool],
 ) -> np.ndarray[bool]:
     return join_numpy(
-        p_id_kindergeld_empf,
-        p_id,
-        _unterhaltsvorschuss_eink_above_income_threshold
+        p_id_kindergeld_empf, p_id, _unterhaltsvorschuss_eink_above_income_threshold
     )
 
 

--- a/src/_gettsim_tests/test_docs.py
+++ b/src/_gettsim_tests/test_docs.py
@@ -136,6 +136,9 @@ def test_type_hints():  # noqa: PLR0912
 
     return_types = {}
     for name, func in functions.items():
+        if hasattr(func, "__info__") and func.__info__["skip_vectorization"]:
+            continue
+
         for var, internal_type in func.__annotations__.items():
             if var == "return":
                 output_name = time_dependent_functions.get(name, name)

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -36,10 +36,10 @@ def test_join_numpy(
 
 
 def test_join_numpy_raises_duplicate_primary_key():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Duplicate primary keys:"):
         join_numpy(np.array([1, 1, 1]), np.array([1, 1, 1]), np.array(["a", "b", "c"]))
 
 
 def test_join_numpy_raises_invalid_foreign_key():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid foreign keys:"):
         join_numpy(np.array([2]), np.array([1]), np.array(["a"]))

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+from _gettsim.shared import join_numpy
+
+
+@pytest.mark.parametrize(
+    "foreign_key, primary_key, target, expected",
+    [
+        (
+            np.array([1, 2, 3]),
+            np.array([1, 2, 3]),
+            np.array(["a", "b", "c"]),
+            np.array(["a", "b", "c"]),
+        ),
+        (
+            np.array([3, 2, 1]),
+            np.array([1, 2, 3]),
+            np.array(["a", "b", "c"]),
+            np.array(["c", "b", "a"]),
+        ),
+        (
+            np.array([1, 1, 1]),
+            np.array([1, 2, 3]),
+            np.array(["a", "b", "c"]),
+            np.array(["a", "a", "a"]),
+        ),
+    ],
+)
+def test_join_numpy(
+    foreign_key: np.ndarray[int],
+    primary_key: np.ndarray[int],
+    target: np.ndarray[str],
+    expected: np.ndarray[str],
+):
+    assert np.array_equal(join_numpy(foreign_key, primary_key, target), expected)
+
+
+def test_join_numpy_raises_duplicate_primary_key():
+    with pytest.raises(ValueError):
+        join_numpy(np.array([1, 1, 1]), np.array([1, 1, 1]), np.array(["a", "b", "c"]))
+
+
+def test_join_numpy_raises_invalid_foreign_key():
+    with pytest.raises(ValueError):
+        join_numpy(np.array([2]), np.array([1]), np.array(["a"]))


### PR DESCRIPTION
### What problem do you want to solve?

Closes #708

Add a `join_numpy` function to make target columns available at the source level. 

The function gets
* Foreign keys,
* Primary keys,
* Targets in the same order as the primary key.

It then maps each foreign key to the associated target. Primary keys must be unique and foreign keys must point to some primary key.

### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
