### PR TITLE
fix: fall back to default value if foreign key of `join_numpy` is unresolved

### DIFF
--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -303,7 +303,7 @@ def join_numpy(
     invalid_foreign_keys = foreign_key[
         (foreign_key >= 0) & (~np.isin(foreign_key, primary_key))
     ]
-    print(invalid_foreign_keys)
+
     if len(invalid_foreign_keys) > 0:
         raise ValueError(f"Invalid foreign keys: {invalid_foreign_keys}")
 

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -300,6 +300,13 @@ def join_numpy(
         duplicate_primary_keys = keys[counts > 1]
         raise ValueError(f"Duplicate primary keys: {duplicate_primary_keys}")
 
+    invalid_foreign_keys = foreign_key[
+        (foreign_key >= 0) & (~np.isin(foreign_key, primary_key))
+    ]
+    print(invalid_foreign_keys)
+    if len(invalid_foreign_keys) > 0:
+        raise ValueError(f"Invalid foreign keys: {invalid_foreign_keys}")
+
     # For each foreign key and for each primary key, check if they match
     matches_foreign_key = foreign_key[:, None] == primary_key
 

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -273,7 +273,7 @@ def join_numpy(
     foreign_key: np.ndarray[Key],
     primary_key: np.ndarray[Key],
     target: np.ndarray[Out],
-    default: Out,
+    value_for_unresolved_foreign_key: Out,
 ) -> np.ndarray[Out]:
     """
     Given a foreign key, find the corresponding primary key, and return the target at
@@ -287,8 +287,8 @@ def join_numpy(
         The primary keys.
     target : np.ndarray[Out]
         The targets in the same order as the primary keys.
-    default : Out
-        The default value to return if no match is found.
+    value_for_unresolved_foreign_key : Out
+        The value to return if no matching primary key is found.
 
     Returns
     -------
@@ -311,16 +311,18 @@ def join_numpy(
     matches_foreign_key = foreign_key[:, None] == primary_key
 
     # For each foreign key, add a column with True at the end, to later fall back to
-    # the default
+    # the value for unresolved foreign keys
     padded_matches_foreign_key = np.pad(
         matches_foreign_key, ((0, 0), (0, 1)), "constant", constant_values=True
     )
 
-    # For ech foreign key, compute the index of the first matching primary key
+    # For each foreign key, compute the index of the first matching primary key
     indices = np.argmax(padded_matches_foreign_key, axis=1)
 
-    # Add the default target at the end
-    padded_targets = np.pad(target, (0, 1), "constant", constant_values=default)
+    # Add the value for unresolved foreign keys at the end of the target array
+    padded_targets = np.pad(
+        target, (0, 1), "constant", constant_values=value_for_unresolved_foreign_key
+    )
 
     # Return the target at the index of the first matching primary key
     return padded_targets.take(indices)

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -273,7 +273,7 @@ def join_numpy(
     foreign_key: np.ndarray[Key],
     primary_key: np.ndarray[Key],
     target: np.ndarray[Out],
-    value_for_unresolved_foreign_key: Out,
+    value_if_foreign_key_is_missing: Out,
 ) -> np.ndarray[Out]:
     """
     Given a foreign key, find the corresponding primary key, and return the target at
@@ -287,7 +287,7 @@ def join_numpy(
         The primary keys.
     target : np.ndarray[Out]
         The targets in the same order as the primary keys.
-    value_for_unresolved_foreign_key : Out
+    value_if_foreign_key_is_missing : Out
         The value to return if no matching primary key is found.
 
     Returns
@@ -321,7 +321,7 @@ def join_numpy(
 
     # Add the value for unresolved foreign keys at the end of the target array
     padded_targets = np.pad(
-        target, (0, 1), "constant", constant_values=value_for_unresolved_foreign_key
+        target, (0, 1), "constant", constant_values=value_if_foreign_key_is_missing
     )
 
     # Return the target at the index of the first matching primary key

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -270,7 +270,10 @@ Out: TypeVar = TypeVar("Out")
 
 
 def join_numpy(
-    foreign_key: np.ndarray[Key], primary_key: np.ndarray[Key], target: np.ndarray[Out]
+    foreign_key: np.ndarray[Key],
+    primary_key: np.ndarray[Key],
+    target: np.ndarray[Out],
+    default: Out,
 ) -> np.ndarray[Out]:
     """
     Given a foreign key, find the corresponding primary key, and return the target at
@@ -284,6 +287,8 @@ def join_numpy(
         The primary keys.
     target : np.ndarray[Out]
         The targets in the same order as the primary keys.
+    default : Out
+        The default value to return if no match is found.
 
     Returns
     -------
@@ -295,10 +300,20 @@ def join_numpy(
         duplicate_primary_keys = keys[counts > 1]
         raise ValueError(f"Duplicate primary keys: {duplicate_primary_keys}")
 
-    try:
-        sorter = np.argsort(primary_key)
-        idx = np.searchsorted(primary_key, foreign_key, sorter=sorter)
-        return target[idx]
-    except IndexError as e:
-        invalid_foreign_keys = foreign_key[~np.isin(foreign_key, primary_key)]
-        raise ValueError(f"Invalid foreign keys: {invalid_foreign_keys}") from e
+    # For each foreign key and for each primary key, check if they match
+    matches_foreign_key = foreign_key[:, None] == primary_key
+
+    # For each foreign key, add a column with True at the end, to later fall back to
+    # the default
+    padded_matches_foreign_key = np.pad(
+        matches_foreign_key, ((0, 0), (0, 1)), "constant", constant_values=True
+    )
+
+    # For ech foreign key, compute the index of the first matching primary key
+    indices = np.argmax(padded_matches_foreign_key, axis=1)
+
+    # Add the default target at the end
+    padded_targets = np.pad(target, (0, 1), "constant", constant_values=default)
+
+    # Return the target at the index of the first matching primary key
+    return padded_targets.take(indices)

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -172,7 +172,10 @@ def _unterhaltsvorschuss_empf_eink_above_income_threshold(
     -------
     """
     return join_numpy(
-        p_id_kindergeld_empf, p_id, _unterhaltsvorschuss_eink_above_income_threshold
+        p_id_kindergeld_empf,
+        p_id,
+        _unterhaltsvorschuss_eink_above_income_threshold,
+        value_if_foreign_key_is_missing=False,
     )
 
 

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -4,25 +4,42 @@ from _gettsim.shared import join_numpy
 
 
 @pytest.mark.parametrize(
-    "foreign_key, primary_key, target, expected",
+    "foreign_key, primary_key, target, default, expected",
     [
         (
             np.array([1, 2, 3]),
             np.array([1, 2, 3]),
             np.array(["a", "b", "c"]),
+            "d",
             np.array(["a", "b", "c"]),
         ),
         (
             np.array([3, 2, 1]),
             np.array([1, 2, 3]),
             np.array(["a", "b", "c"]),
+            "d",
             np.array(["c", "b", "a"]),
         ),
         (
             np.array([1, 1, 1]),
             np.array([1, 2, 3]),
             np.array(["a", "b", "c"]),
+            "d",
             np.array(["a", "a", "a"]),
+        ),
+        (
+            np.array([-1]),
+            np.array([1]),
+            np.array(["a"]),
+            "d",
+            np.array(["d"]),
+        ),
+        (
+            np.array([2]),
+            np.array([1]),
+            np.array(["a"]),
+            "d",
+            np.array(["d"]),
         ),
     ],
 )
@@ -30,16 +47,20 @@ def test_join_numpy(
     foreign_key: np.ndarray[int],
     primary_key: np.ndarray[int],
     target: np.ndarray[str],
+    default: str,
     expected: np.ndarray[str],
 ):
-    assert np.array_equal(join_numpy(foreign_key, primary_key, target), expected)
+    assert np.array_equal(
+        join_numpy(foreign_key, primary_key, target, default),
+        expected,
+    )
 
 
 def test_join_numpy_raises_duplicate_primary_key():
     with pytest.raises(ValueError, match="Duplicate primary keys:"):
-        join_numpy(np.array([1, 1, 1]), np.array([1, 1, 1]), np.array(["a", "b", "c"]))
-
-
-def test_join_numpy_raises_invalid_foreign_key():
-    with pytest.raises(ValueError, match="Invalid foreign keys:"):
-        join_numpy(np.array([2]), np.array([1]), np.array(["a"]))
+        join_numpy(
+            np.array([1, 1, 1]),
+            np.array([1, 1, 1]),
+            np.array(["a", "b", "c"]),
+            "default",
+        )

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -34,13 +34,6 @@ from _gettsim.shared import join_numpy
             "d",
             np.array(["d"]),
         ),
-        (
-            np.array([2]),
-            np.array([1]),
-            np.array(["a"]),
-            "d",
-            np.array(["d"]),
-        ),
     ],
 )
 def test_join_numpy(
@@ -64,3 +57,8 @@ def test_join_numpy_raises_duplicate_primary_key():
             np.array(["a", "b", "c"]),
             "default",
         )
+
+
+def test_join_numpy_raises_invalid_foreign_key():
+    with pytest.raises(ValueError, match="Invalid foreign keys:"):
+        join_numpy(np.array([2]), np.array([1]), np.array(["a"]), "d")

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -4,7 +4,7 @@ from _gettsim.shared import join_numpy
 
 
 @pytest.mark.parametrize(
-    "foreign_key, primary_key, target, value_for_unresolved_foreign_key, expected",
+    "foreign_key, primary_key, target, value_if_foreign_key_is_missing, expected",
     [
         (
             np.array([1, 2, 3]),
@@ -40,11 +40,11 @@ def test_join_numpy(
     foreign_key: np.ndarray[int],
     primary_key: np.ndarray[int],
     target: np.ndarray[str],
-    value_for_unresolved_foreign_key: str,
+    value_if_foreign_key_is_missing: str,
     expected: np.ndarray[str],
 ):
     assert np.array_equal(
-        join_numpy(foreign_key, primary_key, target, value_for_unresolved_foreign_key),
+        join_numpy(foreign_key, primary_key, target, value_if_foreign_key_is_missing),
         expected,
     )
 

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -4,7 +4,7 @@ from _gettsim.shared import join_numpy
 
 
 @pytest.mark.parametrize(
-    "foreign_key, primary_key, target, default, expected",
+    "foreign_key, primary_key, target, value_for_unresolved_foreign_key, expected",
     [
         (
             np.array([1, 2, 3]),
@@ -40,11 +40,11 @@ def test_join_numpy(
     foreign_key: np.ndarray[int],
     primary_key: np.ndarray[int],
     target: np.ndarray[str],
-    default: str,
+    value_for_unresolved_foreign_key: str,
     expected: np.ndarray[str],
 ):
     assert np.array_equal(
-        join_numpy(foreign_key, primary_key, target, default),
+        join_numpy(foreign_key, primary_key, target, value_for_unresolved_foreign_key),
         expected,
     )
 


### PR DESCRIPTION
### What problem do you want to solve?

Closes #740

`join_numpy` now takes a value that is used if a foreign key cannot be resolved, e.g. because it is explicitly set to `-1`.


### Todo

- [X] Pick an appropriate title.
- [X] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [ ] ~~Document PR in CHANGES.md.~~
