### PR TITLE
Allow array returns when `skip_vectorization` is being used, enforce import convention.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
       - id: blacken-docs
       # exclude: docs/source/how_to_guides/optimization/how_to_specify_constraints.md
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.4.4
     hooks:
       - id: ruff
       #   args:
@@ -74,10 +74,10 @@ repos:
     hooks:
       - id: nbqa-black
         additional_dependencies:
-          - black==24.2.0
+          - black==24.4.2
       - id: nbqa-ruff
         additional_dependencies:
-          - ruff==v0.2.1
+          - ruff==v0.4.4
         args:
           - --ignore=B018,T201
   - repo: https://github.com/executablebooks/mdformat

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 - {gh}`755` Allow array returns when `skip_vectorization` is being used, enforce import
   convention ({ghuser}`hmgaudecker`).
-- {gh}`751` Kindergeldübergtrag ({ghuser}`MImmesberger`).
+- {gh}`751` Kindergeldübertrag ({ghuser}`MImmesberger`).
 - {gh}`739` Unterhaltsvorschuss calculation on child level ({ghuser}`MImmesberger`).
 - {gh}`725` KdU calculation on bg level and other small fixes ({ghuser}`MImmesberger`,
   {ghuser}`ChristianZimpelmann`).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`755` Allow array returns when `skip_vectorization` is being used, enforce import
+  convention ({ghuser}`hmgaudecker`).
+- {gh}`751` Kindergeldübergtrag ({ghuser}`MImmesberger`).
 - {gh}`739` Unterhaltsvorschuss calculation on child level ({ghuser}`MImmesberger`).
 - {gh}`725` KdU calculation on bg level and other small fixes ({ghuser}`MImmesberger`,
   {ghuser}`ChristianZimpelmann`).

--- a/docs/geps/gep-04.md
+++ b/docs/geps/gep-04.md
@@ -113,7 +113,8 @@ def soli_st_y_sn(
     anz_personen_sn: int,
     abgelt_st_y_sn: float,
     soli_st_params: dict,
-) -> float: ...
+) -> float:
+    ...
 ```
 
 may use `abgelt_st_y_sn` as an input argument. The DAG backend ensures that the function
@@ -259,7 +260,8 @@ By including `kindergeld_m_bg` as an argument in the definition of
 `arbeitsl_geld_2_m_bg` as follows:
 
 ```python
-def arbeitsl_geld_2_m_bg(kindergeld_m_bg, other_arguments): ...
+def arbeitsl_geld_2_m_bg(kindergeld_m_bg, other_arguments):
+    ...
 ```
 
 a node `kindergeld_m_bg` containing the Bedarfsgemeinschaft-level sum of `kindergeld_m`

--- a/docs/geps/gep-04.md
+++ b/docs/geps/gep-04.md
@@ -113,8 +113,7 @@ def soli_st_y_sn(
     anz_personen_sn: int,
     abgelt_st_y_sn: float,
     soli_st_params: dict,
-) -> float:
-    ...
+) -> float: ...
 ```
 
 may use `abgelt_st_y_sn` as an input argument. The DAG backend ensures that the function
@@ -260,8 +259,7 @@ By including `kindergeld_m_bg` as an argument in the definition of
 `arbeitsl_geld_2_m_bg` as follows:
 
 ```python
-def arbeitsl_geld_2_m_bg(kindergeld_m_bg, other_arguments):
-    ...
+def arbeitsl_geld_2_m_bg(kindergeld_m_bg, other_arguments): ...
 ```
 
 a node `kindergeld_m_bg` containing the Bedarfsgemeinschaft-level sum of `kindergeld_m`

--- a/src/_gettsim/groupings.py
+++ b/src/_gettsim/groupings.py
@@ -18,7 +18,7 @@ def bg_id_numpy(
     fg_id: numpy.ndarray[int],
     alter: numpy.ndarray[int],
     eigenbedarf_gedeckt: numpy.ndarray[bool],
-):
+) -> numpy.ndarray[int]:
     """
     Compute the ID of the Bedarfsgemeinschaft for each person.
     """
