### PR TITLE
Add unterhaltsvors implementation 2009 to 2016

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: check-useless-excludes
       # - id: identity  # Prints all files passed to pre-commits. Debugging.
   - repo: https://github.com/lyz-code/yamlfix
-    rev: 1.16.0
+    rev: 1.17.0
     hooks:
       - id: yamlfix
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -57,7 +57,7 @@ repos:
       - id: blacken-docs
       # exclude: docs/source/how_to_guides/optimization/how_to_specify_constraints.md
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.1
+    rev: v0.6.3
     hooks:
       - id: ruff
       #   args:
@@ -103,7 +103,7 @@ repos:
           - '88'
         files: (docs/.|CHANGES.md|CODE_OF_CONDUCT.md)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
+    rev: v1.11.2
     hooks:
       - id: mypy
         args:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`790` Add unterhaltsvors implementation 2009 to 2016 ({ghuser}`mjbloemer`).
 - {gh}`788` Pension benefit earnings test for early retirees ({ghuser}`MImmesberger`).
 - {gh}`786` Check directly whether child and parent are in same Bedarfsgemeinschaft for
   Kindergeldübertrag ({ghuser}`MImmesberger`).

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -149,19 +149,6 @@ def compute_taxes_and_transfers(  # noqa: PLR0913
         enforce_signature=True,
     )
 
-    if "unterhalt" in params:
-        if (
-            "mindestunterhalt" not in params["unterhalt"]
-            and "unterhaltsvors_m" in processed_functions
-        ):
-            raise NotImplementedError(
-                """
-Unterhaltsvorschuss is not implemented yet prior to 2016, see
-https://github.com/iza-institute-of-labor-economics/gettsim/issues/479.
-
-        """
-            )
-
     results = tax_transfer_function(**input_data)
 
     # Prepare results.

--- a/src/_gettsim/parameters/unterhalt.yaml
+++ b/src/_gettsim/parameters/unterhalt.yaml
@@ -6,10 +6,10 @@ mindestunterhalt:
   description:
     de: >-
       § 1612a BGB, § 1 Mindesunterhaltsverordnung. Mindestunterhalt für Kinder in
-      Abhängigkeit des Alters (unter 6, unter 12, bis 17 Jahre)
+      Abhängigkeit des Alters (0 - 5 Jahre, 6 - 11 Jahre, 12 - 17 Jahre).
     en: >-
-      Minimum Child Alimony depending on age of child (below 6, below 12, up to 17
-      years).
+      Minimum Child Alimony depending on age of child (0 - 5 years, 6 - 11 years, 12 -
+      17 years).
   unit: Euro
   reference_period: Month
   2016-01-01:
@@ -27,115 +27,75 @@ mindestunterhalt:
       betrag: 450
     reference: V. v. 03.12.2015 BGBl. I S. 2188.
   2017-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 342
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 393
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 460
     reference: V. v. 03.12.2015 BGBl. I S. 2188.
   2018-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 348
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 399
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 467
     reference: Artikel 1 V. v. 28.09.2017 BGBl. I S. 3525.
   2019-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 354
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 406
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 476
     reference: Artikel 1 V. v. 28.09.2017 BGBl. I S. 3525.
   2020-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 369
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 424
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 497
     reference: Artikel 1 V. v. 12.09.2019 BGBl. I S. 1393.
   2021-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 393
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 451
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 528
     reference: Artikel 1 V. v. 03.11.2020 BGBl. I S. 2344.
   2022-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 396
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 455
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 533
     reference: Artikel 1 V. v. 30.11.2021 BGBl. I S. 5066.
   2023-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 437
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 502
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 588
     reference: Artikel 1 V. v. 30.11.2022 BGBl. I S. 2130.
   2024-01-01:
+    deviation_from: previous
     1:
-      min_alter: 0
-      max_alter: 5
       betrag: 480
     2:
-      min_alter: 6
-      max_alter: 11
       betrag: 551
     3:
-      min_alter: 12
-      max_alter: 17
       betrag: 645
     reference: Artikel 1 V. v. 29.11.2023 BGBl. I Nr. 330.
 abzugsrate_kindergeld:

--- a/src/_gettsim/parameters/unterhalt.yaml
+++ b/src/_gettsim/parameters/unterhalt.yaml
@@ -13,49 +13,130 @@ mindestunterhalt:
   unit: Euro
   reference_period: Month
   2016-01-01:
-    6: 335
-    12: 384
-    18: 450
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 335
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 384
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 450
     reference: V. v. 03.12.2015 BGBl. I S. 2188.
   2017-01-01:
-    6: 342
-    12: 393
-    18: 460
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 342
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 393
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 460
     reference: V. v. 03.12.2015 BGBl. I S. 2188.
   2018-01-01:
-    6: 348
-    12: 399
-    18: 467
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 348
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 399
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 467
     reference: Artikel 1 V. v. 28.09.2017 BGBl. I S. 3525.
   2019-01-01:
-    6: 354
-    12: 406
-    18: 476
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 354
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 406
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 476
     reference: Artikel 1 V. v. 28.09.2017 BGBl. I S. 3525.
   2020-01-01:
-    6: 369
-    12: 424
-    18: 497
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 369
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 424
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 497
     reference: Artikel 1 V. v. 12.09.2019 BGBl. I S. 1393.
   2021-01-01:
-    6: 393
-    12: 451
-    18: 528
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 393
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 451
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 528
     reference: Artikel 1 V. v. 03.11.2020 BGBl. I S. 2344.
   2022-01-01:
-    6: 396
-    12: 455
-    18: 533
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 396
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 455
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 533
     reference: Artikel 1 V. v. 30.11.2021 BGBl. I S. 5066.
   2023-01-01:
-    6: 437
-    12: 502
-    18: 588
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 437
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 502
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 588
     reference: Artikel 1 V. v. 30.11.2022 BGBl. I S. 2130.
   2024-01-01:
