### PR TITLE
2025 social security and pension parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`809` implement 2025 changes to pensions and social security contributions
+  ({ghuser}`Eric-Sommer`).
 - {gh}`803` Apply correct rounding rules for Ehegattensplitting and update EStG
   parameters ({ghuser}`MImmesberger`, `mjbloemer`).
 - {gh}`797` Update infrastructure to use pixi and modern pre-commit hooks

--- a/src/_gettsim/parameters/ges_rente.yaml
+++ b/src/_gettsim/parameters/ges_rente.yaml
@@ -264,12 +264,15 @@ beitragspflichtiges_durchschnittsentgelt:
     scalar: 42053
     reference: §3 V. v. 24.11.2023 BGBl. 2023 I Nr. 322
   2023-01-01:
-    scalar: 43142
-    reference: §3 V. v. 28.11.2022 BGBl. 2022 I Nr. 2128
-    note: Vorläufiges Durchschnittsentgelt
+    scalar: 44732
+    reference: §3 V. v. 25.11.2024 BGBl. 2024 I Nr. 365.
   2024-01-01:
     scalar: 45358
     reference: §3 V. v. 24.11.2023 BGBl. 2023 I Nr. 322
+    note: Vorläufiges Durchschnittsentgelt
+  2025-01-01:
+    scalar: 50493
+    reference: §3 V. v. 25.11.2024 BGBl. 2024 I Nr. 365.
     note: Vorläufiges Durchschnittsentgelt
 umrechnung_entgeltp_beitrittsgebiet:
   name:
@@ -626,6 +629,10 @@ rentenwert:
   2023-07-01:
     west: 37.60
     ost: 37.60
+  2024-01-07:
+    west: 39.32
+    ost: 39.32
+    reference: V. v. 17.06.2024 BGBl. 2024 I Nr. 194.
 grundr_höchstwert:
   name:
     de: Höchstwert der Entgeltpunkte für Grundrente

--- a/src/_gettsim/parameters/sozialv_beitr.yaml
+++ b/src/_gettsim/parameters/sozialv_beitr.yaml
@@ -272,6 +272,11 @@ beitr_satz:
     ges_krankenv:
       mean_zusatzbeitrag: 0.017
     reference: BAnz AT 31.10.2023 B3
+  2025-01-01:
+    deviation_from: previous
+    ges_krankenv:
+      mean_zusatzbeitrag: 0.025
+    reference: BAnz AT 07.11.2024 B4
 beitr_bemess_grenze_m:
   name:
     de: Beitragsbemessungsgrenzen für die Sozialversicherungsbeiträge
@@ -565,6 +570,14 @@ beitr_bemess_grenze_m:
       west: 7550
       ost: 7450
     reference: V. v. 24.11.2023 BGBl. 2023 I Nr. 322
+  2025-01-01:
+    ges_krankenv:
+      west: 6150
+      ost: 6150
+    ges_rentenv:
+      west: 8050
+      ost: 8050
+    reference: V. v. 25.11.2024 BGBl. 2024 I Nr. 365
 bezugsgröße_selbst_m:
   name:
     de: Monatliche Bezugsgröße
@@ -699,7 +712,11 @@ bezugsgröße_selbst_m:
   2024-01-01:
     west: 3535
     ost: 3465
-    reference: V. v.  29.11.2023 BGBl. 2023 I Nr. 322.
+    reference: V. v. 29.11.2023 BGBl. 2023 I Nr. 322.
+  2025-01-01:
+    west: 3745
+    ost: 3745
+    reference: V. v. 25.11.2024 BGBl. 2024 I Nr. 365.
 mindestanteil_bezugsgröße_beitragspf_einnahme_selbst:
   name:
     de: Mindestberechungsbeitrag für Selbstständige als Anteil der Bezugsgröße

--- a/src/_gettsim/parameters/sozialv_beitr.yaml
+++ b/src/_gettsim/parameters/sozialv_beitr.yaml
@@ -276,7 +276,11 @@ beitr_satz:
     deviation_from: previous
     ges_krankenv:
       mean_zusatzbeitrag: 0.025
-    reference: BAnz AT 07.11.2024 B4
+      reference: BAnz AT 07.11.2024 B4
+    ges_pflegev:
+      standard: 0.018
+      reference: >-
+        Pflege-Beitragssatz-Anpassungsverordnung 2025, Bundestag-Drucksache 20/1371
 beitr_bemess_grenze_m:
   name:
     de: Beitragsbemessungsgrenzen für die Sozialversicherungsbeiträge

--- a/src/_gettsim/parameters/sozialv_beitr.yaml
+++ b/src/_gettsim/parameters/sozialv_beitr.yaml
@@ -572,8 +572,8 @@ beitr_bemess_grenze_m:
     reference: V. v. 24.11.2023 BGBl. 2023 I Nr. 322
   2025-01-01:
     ges_krankenv:
-      west: 6150
-      ost: 6150
+      west: 5512.5
+      ost: 5512.5
     ges_rentenv:
       west: 8050
       ost: 8050


### PR DESCRIPTION
### What problem do you want to solve?
addresses #806 by adding changes to social security contributions and pensions .

To be discussed:
There is no differentiation anymore between East and West Germany with regard to social security and pensions. The easy way (as done here) is to set the `east` and `west` parameter identical henceforth. Alternatively, we could create new functions which ignore the `wohnort_ost` variable.


### Todo

- [x] Pick an appropriate title.
- [x] Put `Closes #XXXX` in the first PR comment to auto-close the relevant issue once
      the PR is accepted. This is not applicable if there is no corresponding issue.
- [x] Document PR in CHANGES.md.