@@ -40,9 +40,9 @@ def bg_id_numpy(
 
 
 def eg_id_numpy(
-    p_id: numpy.ndarray,
-    p_id_einstandspartner: numpy.ndarray,
-) -> numpy.ndarray:
+    p_id: numpy.ndarray[int],
+    p_id_einstandspartner: numpy.ndarray[int],
+) -> numpy.ndarray[int]:
     """
     Compute the ID of the Einstandsgemeinschaft for each person.
     """
@@ -69,9 +69,9 @@ def eg_id_numpy(
 
 
 def ehe_id_numpy(
-    p_id: numpy.ndarray,
-    p_id_ehepartner: numpy.ndarray,
-):
+    p_id: numpy.ndarray[int],
+    p_id_ehepartner: numpy.ndarray[int],
+) -> numpy.ndarray[int]:
     """
     Compute the ID of the Ehe for each person.
     """
@@ -95,13 +95,13 @@ def ehe_id_numpy(
 
 
 def fg_id_numpy(  # noqa: PLR0913
-    p_id: numpy.ndarray,
-    hh_id: numpy.ndarray,
-    alter: numpy.ndarray,
-    p_id_einstandspartner: numpy.ndarray,
-    p_id_elternteil_1: numpy.ndarray,
-    p_id_elternteil_2: numpy.ndarray,
-):
+    p_id: numpy.ndarray[int],
+    hh_id: numpy.ndarray[int],
+    alter: numpy.ndarray[int],
+    p_id_einstandspartner: numpy.ndarray[int],
+    p_id_elternteil_1: numpy.ndarray[int],
+    p_id_elternteil_2: numpy.ndarray[int],
+) -> numpy.ndarray[int]:
     """
     Compute the ID of the Familiengemeinschaft for each person.
     """
@@ -171,10 +171,10 @@ def fg_id_numpy(  # noqa: PLR0913
 
 
 def sn_id_numpy(
-    p_id: numpy.ndarray,
-    p_id_ehepartner: numpy.ndarray,
+    p_id: numpy.ndarray[int],
+    p_id_ehepartner: numpy.ndarray[int],
     gemeinsam_veranlagt: numpy.ndarray[bool],
-):
+) -> numpy.ndarray[int]:
     """
     Compute a Steuernummer (ID) for each person / couple.
     """

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -281,7 +281,12 @@ def _convert_data_to_correct_types(data, functions_overridden):
             column_name in functions_overridden
             and "return" in functions_overridden[column_name].__annotations__
         ):
-            internal_type = functions_overridden[column_name].__annotations__["return"]
+            func = functions_overridden[column_name]
+            if hasattr(func, "__info__") and func.__info__["skip_vectorization"]:
+                breakpoint()
+                internal_type = func.__annotations__["return"]
+            else:
+                internal_type = func.__annotations__["return"]
 
         # Make conversion if necessary
         if internal_type and not check_series_has_expected_type(series, internal_type):

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -391,23 +391,31 @@ class FunctionsAndColumnsOverlapWarning(UserWarning):
 
     def __init__(self, columns_overriding_functions: set[str]) -> None:
         n_cols = len(columns_overriding_functions)
-        first_part = format_errors_and_warnings(
-            f"Your data provides the column{'' if n_cols == 1 else 's'}:"
-        )
+        if n_cols == 1:
+            first_part = format_errors_and_warnings("Your data provides the column:")
+            second_part = format_errors_and_warnings(
+                """
+                This is already present among the hard-coded functions of the taxes and
+                transfers system. If you want this data column to be used instead of
+                calculating it within GETTSIM you need not do anything. If you want this
+                data column to be calculated by hard-coded functions, remove it from the
+                *data* you pass to GETTSIM. You need to pick one option for each column
+                that appears in the list above.
+                """
+            )
+        else:
+            first_part = format_errors_and_warnings("Your data provides the columns:")
+            second_part = format_errors_and_warnings(
+                """
+                These are already present among the hard-coded functions of the taxes
+                and transfers system. If you want a data column to be used instead of
+                calculating it within GETTSIM you do not need to do anything. If you
+                want data columns to be calculated by hard-coded functions, remove them
+                from the *data* you pass to GETTSIM. You need to pick one option for
+                each column that appears in the list above.
+                """
+            )
         formatted = format_list_linewise(list(columns_overriding_functions))
