### PR TITLE
Add Betreuungskosten pointer to synthetic data.

### DIFF
--- a/src/_gettsim/synthetic.py
+++ b/src/_gettsim/synthetic.py
@@ -190,6 +190,7 @@ def return_df_with_ids_for_aggregation(data, n_adults, n_children, adults_marrie
     - p_id_erziehgeld_empf
     - p_id_einstandspartner
     - p_id_ehepartner
+    - p_id_betreuungsk_träger
 
     Parameters
     ----------
@@ -215,6 +216,7 @@ def return_df_with_ids_for_aggregation(data, n_adults, n_children, adults_marrie
         data["p_id_elternteil_2"] = -1
     data["p_id_kindergeld_empf"] = data["p_id_elternteil_1"]
     data["p_id_erziehgeld_empf"] = data["p_id_elternteil_1"]
+    data["p_id_betreuungsk_träger"] = data["p_id_elternteil_1"]
 
     # Create other IDs
     if n_adults == 1:

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -224,6 +224,9 @@ def test_fail_if_functions_and_columns_overlap(
                     i + 1 if i % 3 == 0 else i - 1 if i % 3 == 1 else -1
                     for i in range(33)
                 ],
+                "p_id_betreuungsk_träger": [
+                    -1 if i % 3 != 2 else i - 2 for i in range(33)
+                ],
             },
         ),
         (
@@ -246,6 +249,9 @@ def test_fail_if_functions_and_columns_overlap(
                     i + 1 if i % 3 == 0 else i - 1 if i % 3 == 1 else -1
                     for i in range(33)
                 ],
+                "p_id_betreuungsk_träger": [
+                    -1 if i % 3 != 2 else i - 2 for i in range(33)
+                ],
             },
         ),
         (
@@ -258,6 +264,7 @@ def test_fail_if_functions_and_columns_overlap(
                 "p_id_erziehgeld_empf": [-1, 0],
                 "p_id_ehepartner": [-1, -1],
                 "p_id_einstandspartner": [-1, -1],
+                "p_id_betreuungsk_träger": [-1, 0],
             },
         ),
         (
@@ -270,6 +277,7 @@ def test_fail_if_functions_and_columns_overlap(
                 "p_id_erziehgeld_empf": [-1, -1],
                 "p_id_ehepartner": [1, 0],
                 "p_id_einstandspartner": [1, 0],
+                "p_id_betreuungsk_träger": [-1, -1],
             },
         ),
     ],


### PR DESCRIPTION
When creating synthetic data, the input variable `p_id_betreuungsk_träger` is currently set to 0 for everyone. I adjusted this to be the same as `p_id_kindergeld_empf`.