-    6: 480
-    12: 551
-    18: 645
+    1:
+      min_alter: 0
+      max_alter: 5
+      betrag: 480
+    2:
+      min_alter: 6
+      max_alter: 11
+      betrag: 551
+    3:
+      min_alter: 12
+      max_alter: 17
+      betrag: 645
     reference: Artikel 1 V. v. 29.11.2023 BGBl. I Nr. 330.
 abzugsrate_kindergeld:
   name:

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -55,14 +55,17 @@ altersgrenzen_bezug:
     3: 18
     reference: Artikel 23 G. v. 14.08.2017 BGBl. I S. 3122
     note: New age group 12 to 17 introduced (§ 1 new Abs. 1a UhVorschG).
-rounding:
-  unterhaltsvors_m:
-    note:
-      en: Rounding rules since implementation in 1980 via BGBl. I 1979 S. 1184.
-    1980-01-01:
-      base: 1
-      direction: up
-      reference: § 9 Abs. 3 UhVorschG
+faktor_jüngste_altersgruppe:
+  name:
+    de: >-
+      Faktor mit dem das sächliche Existenzminimum multipliziert wird um den
+      Unterhaltsvorschuss für Kinder der jüngsten Altersgruppe zu berechnen.
+    en: >-
+      Factor by which the sächliche Existenzminimum is multiplied to calculate
+      the advance child alimony for children of the youngest age group.
+  2009-01-01:
+    scalar: 0.87
+    reference: § 1612a Abs. 1 BGB
 unterhaltsvors_anwendungsvors:
   name:
     de: Unterhaltsvorschuss für Kinder entsprechend Anwendungsvorschriften
@@ -114,3 +117,11 @@ unterhaltsvors_anwendungsvors:
       hat. 3Bis zum 31. Dezember 2015 gilt als für ein erstes Kind zu zahlendes
       Kindergeld im Sinne von § 2 Absatz 2 Satz 1 ein Betrag in Höhe von monatlich 184
       Euro."
+rounding:
+  unterhaltsvors_m:
+    note:
+      en: Rounding rules since implementation in 1980 via BGBl. I 1979 S. 1184.
+    1980-01-01:
+      base: 1
+      direction: up
+      reference: § 9 Abs. 3 UhVorschG

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -30,7 +30,7 @@ altersgrenze_mindesteinkommen:
   2017-01-01:
     scalar: 12
     reference: Art. 23 G. v. 14.08.2017 BGBl. I S. 3122.
-altersgrenzen:
+altersgrenzen_bezug:
   name:
     de: Altersgrenzen für den Bezug von Unterhaltsvorschuss
     en: age limits for receiving alimony payments
@@ -49,6 +49,7 @@ altersgrenzen:
     1: 6
     2: 12
     3: 18
+    reference: Artikel 23 G. v. 14.08.2017 BGBl. I S. 3122
 rounding:
   unterhaltsvors_m:
     note:
@@ -67,35 +68,35 @@ unterhaltsvors_anwendungsvors:
       Parametern Kinderfreibetrag für das sächliche Existenzminimum und dem Kindergeld
       für das erste Kind. Wird das Kindergeld unterjährig geändert oder der
       Kinderfreibetrag unterjährig rückwirkend geändert, gelten abweichende
-      Abwendungsvorschriften, die von unveränderten Werten für Kindergeld bzw.
+      Anwendungsvorschriften, die von unveränderten Werten für Kindergeld bzw.
       Kinderfreibetrag ausgehen können. Hier werden die entsprechenden Werte für den
       Unterhaltsvorschuss (d.h. nach Abzug des unterstellten Kindergeldes) verwendet.
     en: >-
       The advance child alimony is calculated in principle from 2009 to 2015 based on
-      the parameters parameters child allowance for the material minimum subsistence
-      level and child benefit for the first child. If the child benefit is changed
-      during the year or the or the child allowance is changed retroactively during the
-      year, deviating application rules apply, which can be based on unchanged values
-      for child benefit or child child allowance can be assumed. Here, the corresponding
-      values for the advance child alimony (i.e. after deduction of the assumed child
-      benefit) are used.
+      the parameters parameters 'child allowance for the material minimum subsistence
+      level' (Kinderfreibetrag für das sächliche Existenzminimum) and Kindergeld for the
+      first child. If the Kindergeld is changed during the year or the or the child
+      allowance is changed retroactively during the year, deviating application rules
+      apply, which can be based on unchanged values for Kindergeld or child child
+      allowance can be assumed. Here, the corresponding values for the advance child
+      alimony (i.e. after deduction of the assumed Kindergeld) are used.
   unit: Euro
   reference_period: Month
   2015-01-01:
     6: 133
     12: 180
-    reference:
+    reference: null
     note: >-
-      2015-01-01 bis 2015-06-31 errechnete sich der Mindesunterhalt aus einem
-      Kinderfreibetrag für das sächliche Existenzminimum in Höhe von 2184 Euro und dem
-      geltenden Kindergeld für das erste Kind in Höhe von 184 Euro. Da der
-      Kinderfreibetragtrospektiv Mitte des Jahres retrospektiv angehoben wurde, gilt im
-      Zuge dessen eine Anwendungsvorschrift, die den alten Kinderfreibetrag für die
-      Berechnung der Unterhaltsleistung unterstellt. § 11a Anwendungsvorschrift: "Im
-      Sinne dieses Gesetzes beträgt für die Zeit vom 1. Januar 2015 bis zum 30. Juni
-      2015 die Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich 317 Euro für ein
-      Kind, das das sechste Lebensjahr noch nicht vollendet hat, und monatlich 364 Euro
-      für ein Kind, das das zwölfte Lebensjahr noch nicht vollendet hat."
+      Der Mindesunterhalt errechnet sich aus einem Kinderfreibetrag für das sächliche
+      Existenzminimum in Höhe von 2184 Euro und dem geltenden Kindergeld für das erste
+      Kind in Höhe von 184 Euro. Da der Kinderfreibetrag Mitte des Jahres retrospektiv
+      angehoben wurde, gilt im Zuge dessen eine Anwendungsvorschrift, die den alten
+      Kinderfreibetrag für die Berechnung der Unterhaltsleistung unterstellt. § 11a
+      Anwendungsvorschrift: "Im Sinne dieses Gesetzes beträgt für die Zeit vom 1. Januar
+      2015 bis zum 30. Juni 2015 die Unterhaltsleistung nach § 2 Absatz 1 Satz 1
+      monatlich 317 Euro für ein Kind, das das sechste Lebensjahr noch nicht vollendet
+      hat, und monatlich 364 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht
+      vollendet hat."
   2015-07-01:
     6: 144
     12: 192

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -15,35 +15,18 @@ mindesteinkommen:
   2017-01-01:
     scalar: 600
     reference: Art. 23 G. v. 14.08.2017 BGBl. I S. 3122.