-        second_part = format_errors_and_warnings(
-            f"""
-            {'This is' if n_cols == 1 else 'These are'} already present among the
-            hard-coded functions of the taxes and transfers system.
-            If you want {'this' if n_cols == 1 else 'a'} data column to be used
-            instead of calculating it within GETTSIM you need not do anything.
-            If you want {'this' if n_cols == 1 else 'a'} data column to be
-            calculated by hard-coded functions, remove
-            {'it' if n_cols == 1 else 'them'} from the *data* you pass to GETTSIM.
-            {'' if n_cols == 1 else '''You need to pick one option for each column
-            that appears in the list above.'''}
-            """
-        )
         how_to_ignore = format_errors_and_warnings(
             """
             If you want to ignore this warning, add the following code to your script

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -2,7 +2,7 @@ import copy
 import functools
 import inspect
 import warnings
-from typing import Literal
+from typing import Literal, get_args
 
 import dags
 import pandas as pd
@@ -283,8 +283,10 @@ def _convert_data_to_correct_types(data, functions_overridden):
         ):
             func = functions_overridden[column_name]
             if hasattr(func, "__info__") and func.__info__["skip_vectorization"]:
-                breakpoint()
-                internal_type = func.__annotations__["return"]
+                # Assumes that things are annotated with np.ndarray([dtype]), might
+                # require a change if using proper numpy.typing. Not changing for now
+                # as we will likely switch to JAX completely.
+                internal_type = get_args(func.__annotations__["return"])[0]
             else:
                 internal_type = func.__annotations__["return"]
 

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -283,7 +283,7 @@ def _convert_data_to_correct_types(data, functions_overridden):
         ):
             func = functions_overridden[column_name]
             if hasattr(func, "__info__") and func.__info__["skip_vectorization"]:
-                # Assumes that things are annotated with np.ndarray([dtype]), might
+                # Assumes that things are annotated with numpy.ndarray([dtype]), might
                 # require a change if using proper numpy.typing. Not changing for now
                 # as we will likely switch to JAX completely.
                 internal_type = get_args(func.__annotations__["return"])[0]

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from datetime import date
 from typing import TypeVar
 
-import numpy as np
+import numpy
 
 from _gettsim.config import SUPPORTED_GROUPINGS
 
@@ -270,38 +270,38 @@ Out: TypeVar = TypeVar("Out")
 
 
 def join_numpy(
-    foreign_key: np.ndarray[Key],
-    primary_key: np.ndarray[Key],
-    target: np.ndarray[Out],
+    foreign_key: numpy.ndarray[Key],
+    primary_key: numpy.ndarray[Key],
+    target: numpy.ndarray[Out],
     value_if_foreign_key_is_missing: Out,
-) -> np.ndarray[Out]:
+) -> numpy.ndarray[Out]:
     """
     Given a foreign key, find the corresponding primary key, and return the target at
     the same index as the primary key.
 
     Parameters
     ----------
-    foreign_key : np.ndarray[Key]
+    foreign_key : numpy.ndarray[Key]
         The foreign keys.
-    primary_key : np.ndarray[Key]
+    primary_key : numpy.ndarray[Key]
         The primary keys.
-    target : np.ndarray[Out]
+    target : numpy.ndarray[Out]
         The targets in the same order as the primary keys.
     value_if_foreign_key_is_missing : Out
         The value to return if no matching primary key is found.
 
     Returns
     -------
-    np.ndarray[Out]
+    numpy.ndarray[Out]
         The joined array.
     """
-    if len(np.unique(primary_key)) != len(primary_key):
-        keys, counts = np.unique(primary_key, return_counts=True)
+    if len(numpy.unique(primary_key)) != len(primary_key):
+        keys, counts = numpy.unique(primary_key, return_counts=True)
         duplicate_primary_keys = keys[counts > 1]
         raise ValueError(f"Duplicate primary keys: {duplicate_primary_keys}")
 
     invalid_foreign_keys = foreign_key[
-        (foreign_key >= 0) & (~np.isin(foreign_key, primary_key))
+        (foreign_key >= 0) & (~numpy.isin(foreign_key, primary_key))
     ]
 
     if len(invalid_foreign_keys) > 0:
@@ -312,15 +312,15 @@ def join_numpy(
 
     # For each foreign key, add a column with True at the end, to later fall back to
     # the value for unresolved foreign keys
-    padded_matches_foreign_key = np.pad(
+    padded_matches_foreign_key = numpy.pad(
         matches_foreign_key, ((0, 0), (0, 1)), "constant", constant_values=True
     )
 
     # For each foreign key, compute the index of the first matching primary key
-    indices = np.argmax(padded_matches_foreign_key, axis=1)
+    indices = numpy.argmax(padded_matches_foreign_key, axis=1)
 
     # Add the value for unresolved foreign keys at the end of the target array
-    padded_targets = np.pad(
+    padded_targets = numpy.pad(
         target, (0, 1), "constant", constant_values=value_if_foreign_key_is_missing
     )
 

--- a/src/_gettsim/synthetic.py
+++ b/src/_gettsim/synthetic.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 
-import numpy as np
+import numpy
 import pandas as pd
 
 from _gettsim.config import RESOURCE_DIR, SUPPORTED_GROUPINGS, TYPES_INPUT_VARIABLES
@@ -230,7 +230,9 @@ def return_df_with_ids_for_aggregation(data, n_adults, n_children, adults_marrie
         data = pd.merge(
             data, data_adults[["p_id", "p_id_einstandspartner"]], on="p_id", how="left"
         ).fillna(-1)
-        data["p_id_einstandspartner"] = data["p_id_einstandspartner"].astype(np.int64)
+        data["p_id_einstandspartner"] = data["p_id_einstandspartner"].astype(
+            numpy.int64
+        )
         if adults_married:
             data["p_id_ehepartner"] = data["p_id_einstandspartner"]
         else:

--- a/src/_gettsim/transfers/arbeitsl_geld.py
+++ b/src/_gettsim/transfers/arbeitsl_geld.py
@@ -1,7 +1,6 @@
 """Functions to compute unemployment benefits (Arbeitslosengeld)."""
 
-import numpy as np
-
+from _gettsim.config import numpy_or_jax as np
 from _gettsim.piecewise_functions import piecewise_polynomial
 from _gettsim.taxes.eink_st import _eink_st_tarif
 from _gettsim.transfers.rente import ges_rente_regelaltersgrenze

--- a/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
+++ b/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
@@ -1,6 +1,6 @@
 """Module for the calculation of the Kindergeldübertrag."""
 
-import numpy as np
+import numpy
 
 from _gettsim.shared import join_numpy, policy_info
 
@@ -68,9 +68,9 @@ def _mean_kindergeld_per_child_ohne_staffelung_m(
 @policy_info(skip_vectorization=True)
 def kindergeld_zur_bedarfsdeckung_m(
     _mean_kindergeld_per_child_m: float,
-    p_id_kindergeld_empf: np.ndarray[int],
-    p_id: np.ndarray[int],
-) -> float:
+    p_id_kindergeld_empf: numpy.ndarray[int],
+    p_id: numpy.ndarray[int],
+) -> numpy.ndarray[float]:
     """Kindergeld that is used to cover the SGB II Regelbedarf of the child.
 
     Even though the Kindergeld is paid to the parent (see function

--- a/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
+++ b/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
@@ -106,7 +106,7 @@ def _diff_kindergeld_kindbedarf_m(
     arbeitsl_geld_2_regelbedarf_m_bg: float,
     kindergeld_zur_bedarfsdeckung_m: float,
     eigenbedarf_gedeckt: bool,
-) -> float:
+) -> numpy.ndarray[float]:
     """Kindergeld that is used to cover the needs (SGB II) of the parent.
 
     If a child does not need all of the Kindergeld to cover its own needs (SGB II), the

--- a/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
+++ b/src/_gettsim/transfers/arbeitsl_geld_2/kindergelduebertrag.py
@@ -106,7 +106,7 @@ def _diff_kindergeld_kindbedarf_m(
     arbeitsl_geld_2_regelbedarf_m_bg: float,
     kindergeld_zur_bedarfsdeckung_m: float,
     eigenbedarf_gedeckt: bool,
-) -> numpy.ndarray[float]:
+) -> float:
     """Kindergeld that is used to cover the needs (SGB II) of the parent.
 
     If a child does not need all of the Kindergeld to cover its own needs (SGB II), the

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -1,7 +1,7 @@
 """This module provides functions to compute advance alimony payments
 (Unterhaltsvorschuss)."""
 
-import numpy as np
+import numpy
 
 from _gettsim.shared import join_numpy, policy_info
 
@@ -60,10 +60,10 @@ def unterhaltsvors_m(
 
 @policy_info(skip_vectorization=True)
 def parent_alleinerz(
-    p_id_kindergeld_empf: np.ndarray[int],
-    p_id: np.ndarray[int],
-    alleinerz: np.ndarray[bool],
-) -> np.ndarray[bool]:
+    p_id_kindergeld_empf: numpy.ndarray[int],
+    p_id: numpy.ndarray[int],
+    alleinerz: numpy.ndarray[bool],
+) -> numpy.ndarray[bool]:
     """Check if parent that receives Unterhaltsvorschuss is a single parent.
 
     Only single parents receive Unterhaltsvorschuss.
@@ -181,10 +181,10 @@ def _unterhaltsvors_anspruch_kind_m(
 
 @policy_info(skip_vectorization=True)
 def _unterhaltsvorschuss_empf_eink_above_income_threshold(
-    p_id_kindergeld_empf: np.ndarray[int],
-    p_id: np.ndarray[int],
-    _unterhaltsvorschuss_eink_above_income_threshold: np.ndarray[bool],
-) -> np.ndarray[bool]:
+    p_id_kindergeld_empf: numpy.ndarray[int],
+    p_id: numpy.ndarray[int],
+    _unterhaltsvorschuss_eink_above_income_threshold: numpy.ndarray[bool],
+) -> numpy.ndarray[bool]:
     """Income of Unterhaltsvorschuss recipient above threshold (this variable is
     defined on child level).
 

--- a/src/_gettsim/visualization.py
+++ b/src/_gettsim/visualization.py
@@ -4,7 +4,7 @@ import operator
 from functools import reduce
 
 import networkx as nx
-import numpy as np
+import numpy
 import pandas as pd
 import plotly.graph_objects as go
 from pygments import highlight, lexers
@@ -113,7 +113,7 @@ def plot_dag(
     names = layout_df.index
     node_x_coord = layout_df[0].values
     node_y_coord = layout_df[1].values
-    url = np.array([dag.nodes[x]["url"] for x in names])
+    url = numpy.array([dag.nodes[x]["url"] for x in names])
     codes = [dag.nodes[x]["source_code"] for x in names]
 
     combo = pd.DataFrame(
@@ -389,26 +389,26 @@ def _create_pygraphviz_layout(dag, orientation):
     # Remap layout from integers to labels.
     integer_to_labels = dict(zip(dag_w_integer_nodes.nodes, dag.nodes))
     layout = {
-        integer_to_labels[i]: np.array(integer_layout[i]) for i in integer_to_labels
+        integer_to_labels[i]: numpy.array(integer_layout[i]) for i in integer_to_labels
     }
 
     # Convert nonnegative integer coordinates from the layout to unit cube.
     min_x = min(i[0] for i in layout.values())
     min_y = min(i[1] for i in layout.values())
-    min_ = np.array([min_x, min_y])
+    min_ = numpy.array([min_x, min_y])
 
     max_x = max(i[0] for i in layout.values())
     max_y = max(i[1] for i in layout.values())
-    max_ = np.array([max_x, max_y])
+    max_ = numpy.array([max_x, max_y])
 
     for k, v in layout.items():
         layout[k] = (v - (max_ + min_) / 2) / ((max_ - min_) / 2).clip(1)
 
     if orientation == "v":
-        layout_df = np.transpose(pd.DataFrame.from_dict(layout))
+        layout_df = numpy.transpose(pd.DataFrame.from_dict(layout))
 
     elif orientation == "h":
-        layout_df = np.transpose(pd.DataFrame.from_dict(layout))
+        layout_df = numpy.transpose(pd.DataFrame.from_dict(layout))
         layout_df[[0, 1]] = layout_df[[1, 0]]
         layout_df[0] = layout_df[0] * (-1)
 

--- a/src/_gettsim_tests/test_functions_loader.py
+++ b/src/_gettsim_tests/test_functions_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import textwrap
 from typing import TYPE_CHECKING
 
-import numpy as np
+import numpy
 import pytest
 from _gettsim.config import RESOURCE_DIR
 from _gettsim.functions_loader import (
@@ -97,8 +97,8 @@ def scalar_func(x: int) -> int:
 
 
 @policy_info(skip_vectorization=True)
-def already_vectorized_func(x: np.ndarray) -> np.ndarray:
-    return np.asarray([xi * 2 for xi in x])
+def already_vectorized_func(x: numpy.ndarray) -> numpy.ndarray:
+    return numpy.asarray([xi * 2 for xi in x])
 
 
 @pytest.mark.parametrize(
@@ -111,4 +111,6 @@ def already_vectorized_func(x: np.ndarray) -> np.ndarray:
 def test_vectorize_func(function: Callable) -> None:
     vectorized_func = _vectorize_func(function)
 
-    assert np.array_equal(vectorized_func(np.array([1, 2, 3])), np.array([2, 4, 6]))
+    assert numpy.array_equal(
+        vectorized_func(numpy.array([1, 2, 3])), numpy.array([2, 4, 6])
+    )

--- a/src/_gettsim_tests/test_join.py
+++ b/src/_gettsim_tests/test_join.py
@@ -1,4 +1,4 @@
-import numpy as np
+import numpy
 import pytest
 from _gettsim.shared import join_numpy
 
@@ -7,43 +7,43 @@ from _gettsim.shared import join_numpy
     "foreign_key, primary_key, target, value_if_foreign_key_is_missing, expected",
     [
         (
-            np.array([1, 2, 3]),
-            np.array([1, 2, 3]),
-            np.array(["a", "b", "c"]),
+            numpy.array([1, 2, 3]),
+            numpy.array([1, 2, 3]),
+            numpy.array(["a", "b", "c"]),
             "d",
-            np.array(["a", "b", "c"]),
+            numpy.array(["a", "b", "c"]),
         ),
         (
-            np.array([3, 2, 1]),
-            np.array([1, 2, 3]),
-            np.array(["a", "b", "c"]),
+            numpy.array([3, 2, 1]),
+            numpy.array([1, 2, 3]),
+            numpy.array(["a", "b", "c"]),
             "d",
-            np.array(["c", "b", "a"]),
+            numpy.array(["c", "b", "a"]),
         ),
         (
-            np.array([1, 1, 1]),
-            np.array([1, 2, 3]),
-            np.array(["a", "b", "c"]),
+            numpy.array([1, 1, 1]),
+            numpy.array([1, 2, 3]),
+            numpy.array(["a", "b", "c"]),
             "d",
-            np.array(["a", "a", "a"]),
+            numpy.array(["a", "a", "a"]),
         ),
         (
-            np.array([-1]),
-            np.array([1]),
-            np.array(["a"]),
+            numpy.array([-1]),
+            numpy.array([1]),
+            numpy.array(["a"]),
             "d",
-            np.array(["d"]),
+            numpy.array(["d"]),
         ),
     ],
 )
 def test_join_numpy(
-    foreign_key: np.ndarray[int],
-    primary_key: np.ndarray[int],
-    target: np.ndarray[str],
+    foreign_key: numpy.ndarray[int],
+    primary_key: numpy.ndarray[int],
+    target: numpy.ndarray[str],
     value_if_foreign_key_is_missing: str,
-    expected: np.ndarray[str],
+    expected: numpy.ndarray[str],
 ):
-    assert np.array_equal(
+    assert numpy.array_equal(
         join_numpy(foreign_key, primary_key, target, value_if_foreign_key_is_missing),
         expected,
     )
@@ -52,13 +52,13 @@ def test_join_numpy(
 def test_join_numpy_raises_duplicate_primary_key():
     with pytest.raises(ValueError, match="Duplicate primary keys:"):
         join_numpy(
-            np.array([1, 1, 1]),
-            np.array([1, 1, 1]),
-            np.array(["a", "b", "c"]),
+            numpy.array([1, 1, 1]),
+            numpy.array([1, 1, 1]),
+            numpy.array(["a", "b", "c"]),
             "default",
         )
 
 
 def test_join_numpy_raises_invalid_foreign_key():
     with pytest.raises(ValueError, match="Invalid foreign keys:"):
-        join_numpy(np.array([2]), np.array([1]), np.array(["a"]), "d")
+        join_numpy(numpy.array([2]), numpy.array([1]), numpy.array(["a"]), "d")

--- a/src/_gettsim_tests/test_piecewise_polynomial.py
+++ b/src/_gettsim_tests/test_piecewise_polynomial.py
@@ -2,7 +2,7 @@
 Tests for `piecewise_polynomial`
 """
 
-import numpy as np
+import numpy
 from _gettsim.piecewise_functions import (
     get_piecewise_parameters,
 )
@@ -41,6 +41,6 @@ def test_get_piecewise_parameters_all_intercepts_supplied():
         parameter="test",
         func_type="linear",
     )["intercepts_at_lower_thresholds"]
-    expected = np.array([0.27, 0.5, 0.8, 1])
+    expected = numpy.array([0.27, 0.5, 0.8, 1])
 
-    np.testing.assert_almost_equal(actual, expected, decimal=10)
+    numpy.testing.assert_almost_equal(actual, expected, decimal=10)

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import numpy as np
+import numpy
 import pandas as pd
 import pytest
 from _gettsim.synthetic import create_synthetic_data
@@ -160,7 +160,7 @@ def test_specs_constant_over_households(col, expected, synthetic_data_spec_varia
         ("alter", [50, 30, 5] * 11),
         (
             "bruttolohn_m",
-            np.concatenate([[i / 2, i / 2, 0] for i in range(0, 1001, 100)]),
+            numpy.concatenate([[i / 2, i / 2, 0] for i in range(0, 1001, 100)]),
         ),
         ("gemeinsam_veranlagt", [True, True, False] * 11),
     ],


### PR DESCRIPTION
### What problem do you want to solve?

- Extract the `float` bit from typing info like `numpy.ndarray[float]`, so we can use proper return types.
- Add array types in some cases
- Enforce convention for importing numpy:
  - `np` means our own `numpy_or_jax`
  - `numpy` means numpy proper
