### PR TITLE
Use qualified name for rounding keys in params files

### DIFF
--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -373,7 +373,7 @@ def _add_rounding_to_function(
     """
     func = copy.deepcopy(input_function)
     nice_name = ".".join(path)
-    leaf_name = path[-1]
+    qualified_name = "__".join(path)
 
     if input_function.params_key_for_rounding:
         params_key = func.params_key_for_rounding
@@ -381,20 +381,20 @@ def _add_rounding_to_function(
         if not (
             params_key in params
             and "rounding" in params[params_key]
-            and leaf_name in params[params_key]["rounding"]
+            and qualified_name in params[params_key]["rounding"]
         ):
             raise KeyError(
                 KeyErrorMessage(
                     f"""
                     Rounding specifications for function {nice_name} are expected
                     in the parameter dictionary at:\n
-                    [{params_key!r}]['rounding'][{leaf_name!r}].\n
+                    [{params_key!r}]['rounding'][{qualified_name!r}].\n
                     These nested keys do not exist. If this function should not be
                     rounded, remove the respective decorator.
                     """
                 )
             )
-        rounding_spec = params[params_key]["rounding"][leaf_name]
+        rounding_spec = params[params_key]["rounding"][qualified_name]
         # Check if expected parameters are present in rounding specifications.
         if not ("base" in rounding_spec and "direction" in rounding_spec):
             raise KeyError(
@@ -402,7 +402,7 @@ def _add_rounding_to_function(
                     "Both 'base' and 'direction' are expected as rounding "
                     "parameters in the parameter dictionary. \n "
                     "At least one of them is missing at:\n"
-                    f"[{params_key!r}]['rounding'][{leaf_name!r}]."
+                    f"[{params_key!r}]['rounding'][{qualified_name!r}]."
                 )
             )
         # Add rounding.

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -114,12 +114,14 @@ def test_rounding(base, direction, to_add_after_rounding, input_values, exp_outp
     def test_func(income):
         return income
 
-    data = {"groupings": {"p_id": pd.Series([1, 2])}}
-    data["income"] = pd.Series(input_values)
+    data = {
+        "groupings": {"p_id": pd.Series([1, 2])},
+        "namespace": {"income": pd.Series(input_values)},
+    }
     rounding_specs = {
         "params_key_test": {
             "rounding": {
-                "test_func": {
+                "namespace__test_func": {
                     "base": base,
                     "direction": direction,
                 }
@@ -128,17 +130,23 @@ def test_rounding(base, direction, to_add_after_rounding, input_values, exp_outp
     }
 
     if to_add_after_rounding:
-        rounding_specs["params_key_test"]["rounding"]["test_func"][
+        rounding_specs["params_key_test"]["rounding"]["namespace__test_func"][
             "to_add_after_rounding"
         ] = to_add_after_rounding
 
-    environment = PolicyEnvironment({"test_func": test_func}, rounding_specs)
+    environment = PolicyEnvironment(
+        {"namespace": {"test_func": test_func}}, rounding_specs
+    )
 
     calc_result = compute_taxes_and_transfers(
-        data_tree=data, environment=environment, targets_tree={"test_func": None}
+        data_tree=data,
+        environment=environment,
+        targets_tree={"namespace": {"test_func": None}},
     )
     assert_series_equal(
-        pd.Series(calc_result["test_func"]), pd.Series(exp_output), check_names=False
+        pd.Series(calc_result["namespace"]["test_func"]),
+        pd.Series(exp_output),
+        check_names=False,
     )
 
 


### PR DESCRIPTION
### What problem do you want to solve?

Uses the qualified name instead of the leaf name to look for rounding specs in the params file. This is a temporary solution until we have tackled #823.