-altersgrenze_mindesteinkommen:
-  name:
-    de: >-
-      Altersgrenze, ab der UHV nur mit einem Mindesteinkommen in Höhe von
-      `mindesteinkommen` bezogen werden kann.
-    en: >-
-      Age threshold from which on Unterhaltsvorschuss is only paied if earnings are
-      above `mindesteinkommen`.
-  description:
-    de: § 1 (1a) Nr. 2 Unterhaltsvorschussgesetz
-    en: null
-  unit: Years
-  2017-01-01:
-    scalar: 12
-    reference: Art. 23 G. v. 14.08.2017 BGBl. I S. 3122.
 altersgrenzen_bezug:
   name:
-    de: Altersgrenzen für den Bezug von Unterhaltsvorschuss
-    en: age limits for receiving alimony payments
+    de: Altersgrenzen für den Bezug von Unterhaltsvorschuss bis Juni 2017.
+    en: Age limits for receiving alimony payments until June 2017.
   description:
     de: >-
       Kinder, die das 12. Lebensjahr noch nicht vollendet haben und bei einem
-      alleinerziehenden Elternteil leben haben Anspruch auf Unterhaltszahlungen. Zudem
-      können seit Juli 2017 auch Kinder bis zur Vollendung des 18. Lebensjahres
-      Unterhaltsvorschuss bekommen, wenn das Elternteil ein Mindesteinkommen hat.
+      alleinerziehenden Elternteil leben haben Anspruch auf Unterhaltszahlungen. Seit
+      Juli 2017 gelten die Altersgrenzen des Mindestunterhalts.
     en: >-
       Children under the age of 12 living with a single parent are entitled to alimony
-      payments. In addition, since July 2017, children up to the age of 18 receive
-      advance on alimony payments if the parent has income beyond a minimal threshold.
+      payments. Since July 2017, the age limits of the minimum alimony apply.
   reference: § 1 Abs. 1, 1a UhVorschG
   2008-01-01:
     1:
@@ -93,28 +76,31 @@ unterhaltsvors_anwendungsvors:
     2: 180
     reference: null
     note: >-
-      Der Mindesunterhalt errechnet sich aus einem Kinderfreibetrag für das sächliche
-      Existenzminimum in Höhe von 2184 Euro und dem geltenden Kindergeld für das erste
-      Kind in Höhe von 184 Euro. Da der Kinderfreibetrag Mitte des Jahres retrospektiv
-      angehoben wurde, gilt im Zuge dessen eine Anwendungsvorschrift, die den alten
-      Kinderfreibetrag für die Berechnung der Unterhaltsleistung unterstellt. § 11a
-      Anwendungsvorschrift: "Im Sinne dieses Gesetzes beträgt für die Zeit vom 1. Januar
-      2015 bis zum 30. Juni 2015 die Unterhaltsleistung nach § 2 Absatz 1 Satz 1
-      monatlich 317 Euro für ein Kind, das das sechste Lebensjahr noch nicht vollendet
-      hat, und monatlich 364 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht
-      vollendet hat."
+      Durch Anpassung des Kinderfreibetrags in der Mitte des Jahres gilt eine vorläufige
+      Anwendungsvorschrift, welche den Mindestunterhalt basierend auf dem alten
+      Kinderfreibetrag berechnet. § 11a Anwendungsvorschrift: "Im Sinne dieses Gesetzes
+      beträgt für die Zeit vom 1. Januar 2015 bis zum 30. Juni 2015 die
+      Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich 317 Euro für ein Kind, das
+      das sechste Lebensjahr noch nicht vollendet hat, und monatlich 364 Euro für ein
+      Kind, das das zwölfte Lebensjahr noch nicht vollendet hat." Der
+      Unterhaltsvorschuss berechnet sich aus diesem Mindestunterhalt abzüglich des
+      Kindergeldes für das erste Kind vor Anpassung des Kinderfreibetrags (hier: 184
+      Euro).
   2015-07-01:
     1: 144
     2: 192
     reference: Artikel 9 Gesetz v. 16.07.2015 BGBl. I S. 1202.
     note: >-
-      § 11a Anwendungsvorschrift: "Für die Zeit vom 1. Juli 2015 bis zum 31.
-      Dezember 2015 beträgt die Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich
-      328 Euro für ein Kind, das das sechste Lebensjahr noch nicht vollendet hat, und
-      monatlich 376 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht vollendet
-      hat. 3Bis zum 31. Dezember 2015 gilt als für ein erstes Kind zu zahlendes
-      Kindergeld im Sinne von § 2 Absatz 2 Satz 1 ein Betrag in Höhe von monatlich 184
-      Euro."
+      § 11a Anwendungsvorschrift: "Für die Zeit vom 1. Juli 2015 bis zum 31. Dezember
+      2015 beträgt die Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich 328 Euro
+      für ein Kind, das das sechste Lebensjahr noch nicht vollendet hat, und monatlich
+      376 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht vollendet hat. 3Bis
+      zum 31. Dezember 2015 gilt als für ein erstes Kind zu zahlendes Kindergeld im
+      Sinne von § 2 Absatz 2 Satz 1 ein Betrag in Höhe von monatlich 184 Euro." Der
+      Unterhaltsvorschuss berechnet sich aus diesem Mindestunterhalt abzüglich des
+      Kindergeldes für das erste Kind vor Anpassung des Kinderfreibetrags (hier: 184
+      Euro). Ab 2016 orientiert sich der Unterhaltsvorschuss wieder an den regulären
+      Mindestunterhaltsbeträgen.
 rounding:
   unterhaltsvors_m:
     note:

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -45,7 +45,7 @@ altersgrenzen:
       payments. In addition, children up to the age of 18 receive advance on alimony
       payments if the parent has income beyond a minimal threshold.
   reference: § 1 Abs. 1, 1a UhVorschG
