### PR TITLE
Test whether `DEFAULT_TARGETS` can be computed with `create_synthetic_data` output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`785` Add NotImplementedError to Unterhaltsvorschuss and test whether output from
+  `create_synthetic_data` is enough to compute default targets ({ghuser}`MImmesberger`).
 - {gh}`772` Add Mindesteinkommen check to Wohngeld, calculate anz_eig_kind_bis_24
   instead of requiring it as an input variable ({ghuser}`MImmesberger`).
 - {gh}`771` Move SGB II Regelsatz calculation from BG to individual level

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -14,7 +14,7 @@ aggregate_by_p_id_unterhaltsvors = {
 }
 
 
-@policy_info(params_key_for_rounding="unterhaltsvors")
+@policy_info(start_date="2017-01-01", params_key_for_rounding="unterhaltsvors")
 def unterhaltsvors_m(
     kind_unterh_erhalt_m: float,
     _unterhaltsvors_anspruch_kind_m: float,
@@ -56,6 +56,20 @@ def unterhaltsvors_m(
         out = 0.0
 
     return out
+
+
+@policy_info(
+    end_date="2016-12-31",
+    name_in_dag="unterhaltsvors_m",
+    params_key_for_rounding="unterhaltsvors",
+)
+def unterhaltsvors_not_implemented_m() -> float:
+    raise NotImplementedError(
+        """
+        Unterhaltsvorschuss is not implemented prior to 2017.
+        https://github.com/iza-institute-of-labor-economics/gettsim/issues/566
+    """
+    )
 
 
 @policy_info(skip_vectorization=True)
@@ -130,6 +144,7 @@ def _kindergeld_erstes_kind_gestaffelt_m(
     return kindergeld_params["kindergeld"][1]
 
 
+@policy_info(start_date="2017-01-01")
 def _unterhaltsvors_anspruch_kind_m(
     alter: int,
     _unterhaltsvorschuss_empf_eink_above_income_threshold: bool,
@@ -179,7 +194,7 @@ def _unterhaltsvors_anspruch_kind_m(
     return out
 
 
-@policy_info(skip_vectorization=True)
+@policy_info(start_date="2017-01-01", skip_vectorization=True)
 def _unterhaltsvorschuss_empf_eink_above_income_threshold(
     p_id_kindergeld_empf: numpy.ndarray[int],
     p_id: numpy.ndarray[int],
@@ -208,6 +223,7 @@ def _unterhaltsvorschuss_empf_eink_above_income_threshold(
     )
 
 
+@policy_info(start_date="2017-01-01")
 def _unterhaltsvorschuss_eink_above_income_threshold(
     unterhaltsvorschuss_eink_m: float,
     unterhaltsvors_params: dict,
@@ -228,6 +244,7 @@ def _unterhaltsvorschuss_eink_above_income_threshold(
     return unterhaltsvorschuss_eink_m >= unterhaltsvors_params["mindesteinkommen"]
 
 
+@policy_info(start_date="2017-01-01")
 def unterhaltsvorschuss_eink_m(  # noqa: PLR0913
     bruttolohn_m: float,
     sonstig_eink_m: float,

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -293,7 +293,7 @@ def test_p_id_groups(fixture, expected, request):
 
 @pytest.mark.parametrize(
     "fixture, policy_date",
-    [("synthetic_data_couple_with_children", i) for i in range(2017, 2024)],
+    [("synthetic_data_couple_with_children", y) for y in range(2017, 2024)],
 )
 def test_default_targets(fixture, policy_date, request):
     policy_params, policy_functions = set_up_policy_environment(policy_date)

--- a/src/_gettsim_tests/test_synthetic.py
+++ b/src/_gettsim_tests/test_synthetic.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import numpy
 import pandas as pd
 import pytest
+from _gettsim.config import DEFAULT_TARGETS
+from _gettsim.interface import compute_taxes_and_transfers
+from _gettsim.policy_environment import set_up_policy_environment
 from _gettsim.synthetic import create_synthetic_data
 
 
@@ -286,3 +289,17 @@ def test_p_id_groups(fixture, expected, request):
     df = request.getfixturevalue(fixture)
     for col, values in expected.items():
         pd.testing.assert_series_equal(df[col], pd.Series(values, name=col))
+
+
+@pytest.mark.parametrize(
+    "fixture, policy_date",
+    [("synthetic_data_couple_with_children", i) for i in range(2017, 2024)],
+)
+def test_default_targets(fixture, policy_date, request):
+    policy_params, policy_functions = set_up_policy_environment(policy_date)
+    compute_taxes_and_transfers(
+        data=request.getfixturevalue(fixture),
+        targets=DEFAULT_TARGETS,
+        params=policy_params,
+        functions=policy_functions,
+    )


### PR DESCRIPTION
Closes #733

I let the test run through the years 2017-2024. Extending further back does not work because the Unterhaltsvorschuss isn't implemented prior to 2017 (as discussed in #566). 

I also added a `NotImplementedError` for the Unterhaltsvorschuss until 2016.

Related to #627 