### PR TITLE
Update KiZ params 2024-2026

### DIFF
--- a/src/_gettsim/parameters/kinderzuschl.yaml
+++ b/src/_gettsim/parameters/kinderzuschl.yaml
@@ -30,26 +30,26 @@ maximum:
     scalar: 292
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
-      according to § 6a (2) BKGG.
-      Satz 1 und 2: (6604-340)/12-250=272. KiZ Höchstbetrag
-      nach Satz 3: max(272,224)=272. Plus KiZ Sofortzuschlag nach Satz 4: 20.
+      There is no law or decree that explicitly sets this parameter; hence, it must be
+      calculated according to § 6a (2) BKGG. Satz 1 und 2: (6604-340)/12-250=272. KiZ
+      Höchstbetrag nach Satz 3: max(272,224)=272. Plus KiZ Sofortzuschlag nach Satz 4:
+      20.
   2025-01-01:
     scalar: 297
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
-      according to § 6a (2) BKGG. Satz 1 und 2:
-      (6648-348)/12-255=270. KiZ Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ
-      Sofortzuschlag nach Satz 4: 25.
+      There is no law or decree that explicitly sets this parameter; hence, it must be
+      calculated according to § 6a (2) BKGG. Satz 1 und 2: (6648-348)/12-255=270. KiZ
+      Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4:
+      25.
   2026-01-01:
     scalar: 297
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
-      according to § 6a (2) BKGG.
-      Satz 1 und 2: (6696-348)/12-259=270. KiZ Höchstbetrag nach Satz 3:
-      max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4: 25.
+      There is no law or decree that explicitly sets this parameter; hence, it must be
+      calculated according to § 6a (2) BKGG. Satz 1 und 2: (6696-348)/12-259=270. KiZ
+      Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4:
+      25.
 kindersofortzuschl:
   name:
     de: Kindersofortzuschlag für Kinderzuschlag

--- a/src/_gettsim/parameters/kinderzuschl.yaml
+++ b/src/_gettsim/parameters/kinderzuschl.yaml
@@ -30,10 +30,23 @@ maximum:
     scalar: 292
     reference: null
     note: >-
-      No law, should be calculated from other parameters (as 2021/2022),
-      but parameters are not known yet.
-    # TODO(@MImmesberger): Add reference or parameters to calculate the max kinderzuschl
-    # https://github.com/iza-institute-of-labor-economics/gettsim/issues/682
+      No overwriting law/decree, should be calculated according to § 6a (2) from other
+      parameters (as 2021/2022). Satz 1 und 2: (6604-340)/12-250=272. KiZ Höchstbetrag
+      nach Satz 3: max(272,224)=272. Plus KiZ Sofortzuschlag nach Satz 4: 20.
+  2025-01-01:
+    scalar: 297
+    reference: null
+    note: >-
+      No overwriting law/decree, calculated according to § 6a (2). Satz 1 und 2:
+      (6648-348)/12-255=270. KiZ Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ
+      Sofortzuschlag nach Satz 4: 25.
+  2025-01-01:
+    scalar: 297
+    reference: null
+    note: >-
+      No overwriting law/decree, calculated according to § 6a (2). nach § 6a (2):
+      Satz 1 und 2: (6696-348)/12-259=270. KiZ Höchstbetrag nach Satz 3:
+      max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4: 25.
 kindersofortzuschl:
   name:
     de: Kindersofortzuschlag für Kinderzuschlag

--- a/src/_gettsim/parameters/kinderzuschl.yaml
+++ b/src/_gettsim/parameters/kinderzuschl.yaml
@@ -30,21 +30,24 @@ maximum:
     scalar: 292
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG.
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
+      according to § 6a (2) BKGG.
       Satz 1 und 2: (6604-340)/12-250=272. KiZ Höchstbetrag
       nach Satz 3: max(272,224)=272. Plus KiZ Sofortzuschlag nach Satz 4: 20.
   2025-01-01:
     scalar: 297
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG. Satz 1 und 2:
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
+      according to § 6a (2) BKGG. Satz 1 und 2:
       (6648-348)/12-255=270. KiZ Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ
       Sofortzuschlag nach Satz 4: 25.
   2026-01-01:
     scalar: 297
     reference: null
     note: >-
-      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG.
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated
+      according to § 6a (2) BKGG.
       Satz 1 und 2: (6696-348)/12-259=270. KiZ Höchstbetrag nach Satz 3:
       max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4: 25.
 kindersofortzuschl:

--- a/src/_gettsim/parameters/kinderzuschl.yaml
+++ b/src/_gettsim/parameters/kinderzuschl.yaml
@@ -30,21 +30,21 @@ maximum:
     scalar: 292
     reference: null
     note: >-
-      No overwriting law/decree, should be calculated according to § 6a (2) from other
-      parameters (as 2021/2022). Satz 1 und 2: (6604-340)/12-250=272. KiZ Höchstbetrag
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG.
+      Satz 1 und 2: (6604-340)/12-250=272. KiZ Höchstbetrag
       nach Satz 3: max(272,224)=272. Plus KiZ Sofortzuschlag nach Satz 4: 20.
   2025-01-01:
     scalar: 297
     reference: null
     note: >-
-      No overwriting law/decree, calculated according to § 6a (2). Satz 1 und 2:
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG. Satz 1 und 2:
       (6648-348)/12-255=270. KiZ Höchstbetrag nach Satz 3: max(270,272)=272. Plus KiZ
       Sofortzuschlag nach Satz 4: 25.
-  2025-01-01:
+  2026-01-01:
     scalar: 297
     reference: null
     note: >-
-      No overwriting law/decree, calculated according to § 6a (2). nach § 6a (2):
+      There is no law or decree that explicitly sets this parameter; hence, it must be calculated according to § 6a (2) BKGG.
       Satz 1 und 2: (6696-348)/12-259=270. KiZ Höchstbetrag nach Satz 3:
       max(270,272)=272. Plus KiZ Sofortzuschlag nach Satz 4: 25.
 kindersofortzuschl:


### PR DESCRIPTION
This PR updates KiZ parameters and references for 2024 to 2026. In the absence of any overriding law or decree, calculations should follow § 6a (2) based on other parameters.