-  2008-01-01:
+  2009-01-01:
     1: 6
     2: 12
     3: 18

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -38,18 +38,23 @@ altersgrenzen_bezug:
     de: >-
       Kinder, die das 12. Lebensjahr noch nicht vollendet haben und bei einem
       alleinerziehenden Elternteil leben haben Anspruch auf Unterhaltszahlungen. Zudem
-      können auch Kinder bis zur Vollendung des 18. Lebensjahres Unterhaltsvorschuss
-      bekommen, wenn das Elternteil ein Mindesteinkommen hat.
+      können seit Juli 2017 auch Kinder bis zur Vollendung des 18. Lebensjahres
+      Unterhaltsvorschuss bekommen, wenn das Elternteil ein Mindesteinkommen hat.
     en: >-
       Children under the age of 12 living with a single parent are entitled to alimony
-      payments. In addition, children up to the age of 18 receive advance on alimony
-      payments if the parent has income beyond a minimal threshold.
+      payments. In addition, since July 2017, children up to the age of 18 receive
+      advance on alimony payments if the parent has income beyond a minimal threshold.
   reference: § 1 Abs. 1, 1a UhVorschG
-  2009-01-01:
+  2008-01-01:
+    1: 6
+    2: 12
+    reference: G. v. 21.12.2007 BGBl. I S. 3194
+  2017-07-01:
     1: 6
     2: 12
     3: 18
     reference: Artikel 23 G. v. 14.08.2017 BGBl. I S. 3122
+    note: New age group 12 to 17 introduced (§ 1 new Abs. 1a UhVorschG).
 rounding:
   unterhaltsvors_m:
     note:

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -45,7 +45,7 @@ altersgrenzen:
       payments. In addition, children up to the age of 18 receive advance on alimony
       payments if the parent has income beyond a minimal threshold.
   reference: § 1 Abs. 1, 1a UhVorschG
-  2017-01-01:
+  2008-01-01:
     1: 6
     2: 12
     3: 18
@@ -57,3 +57,54 @@ rounding:
       base: 1
       direction: up
       reference: § 9 Abs. 3 UhVorschG
+unterhaltsvors_anwendungsvors:
+  name:
+    de: Unterhaltsvorschuss für Kinder entsprechend Anwendungsvorschriften
+    en: Advance Child Alimony according to application regulations
+  description:
+    de: >-
+      Der Unterhaltsvorschuss wird 2009 bis 2015 prinzipiell berechnet basierend auf den
+      Parametern Kinderfreibetrag für das sächliche Existenzminimum und dem Kindergeld
+      für das erste Kind. Wird das Kindergeld unterjährig geändert oder der
+      Kinderfreibetrag unterjährig rückwirkend geändert, gelten abweichende
+      Abwendungsvorschriften, die von unveränderten Werten für Kindergeld bzw.
+      Kinderfreibetrag ausgehen können. Hier werden die entsprechenden Werte für den
+      Unterhaltsvorschuss (d.h. nach Abzug des unterstellten Kindergeldes) verwendet.
+    en: >-
+      The advance child alimony is calculated in principle from 2009 to 2015 based on
+      the parameters parameters child allowance for the material minimum subsistence
+      level and child benefit for the first child. If the child benefit is changed
+      during the year or the or the child allowance is changed retroactively during the
+      year, deviating application rules apply, which can be based on unchanged values
+      for child benefit or child child allowance can be assumed. Here, the corresponding
+      values for the advance child alimony (i.e. after deduction of the assumed child
+      benefit) are used.
+  unit: Euro
+  reference_period: Month
+  2015-01-01:
+    6: 133
+    12: 180
+    reference:
+    note: >-
+      2015-01-01 bis 2015-06-31 errechnete sich der Mindesunterhalt aus einem
+      Kinderfreibetrag für das sächliche Existenzminimum in Höhe von 2184 Euro und dem
+      geltenden Kindergeld für das erste Kind in Höhe von 184 Euro. Da der
+      Kinderfreibetragtrospektiv Mitte des Jahres retrospektiv angehoben wurde, gilt im
+      Zuge dessen eine Anwendungsvorschrift, die den alten Kinderfreibetrag für die
+      Berechnung der Unterhaltsleistung unterstellt. § 11a Anwendungsvorschrift: "Im
+      Sinne dieses Gesetzes beträgt für die Zeit vom 1. Januar 2015 bis zum 30. Juni
+      2015 die Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich 317 Euro für ein
+      Kind, das das sechste Lebensjahr noch nicht vollendet hat, und monatlich 364 Euro
+      für ein Kind, das das zwölfte Lebensjahr noch nicht vollendet hat."
+  2015-07-01:
+    6: 144
+    12: 192
+    reference: Artikel 9 Gesetz v. 16.07.2015 BGBl. I S. 1202.
+    note: >-
+      § 11a Anwendungsvorschrift: "Für die Zeit vom 1. Juli 2015 bis zum 31.
+      Dezember 2015 beträgt die Unterhaltsleistung nach § 2 Absatz 1 Satz 1 monatlich
+      328 Euro für ein Kind, das das sechste Lebensjahr noch nicht vollendet hat, und
+      monatlich 376 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht vollendet
+      hat. 3Bis zum 31. Dezember 2015 gilt als für ein erstes Kind zu zahlendes
+      Kindergeld im Sinne von § 2 Absatz 2 Satz 1 ein Betrag in Höhe von monatlich 184
+      Euro."

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -46,15 +46,13 @@ altersgrenzen_bezug:
       advance on alimony payments if the parent has income beyond a minimal threshold.
   reference: § 1 Abs. 1, 1a UhVorschG
   2008-01-01:
-    1: 6
-    2: 12
+    1:
+      min_alter: 0
+      max_alter: 5
+    2:
+      min_alter: 6
+      max_alter: 11
     reference: G. v. 21.12.2007 BGBl. I S. 3194
-  2017-07-01:
-    1: 6
-    2: 12
-    3: 18
-    reference: Artikel 23 G. v. 14.08.2017 BGBl. I S. 3122
-    note: New age group 12 to 17 introduced (§ 1 new Abs. 1a UhVorschG).
 faktor_jüngste_altersgruppe:
   name:
     de: >-
@@ -91,8 +89,8 @@ unterhaltsvors_anwendungsvors:
   unit: Euro
   reference_period: Month
   2015-01-01:
-    6: 133
-    12: 180
+    1: 133
+    2: 180
     reference: null
     note: >-
       Der Mindesunterhalt errechnet sich aus einem Kinderfreibetrag für das sächliche
@@ -106,8 +104,8 @@ unterhaltsvors_anwendungsvors:
       hat, und monatlich 364 Euro für ein Kind, das das zwölfte Lebensjahr noch nicht
       vollendet hat."
   2015-07-01:
-    6: 144
-    12: 192
+    1: 144
+    2: 192
     reference: Artikel 9 Gesetz v. 16.07.2015 BGBl. I S. 1202.
     note: >-
       § 11a Anwendungsvorschrift: "Für die Zeit vom 1. Juli 2015 bis zum 31.

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -187,13 +187,13 @@ def _unterhaltsvors_anspruch_kind_m_2009_bis_2014(
         "sächl_existenzmin"
     ]
 
-    if alter < altersgrenzen[1]:
+    if altersgrenzen[1]["min_alter"] <= alter <= altersgrenzen[1]["max_alter"]:
         out = (
             unterhaltsvors_params["faktor_jüngste_altersgruppe"]
             * (2 * kinderfreib_sächl_existenzmin / 12)
             - _kindergeld_erstes_kind_m
         )
-    elif altersgrenzen[1] <= alter < altersgrenzen[2]:
+    elif altersgrenzen[2]["min_alter"] <= alter <= altersgrenzen[2]["max_alter"]:
         out = 2 * kinderfreib_sächl_existenzmin / 12 - _kindergeld_erstes_kind_m
     else:
         out = 0.0
@@ -231,10 +231,10 @@ def _unterhaltsvors_anspruch_kind_m_anwendungsvors(
 
     unterhaltsvors = unterhaltsvors_params["unterhaltsvors_anwendungsvors"]
 
-    if alter < altersgrenzen[1]:
-        out = unterhaltsvors[altersgrenzen[1]]
-    elif altersgrenzen[1] <= alter < altersgrenzen[2]:
-        out = unterhaltsvors[altersgrenzen[2]]
+    if altersgrenzen[1]["min_alter"] <= alter <= altersgrenzen[1]["max_alter"]:
+        out = unterhaltsvors[1]
+    elif altersgrenzen[2]["min_alter"] <= alter <= altersgrenzen[2]["max_alter"]:
+        out = unterhaltsvors[2]
     else:
         out = 0.0
 
@@ -250,7 +250,6 @@ def _unterhaltsvors_anspruch_kind_m_2016_bis_201706(
     alter: int,
     _kindergeld_erstes_kind_m: float,
     unterhalt_params: dict,
-    unterhaltsvors_params: dict,
 ) -> float:
     """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
@@ -268,20 +267,17 @@ def _unterhaltsvors_anspruch_kind_m_2016_bis_201706(
         See :func:`_kindergeld_erstes_kind_m`.
     unterhalt_params
         See params documentation :ref:`unterhalt_params <unterhalt_params>`.
-    unterhaltsvors_params
-        See params documentation :ref:`unterhaltsvors_params <unterhaltsvors_params>`.
 
     Returns
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
     mindestunterhalt = unterhalt_params["mindestunterhalt"]
 
-    if alter < altersgrenzen[1]:
-        out = mindestunterhalt[altersgrenzen[1]] - _kindergeld_erstes_kind_m
-    elif altersgrenzen[1] <= alter < altersgrenzen[2]:
-        out = mindestunterhalt[altersgrenzen[2]] - _kindergeld_erstes_kind_m
+    if mindestunterhalt[1]["min_alter"] <= alter <= mindestunterhalt[1]["max_alter"]:
+        out = mindestunterhalt[1]["betrag"] - _kindergeld_erstes_kind_m
+    elif mindestunterhalt[2]["min_alter"] <= alter <= mindestunterhalt[2]["max_alter"]:
+        out = mindestunterhalt[2]["betrag"] - _kindergeld_erstes_kind_m
     else:
         out = 0.0
 
@@ -298,7 +294,8 @@ def _unterhaltsvors_anspruch_kind_m_ab_201707(
 ) -> float:
     """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
-    Introduction of a minimum income threshold if child is older than some threshold.
+    Introduction of a minimum income threshold if child is older than some threshold and
+    third age group (12-17) via Artikel 23 G. v. 14.08.2017 BGBl. I S. 3122.
 
     Parameters
     ----------
@@ -317,15 +314,14 @@ def _unterhaltsvors_anspruch_kind_m_ab_201707(
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
     mindestunterhalt = unterhalt_params["mindestunterhalt"]
 
-    if alter < altersgrenzen[1]:
-        out = mindestunterhalt[altersgrenzen[1]] - _kindergeld_erstes_kind_m
-    elif altersgrenzen[1] <= alter < altersgrenzen[2]:
-        out = mindestunterhalt[altersgrenzen[2]] - _kindergeld_erstes_kind_m
-    elif altersgrenzen[2] <= alter < altersgrenzen[3]:
-        out = mindestunterhalt[altersgrenzen[3]] - _kindergeld_erstes_kind_m
+    if mindestunterhalt[1]["min_alter"] <= alter <= mindestunterhalt[1]["max_alter"]:
+        out = mindestunterhalt[1]["betrag"] - _kindergeld_erstes_kind_m
+    elif mindestunterhalt[2]["min_alter"] <= alter <= mindestunterhalt[2]["max_alter"]:
+        out = mindestunterhalt[2]["betrag"] - _kindergeld_erstes_kind_m
+    elif mindestunterhalt[3]["min_alter"] <= alter <= mindestunterhalt[3]["max_alter"]:
+        out = mindestunterhalt[3]["betrag"] - _kindergeld_erstes_kind_m
     else:
         out = 0.0
 

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -66,8 +66,7 @@ def unterhaltsvors_m(
 def unterhaltsvors_not_implemented_m() -> float:
     raise NotImplementedError(
         """
-        Unterhaltsvorschuss is not implemented prior to 2008.
-        https://github.com/iza-institute-of-labor-economics/gettsim/issues/566
+        Unterhaltsvorschuss is not implemented prior to 2009.
     """
     )
 

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -239,10 +239,10 @@ def _unterhaltsvors_anspruch_kind_m_anwendungsvors(
 
 @policy_info(
     start_date="2016-01-01",
-    end_date="2016-12-31",
+    end_date="2017-06-30",
     name_in_dag="_unterhaltsvors_anspruch_kind_m",
 )
-def _unterhaltsvors_anspruch_kind_m_2016(
+def _unterhaltsvors_anspruch_kind_m_2016_bis_201706(
     alter: int,
     _kindergeld_erstes_kind_m: float,
     unterhalt_params: dict,
@@ -284,8 +284,8 @@ def _unterhaltsvors_anspruch_kind_m_2016(
     return out
 
 
-@policy_info(start_date="2017-01-01", name_in_dag="_unterhaltsvors_anspruch_kind_m")
-def _unterhaltsvors_anspruch_kind_m_ab_2017(
+@policy_info(start_date="2017-07-01", name_in_dag="_unterhaltsvors_anspruch_kind_m")
+def _unterhaltsvors_anspruch_kind_m_ab_201707(
     alter: int,
     _unterhaltsvorschuss_empf_eink_above_income_threshold: bool,
     _kindergeld_erstes_kind_m: float,

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -154,14 +154,12 @@ def _unterhaltsvors_anspruch_kind_m_2009_bis_2014(
     unterhaltsvors_params: dict,
     eink_st_abzuege_params: dict,
 ) -> float:
-    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level for the
-    years 2009 to 2014.
+    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
     Relevant parameter is directly 'steuerfrei zu stellenden sächlichen Existenzminimum
     des minderjährigen Kindes' § 1612a (1). Modeling relative to the child allowance for
     this. The amout for the lower age group is defined relative to the middle age group
-    with a factor of 0.87. There is probably a rounding rule documented somewhere in
-    some (Durchführungs-)Verordnung.
+    with a factor of 0.87.
 
     Rule was in priciple also active for 2015 but has been overwritten by an
     Anwendungsvorschrift as Kinderfreibetrag and Kindergeld changed on July 2015.
@@ -181,7 +179,7 @@ def _unterhaltsvors_anspruch_kind_m_2009_bis_2014(
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen"]
+    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
 
     kinderfreib_sächl_existenzmin = eink_st_abzuege_params["kinderfreib"][
         "sächl_existenzmin"
@@ -208,12 +206,11 @@ def _unterhaltsvors_anspruch_kind_m_anwendungsvors(
     alter: int,
     unterhaltsvors_params: dict,
 ) -> float:
-    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level over
-    the year 2015.
+    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
     Rule _unterhaltsvors_anspruch_kind_m_2009_bis_2014 was in priciple also active for
     2015 but has been overwritten by an Anwendungsvorschrift as Kinderfreibetrag and
-    Kindergeld changed on July 2015.
+    Kindergeld changed in July 2015.
 
     Parameters
     ----------
@@ -226,7 +223,7 @@ def _unterhaltsvors_anspruch_kind_m_anwendungsvors(
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen"]
+    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
 
     unterhaltsvors = unterhaltsvors_params["unterhaltsvors_anwendungsvors"]
 
@@ -251,8 +248,7 @@ def _unterhaltsvors_anspruch_kind_m_2016(
     unterhalt_params: dict,
     unterhaltsvors_params: dict,
 ) -> float:
-    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level for the
-    year 2016.
+    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
     § 2 Unterhaltsvorschussgesetz refers to Section § 1612a BGB. There still is the
     reference to 'steuerfrei zu stellenden sächlichen Existenzminimum des minderjährigen
@@ -275,7 +271,7 @@ def _unterhaltsvors_anspruch_kind_m_2016(
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen"]
+    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
     mindestunterhalt = unterhalt_params["mindestunterhalt"]
 
     if alter < altersgrenzen[1]:
@@ -296,8 +292,9 @@ def _unterhaltsvors_anspruch_kind_m_ab_2017(
     unterhalt_params: dict,
     unterhaltsvors_params: dict,
 ) -> float:
-    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level since
-    2017.
+    """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
+
+    Introduction of a minimum income threshold if child is older than some threshold.
 
     Parameters
     ----------
@@ -316,7 +313,7 @@ def _unterhaltsvors_anspruch_kind_m_ab_2017(
     -------
 
     """
-    altersgrenzen = unterhaltsvors_params["altersgrenzen"]
+    altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
     mindestunterhalt = unterhalt_params["mindestunterhalt"]
 
     if alter < altersgrenzen[1]:

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -290,7 +290,6 @@ def _unterhaltsvors_anspruch_kind_m_ab_201707(
     _unterhaltsvorschuss_empf_eink_above_income_threshold: bool,
     _kindergeld_erstes_kind_m: float,
     unterhalt_params: dict,
-    unterhaltsvors_params: dict,
 ) -> float:
     """Claim for advance on alimony payment (Unterhaltsvorschuss) on child level.
 
@@ -307,8 +306,6 @@ def _unterhaltsvors_anspruch_kind_m_ab_201707(
         See :func:`_kindergeld_erstes_kind_m`.
     unterhalt_params
         See params documentation :ref:`unterhalt_params <unterhalt_params>`.
-    unterhaltsvors_params
-        See params documentation :ref:`unterhaltsvors_params <unterhaltsvors_params>`.
 
     Returns
     -------
@@ -320,17 +317,12 @@ def _unterhaltsvors_anspruch_kind_m_ab_201707(
         out = mindestunterhalt[1]["betrag"] - _kindergeld_erstes_kind_m
     elif mindestunterhalt[2]["min_alter"] <= alter <= mindestunterhalt[2]["max_alter"]:
         out = mindestunterhalt[2]["betrag"] - _kindergeld_erstes_kind_m
-    elif mindestunterhalt[3]["min_alter"] <= alter <= mindestunterhalt[3]["max_alter"]:
+    elif (
+        mindestunterhalt[3]["min_alter"] <= alter <= mindestunterhalt[3]["max_alter"]
+        and _unterhaltsvorschuss_empf_eink_above_income_threshold
+    ):
         out = mindestunterhalt[3]["betrag"] - _kindergeld_erstes_kind_m
     else:
-        out = 0.0
-
-    # Older kids get it only if the single parent has income > mindesteinkommen.
-    if (
-        out > 0
-        and (alter >= unterhaltsvors_params["altersgrenze_mindesteinkommen"])
-        and (not _unterhaltsvorschuss_empf_eink_above_income_threshold)
-    ):
         out = 0.0
 
     return out

--- a/src/_gettsim/transfers/unterhaltsvors.py
+++ b/src/_gettsim/transfers/unterhaltsvors.py
@@ -179,6 +179,8 @@ def _unterhaltsvors_anspruch_kind_m_2009_bis_2014(
     -------
 
     """
+    # TODO(@MImmesberger): Remove explicit parameter conversion.
+    # https://github.com/iza-institute-of-labor-economics/gettsim/issues/575
     altersgrenzen = unterhaltsvors_params["altersgrenzen_bezug"]
 
     kinderfreib_sächl_existenzmin = eink_st_abzuege_params["kinderfreib"][
@@ -187,7 +189,9 @@ def _unterhaltsvors_anspruch_kind_m_2009_bis_2014(
 
     if alter < altersgrenzen[1]:
         out = (
-            0.87 * (2 * kinderfreib_sächl_existenzmin / 12) - _kindergeld_erstes_kind_m
+            unterhaltsvors_params["faktor_jüngste_altersgruppe"]
+            * (2 * kinderfreib_sächl_existenzmin / 12)
+            - _kindergeld_erstes_kind_m
         )
     elif altersgrenzen[1] <= alter < altersgrenzen[2]:
         out = 2 * kinderfreib_sächl_existenzmin / 12 - _kindergeld_erstes_kind_m

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2009/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2009/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 158.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2009/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2009/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 117.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2010/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2010/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2010/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2010/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2011/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2011/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2011/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2011/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2012/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2012/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2012/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2012/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2013/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2013/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2013/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2013/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2014/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2014/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2014/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2014/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2015-07/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2015-07/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.berit-sander.de/2015/aktueller-unterhaltsvorschuss-ab-01-08-2015/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 192.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2015-07/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2015-07/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.berit-sander.de/2015/aktueller-unterhaltsvorschuss-ab-01-08-2015/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 144.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2015/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2015/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 180.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2015/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2015/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: Regression test.
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 133.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2016/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2016/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.berit-sander.de/2016/unterhaltsvorschuss-zum-01-01-2016/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 194.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2016/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2016/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.berit-sander.de/2016/unterhaltsvorschuss-zum-01-01-2016/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 145.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 201.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 268.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017-07/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 150.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 201.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2017/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,35 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 150.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 205.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 273.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2018-1/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 154.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html#google_vignette
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 202.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 272.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-07/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 150.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html#google_vignette
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 212.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 282.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2019-1/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 160.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 220.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/aenderungen-2020-kinderzuschlag-unterhaltsvorschuss-freibetraege-142746
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/aenderungen-2020-kinderzuschlag-unterhaltsvorschuss-freibetraege-142746
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 293.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2020/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/aenderungen-2020-kinderzuschlag-unterhaltsvorschuss-freibetraege-142746
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 165.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/aenderungen-2020-kinderzuschlag-unterhaltsvorschuss-freibetraege-142746
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 232.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 309.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2021/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 174.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 236.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html#google_vignette
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html#google_vignette
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 314.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2022/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html#google_vignette
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 177.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.lohnsteuer-kompakt.de/steuerwissen/unterhaltsvorschuss-wird-erhoeht/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 252.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.lohnsteuer-kompakt.de/steuerwissen/unterhaltsvorschuss-wird-erhoeht/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.lohnsteuer-kompakt.de/steuerwissen/unterhaltsvorschuss-wird-erhoeht/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 338.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2023/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.lohnsteuer-kompakt.de/steuerwissen/unterhaltsvorschuss-wird-erhoeht/
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 187.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_mittlere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_mittlere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the middle age group (6-11).
+  source: https://www.bmfsfj.de/bmfsfj/themen/familie/familienleistungen/unterhaltsvorschuss/unterhaltsvorschuss-73558
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 8
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 301.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_obere_altergruppe_kein_einkommen.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.bmfsfj.de/bmfsfj/themen/familie/familienleistungen/unterhaltsvorschuss/unterhaltsvorschuss-73558
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 0.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_untere_altergruppe.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshoehe_untere_altergruppe.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the lower age group (0-5).
+  source: https://www.bmfsfj.de/bmfsfj/themen/familie/familienleistungen/unterhaltsvorschuss/unterhaltsvorschuss-73558
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 4
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 0.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 230.0

--- a/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshuehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
+++ b/src/_gettsim_tests/test_data/unterhaltsvors/2024/anspruchshuehe_obere_altergruppe_kein_einkommen_ueber_einkommensgrenze.yaml
@@ -1,0 +1,38 @@
+---
+info:
+  note: One child in the upper age group (12-17).
+  source: https://www.bmfsfj.de/bmfsfj/themen/familie/familienleistungen/unterhaltsvorschuss/unterhaltsvorschuss-73558
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_elternteil_1:
+      - -1
+      - 0
+    p_id_elternteil_2:
+      - -1
+      - -1
+    p_id_kindergeld_empf:
+      - -1
+      - 0
+    alter:
+      - 45
+      - 15
+    alleinerz:
+      - true
+      - false
+    unterhaltsvorschuss_eink_m:
+      - 1000.0
+      - 0.0
+    kind_unterh_erhalt_m:
+      - 0.0
+      - 0.0
+  assumed: {}
+outputs:
+  unterhaltsvors_m:
+    - 0.0
+    - 395.0


### PR DESCRIPTION
This PR implements Unterhaltsvorschuss for the years 2009 to 2016.

Closes https://github.com/iza-institute-of-labor-economics/gettsim/issues/566
Closes #479 

Implementation before 2009 will be a separate PR once this is done.

## Tests/comparison


### Test with synthetic household middle age group child (6-11)

````python
data = create_synthetic_data(
    n_adults=1,
    n_children=1,
    specs_constant_over_households={"bruttolohn_m": [0.0, 0.0], "alter": [35, 7]},
)
````

|         | GETTSIM | ifo      | [Wiki](https://de.wikipedia.org/wiki/Unterhaltsvorschuss) | Other source | Rule |
|---------|---------|----------|-----------|---------|------|
| 2009-01 | 158.00  | (158.00) | 158       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2009-03 | 158.00  | (158.00) | 158       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2009-07 | 158.00  | 158.00   | 158       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030)        | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2010-01 | 180.00  | 180.00   | 180       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/familien-werden-ab-2010-staerker-entlastet-100030)        | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2011-01 | 180.00  | 180.00   | 180       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2012-01 | 180.00  | 180.00   | 180       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2013-01 | 180.00  | 180.00   | 180       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2014-01 | 180.00  | 180.00   | 180       |         | `_unterhaltsvors_anspruch_kind_m_2009_bis_2014` |
| 2015-01 | 180.00  | (180.00) | 180       | [4](https://www.berit-sander.de/2015/aktueller-unterhaltsvorschuss-ab-01-08-2015/)        | `_unterhaltsvors_anspruch_kind_m_anwendungsvors` |
| 2015-07 | 192.00  | 192.00   | 192       | [4](https://www.berit-sander.de/2015/aktueller-unterhaltsvorschuss-ab-01-08-2015/)        | `_unterhaltsvors_anspruch_kind_m_anwendungsvors` |
| 2016-01 | 194.00  | (194.00) | 194       | [3](https://www.berit-sander.de/2016/unterhaltsvorschuss-zum-01-01-2016/)        | `_unterhaltsvors_anspruch_kind_m_2016` |
| 2016-07 | 194.00  | 194.00   | 194       | [3](https://www.berit-sander.de/2016/unterhaltsvorschuss-zum-01-01-2016/)        | `_unterhaltsvors_anspruch_kind_m_2016` |
| 2017-01 | 201.00  | (201.00) | 201       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2017-07 | 201.00  | 201.00   | 201       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2018-01 | 205.00  | 205.00   | 205       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/das-aendert-sich-2018-120510)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2019-01 | 212.00  | (212.00) | 212       | [BMFSFJ](https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2019-07 | 202.00  | 202.00   | 202       | [BMFSFJ](https://www.daten.bmfsfj.de/resource/blob/133150/3d1b9355628bdb262dc4856f11a98e48/unterhaltsvorschuss-einleger-aenderungen-data.pdf)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2020-01 | 220.00  | 220.00   | 220       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/aktuelles/alle-meldungen/aenderungen-2020-kinderzuschlag-unterhaltsvorschuss-freibetraege-142746)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2021-01 | 232.00  | 232.00   | 232       | [Familienportal](https://familienportal.de/familienportal/meta/aktuelles/aktuelle-meldungen/mehr-geld-fuer-familien-mit-kleinen-einkommen-ab-2021-161920)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2022-01 | 236.00  | 236.00   | 236       | [2](https://www.oeffentlichen-dienst.de/wirtschafts-news/129-familienrecht/1230-unterhaltsvorschuss.html)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2023-01 | 252.00  | 252.00   | 252       | [1](https://www.lohnsteuer-kompakt.de/steuerwissen/unterhaltsvorschuss-wird-erhoeht/)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |
| 2024-01 | 301.00  | 301.00   | 301       | [BMFSFJ](https://www.bmfsfj.de/bmfsfj/themen/familie/familienleistungen/unterhaltsvorschuss/unterhaltsvorschuss-73558)        | `_unterhaltsvors_anspruch_kind_m_ab_2017` |



### Test with synthetic household, lower age group child (0-5)

````python
data = create_synthetic_data(
    n_adults=1,
    n_children=1,
    specs_constant_over_households={"bruttolohn_m": [0.0, 0.0], "alter": [35, 5]},
)
````

|         | GETTSIM | ifo      | [Wiki](https://de.wikipedia.org/wiki/Unterhaltsvorschuss) |
|---------|---------|----------|-----------|
| 2009-01 | 117.00  | 116.14*  | 117       |
| 2010-01 | 133.00  | 132.68*  | 133       |
| 2015-01 | 133.00  |          | 133       |
| 2015-07 | 144.00  | 143.12*  | 144       |
| 2016-07 | 145.00  | 145.00   | 145       |
| 2017-01 | 150.00  | (150.00) | 150       |
| 2017-07 | 150.00  | 150.00   | 150       |
| 2018-01 | 154.00  | 154.00   | 154       |
| 2019-01 | 160.00  | (160.00) | 160       |
| 2019-07 | 150.00  | 150.00   | 150       |
| 2020-01 | 165.00  | 165.00   | 165       |
| 2024-01 | 230.00  | 230.00   | 230       |

*no rounding rule applied




### Test with synthetic household, upper age group child (12-17), 0 gross income:

````python
data = create_synthetic_data(
    n_adults=1,
    n_children=1,
    specs_constant_over_households={"bruttolohn_m": [0.0, 0.0], "alter": [35, 15]},
)
````


|         | GETTSIM | ifo      | [Wiki](https://de.wikipedia.org/wiki/Unterhaltsvorschuss) |
|---------|---------|----------|-----------|
| 2016-07 | 0       | 0        | -         |
| 2017-01 | 0       | (0)      | -         |
| 2017-07 | 0       | 0        | -         |
| 2018-01 | 0       | 0        | -         |
| 2024-01 | 0       | 0        | -         |



### Test with synthetic household, upper age group child (12-17), 600 Euro gross income:

````python
data = create_synthetic_data(
    n_adults=1,
    n_children=1,
    specs_constant_over_households={"bruttolohn_m": [600.0, 0.0], "alter": [35, 15]},
)
````


|         | GETTSIM | ifo      | [Wiki](https://de.wikipedia.org/wiki/Unterhaltsvorschuss) |
|---------|---------|----------|-----------|
| 2016-07 | 0       | 0        | -         |
| 2017-01 | 0       | (0)      | -         |
| 2017-07 | 268.00  | 268.00   | 268       |
| 2018-01 | 273.00  | 273.00   | 273         |
| 2024-01 | 395.00  | 395.00   | 395         |


