### PR TITLE
Use the most recent dags, unify flatten operations

### DIFF
--- a/docs/rtd_environment.yml
+++ b/docs/rtd_environment.yml
@@ -11,7 +11,7 @@ dependencies:
 
   # gettsim dependencies
   - astor
-  - dags
+  - dags>=0.3.0
   - ipywidgets
   - networkx
   - numpy
@@ -33,5 +33,3 @@ dependencies:
   - sphinx-copybutton
   - pip:
       - -e ../
-      - git+https://github.com/OpenSourceEconomics/dags
-      - flatten_dict

--- a/pixi.lock
+++ b/pixi.lock
@@ -263,7 +263,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -497,7 +497,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h01d7ebd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -731,7 +731,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312hea69d52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -972,7 +972,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/90/51523adbedc808e03271c7448fd71da1660cc02603eaaf10b9ab4f102146/kaleido-0.1.0.post1-py2.py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -1244,7 +1244,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -1478,7 +1478,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py311h4d7f069_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -1712,7 +1712,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311h917b07b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -1953,7 +1953,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311he736701_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/90/51523adbedc808e03271c7448fd71da1660cc02603eaaf10b9ab4f102146/kaleido-0.1.0.post1-py2.py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -2225,7 +2225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -2459,7 +2459,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h01d7ebd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -2693,7 +2693,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312hea69d52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -2934,7 +2934,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/90/51523adbedc808e03271c7448fd71da1660cc02603eaaf10b9ab4f102146/kaleido-0.1.0.post1-py2.py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -3217,7 +3217,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/b3/a0f0f4faac229b0011d8c4a7ee6da7c2dca0b6fd08039c95920846f23ca4/kaleido-0.2.1-py2.py3-none-manylinux1_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -3462,7 +3462,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h01d7ebd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h8210216_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f7/0ccaa596ec341963adbb4f839774c36d5659e75a0812d946732b927d480e/kaleido-0.2.1-py2.py3-none-macosx_10_11_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -3707,7 +3707,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312hea69d52_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/45/8e/4297556be5a07b713bb42dde0f748354de9a6918dee251c0e6bdcda341e7/kaleido-0.2.1-py2.py3-none-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl
@@ -3948,7 +3948,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h4389bb4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_1.conda
-      - pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+      - pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
       - pypi: https://files.pythonhosted.org/packages/43/f5/ee39c6e92acc742c052f137b47c210cd0a1b72dcd3f98495528bb4d27761/flatten_dict-0.4.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/77/6f/0da6e0bc90e738fc63c584d65bef326f76a6550343ae1c243647bd1880fd/jax-0.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/3b/68981550dc34b86deb8e50b8cb14fd8bd620876276cfce2218ef7f11be90/jaxlib-0.5.1-cp312-cp312-win_amd64.whl
@@ -5035,9 +5035,9 @@ packages:
   purls: []
   size: 45728
   timestamp: 1741128060593
-- pypi: git+https://github.com/OpenSourceEconomics/dags#4f407198f03cfefbf2ff73e040f00097a4609c37
+- pypi: git+https://github.com/OpenSourceEconomics/dags?rev=b8e2194e235fd10b50a40840002dae8e7ea5e4a2#b8e2194e235fd10b50a40840002dae8e7ea5e4a2
   name: dags
-  version: 0.2.4.dev7+g4f40719
+  version: 0.2.4.dev18+gb8e2194
   requires_dist:
   - flatten-dict
   - networkx
@@ -5578,8 +5578,8 @@ packages:
   timestamp: 1694400856979
 - pypi: .
   name: gettsim
-  version: 0.7.1.dev235+gb364dcf0.d20250318
-  sha256: 25a6028fe7546108edca13705411fb4164ce2110bbf8adfe259143dc46bda3ed
+  version: 0.7.1.dev248+g49900a6f.d20250319
+  sha256: 8079b63057a3b2e4b293ef93e802113133b762fbfd3b743d0877ba7c4c8346ff
   requires_dist:
   - astor
   - ipywidgets

--- a/pixi.lock
+++ b/pixi.lock
@@ -5578,8 +5578,8 @@ packages:
   timestamp: 1694400856979
 - pypi: .
   name: gettsim
-  version: 0.7.1.dev248+g49900a6f.d20250319
-  sha256: 8079b63057a3b2e4b293ef93e802113133b762fbfd3b743d0877ba7c4c8346ff
+  version: 0.7.1.dev252+g406bf28b.d20250319
+  sha256: 56aff80ebaa722eb1b69606afa795de03da62070101282c257220c85adcba8b7
   requires_dist:
   - astor
   - ipywidgets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ pytest-xdist = "*"
 [tool.pixi.pypi-dependencies]
 gettsim = {path = ".", editable = true}
 pdbp = "*"
-dags = {git = "https://github.com/OpenSourceEconomics/dags"}
+dags = {git = "https://github.com/OpenSourceEconomics/dags", rev="b8e2194e235fd10b50a40840002dae8e7ea5e4a2"}
 flatten_dict = "*"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ pytest-xdist = "*"
 [tool.pixi.pypi-dependencies]
 gettsim = {path = ".", editable = true}
 pdbp = "*"
-dags = {git = "https://github.com/OpenSourceEconomics/dags", rev="b8e2194e235fd10b50a40840002dae8e7ea5e4a2"}
+dags = {git = "https://github.com/OpenSourceEconomics/dags"}
 
 
 [tool.pixi.target.unix.pypi-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ pytest-xdist = "*"
 gettsim = {path = ".", editable = true}
 pdbp = "*"
 dags = {git = "https://github.com/OpenSourceEconomics/dags", rev="b8e2194e235fd10b50a40840002dae8e7ea5e4a2"}
-flatten_dict = "*"
 
 
 [tool.pixi.target.unix.pypi-dependencies]

--- a/src/_gettsim/config.py
+++ b/src/_gettsim/config.py
@@ -36,7 +36,6 @@ RESOURCE_DIR = Path(__file__).parent.resolve()
 GEP_01_CHARACTER_LIMIT_USER_FACING_COLUMNS = 20
 GEP_01_CHARACTER_LIMIT_OTHER_COLUMNS = 32
 
-QUALIFIED_NAME_SEPARATOR = "__"
 
 # List of paths to internal functions.
 # If a path is a directory, all Python files are recursively collected from that folder.

--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -4,7 +4,7 @@ import inspect
 import warnings
 from typing import Any, Literal, get_args
 
-import dags
+import dags.tree as dt
 import flatten_dict
 import networkx as nx
 import optree
@@ -120,7 +120,7 @@ def compute_taxes_and_transfers(
         params=environment.params,
     )
 
-    input_structure = dags.create_input_structure_tree(
+    input_structure = dt.create_input_structure_tree(
         functions_tree_not_overridden,
     )
 
@@ -141,7 +141,7 @@ def compute_taxes_and_transfers(
         p_ids=data_tree_with_correct_types.get("demographics", {}).get("p_id", {}),
     )
 
-    tax_transfer_function = dags.concatenate_functions_tree(
+    tax_transfer_function = dt.concatenate_functions_tree(
         functions=functions_tree_with_partialled_parameters,
         targets=targets_tree,
         input_structure=input_structure,
@@ -295,7 +295,7 @@ def _create_input_data_for_concatenated_function(
 
     """
     # Create dag using processed functions
-    dag = dags.dag_tree.create_dag_tree(
+    dag = dt.create_dag_tree(
         functions=functions_tree,
         targets=targets_tree,
         input_structure=input_structure,

--- a/src/_gettsim/policy_environment.py
+++ b/src/_gettsim/policy_environment.py
@@ -4,6 +4,7 @@ import copy
 import datetime
 from typing import TYPE_CHECKING, Any
 
+import dags.tree as dt
 import numpy
 import optree
 import pandas as pd
@@ -414,22 +415,22 @@ def _load_parameter_group_from_yaml(
 
     """
 
-    def subtract_years_from_date(dt, years):
+    def subtract_years_from_date(date, years):
         """Subtract one or more years from a date object."""
         try:
-            dt = dt.replace(year=dt.year - years)
+            date = date.replace(year=date.year - years)
 
         # Take care of leap years
         except ValueError:
-            dt = dt.replace(year=dt.year - years, day=dt.day - 1)
-        return dt
+            date = date.replace(year=date.year - years, day=date.day - 1)
+        return date
 
-    def set_date_to_beginning_of_year(dt):
+    def set_date_to_beginning_of_year(date):
         """Set date to the beginning of the year."""
 
-        dt = dt.replace(month=1, day=1)
+        date = date.replace(month=1, day=1)
 
-        return dt
+        return date
 
     raw_group_data = yaml.load(
         (yaml_path / f"{group}.yaml").read_text(encoding="utf-8"),
@@ -624,8 +625,8 @@ def _fail_if_name_of_last_branch_element_not_leaf_name_of_function(
     """Raise error if a PolicyFunction does not have the same leaf name as the last
     branch element of the tree path.
     """
-    tree_paths, functions, _ = optree.tree_flatten_with_path(functions_tree)
-    for tree_path, function in zip(tree_paths, functions):
+
+    for tree_path, function in dt.flatten_to_tree_paths(functions_tree).items():
         if tree_path[-1] != function.leaf_name:
             raise KeyError(
                 f"""

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -6,7 +6,7 @@ from typing import Any, TypeVar
 import flatten_dict
 import numpy
 import optree
-from dags.signature import rename_arguments
+from dags import rename_arguments
 from flatten_dict.reducers import make_reducer
 from flatten_dict.splitters import make_splitter
 

--- a/src/_gettsim/shared.py
+++ b/src/_gettsim/shared.py
@@ -3,14 +3,12 @@ import textwrap
 from collections.abc import Callable
 from typing import Any, TypeVar
 
-import flatten_dict
+import dags.tree as dt
 import numpy
 import optree
 from dags import rename_arguments
-from flatten_dict.reducers import make_reducer
-from flatten_dict.splitters import make_splitter
 
-from _gettsim.config import QUALIFIED_NAME_SEPARATOR, SUPPORTED_GROUPINGS
+from _gettsim.config import SUPPORTED_GROUPINGS
 from _gettsim.function_types import PolicyFunction
 from _gettsim.gettsim_typing import NestedDataDict, NestedFunctionDict
 
@@ -33,10 +31,6 @@ def format_list_linewise(list_):
         ]
         """
     ).format(formatted_list=formatted_list)
-
-
-qualified_name_reducer = make_reducer(delimiter=QUALIFIED_NAME_SEPARATOR)
-qualified_name_splitter = make_splitter(delimiter=QUALIFIED_NAME_SEPARATOR)
 
 
 def create_tree_from_path_and_value(path: tuple[str], value: Any = None) -> dict:
@@ -176,12 +170,12 @@ def partition_tree_by_reference_tree(
     - The first tree with leaves present in both trees.
     - The second tree with leaves absent in the reference tree.
     """
-    ref_paths = set(flatten_dict.flatten(reference_tree).keys())
-    flat = flatten_dict.flatten(tree_to_partition)
-    intersection = flatten_dict.unflatten(
+    ref_paths = set(dt.tree_paths(reference_tree))
+    flat = dt.flatten_to_tree_paths(tree_to_partition)
+    intersection = dt.unflatten_from_tree_paths(
         {path: leaf for path, leaf in flat.items() if path in ref_paths}
     )
-    difference = flatten_dict.unflatten(
+    difference = dt.unflatten_from_tree_paths(
         {path: leaf for path, leaf in flat.items() if path not in ref_paths}
     )
 

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import flatten_dict
 import optree
-from dags.signature import rename_arguments
+from dags import rename_arguments
 
 from _gettsim.config import (
     SUPPORTED_GROUPINGS,

--- a/src/_gettsim/time_conversion.py
+++ b/src/_gettsim/time_conversion.py
@@ -2,8 +2,7 @@ import inspect
 import re
 from collections.abc import Callable
 
-import flatten_dict
-import optree
+import dags.tree as dt
 from dags import rename_arguments
 
 from _gettsim.config import (
@@ -271,10 +270,10 @@ def create_time_conversion_functions(
     """
 
     converted_functions = {}
-    data_tree_paths = list(flatten_dict.flatten(data_tree).keys())
+    data_tree_paths = dt.tree_paths(data_tree)
 
     # Create time-conversions for existing functions
-    for path, function in zip(*optree.tree_flatten_with_path(functions_tree)[:2]):
+    for path, function in dt.flatten_to_tree_paths(functions_tree).items():
         leaf_name = path[-1]
         all_time_conversions_for_this_function = _create_time_conversion_functions(
             name=leaf_name, func=function
@@ -282,7 +281,7 @@ def create_time_conversion_functions(
         for der_name, der_func in all_time_conversions_for_this_function.items():
             new_path = [*path[:-1], der_name]
             # Skip if the function already exists or the data column exists
-            if new_path in optree.tree_paths(converted_functions) + data_tree_paths:
+            if new_path in dt.tree_paths(converted_functions) + data_tree_paths:
                 continue
             else:
                 converted_functions = insert_path_and_value(
@@ -300,7 +299,7 @@ def create_time_conversion_functions(
         for der_name, der_func in all_time_conversions_for_this_data_column.items():
             new_path = [*path[:-1], der_name]
             # Skip if the function already exists or the data column exists
-            if new_path in optree.tree_paths(converted_functions) + data_tree_paths:
+            if new_path in dt.tree_paths(converted_functions) + data_tree_paths:
                 continue
             else:
                 # Upsert because derived functions based on data should overwrite

--- a/src/_gettsim/visualization.py
+++ b/src/_gettsim/visualization.py
@@ -3,7 +3,7 @@ import inspect
 import operator
 from functools import reduce
 
-import dags
+import dags.tree as dt
 import networkx as nx
 import numpy
 import pandas as pd
@@ -91,7 +91,7 @@ def plot_dag(
     )[1]
 
     # Create parameter input structure.
-    input_structure = dags.dag_tree.create_input_structure_tree(
+    input_structure = dt.create_input_structure_tree(
         functions=functions_not_overridden,
         targets=None,  # None because no functions should be filtered out
     )
@@ -111,7 +111,7 @@ def plot_dag(
         params=environment.params,
     )
 
-    input_structure = dags.dag_tree.create_input_structure_tree(
+    input_structure = dt.create_input_structure_tree(
         functions=processed_functions,
         targets=None,
     )

--- a/src/_gettsim_tests/test_aggregate_by_p_id.py
+++ b/src/_gettsim_tests/test_aggregate_by_p_id.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_aggregate_by_p_id(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_arbeitsl_geld.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_arbeitslosengeld(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_arbeitsl_geld_2.py
+++ b/src/_gettsim_tests/test_arbeitsl_geld_2.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_arbeitslosengeld_2(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_benefit_checks.py
+++ b/src/_gettsim_tests/test_benefit_checks.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_vorrangprüfungen(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_demographic_vars.py
+++ b/src/_gettsim_tests/test_demographic_vars.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_demographics(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_eink_st.py
+++ b/src/_gettsim_tests/test_eink_st.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_einkommensteuer(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_elterngeld.py
+++ b/src/_gettsim_tests/test_elterngeld.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_elterngeld(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_erwerbsm_rente.py
+++ b/src/_gettsim_tests/test_erwerbsm_rente.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_erwerbsminderungsrente(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_erziehungsgeld.py
+++ b/src/_gettsim_tests/test_erziehungsgeld.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_erziehungsgeld(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_favorability_check.py
+++ b/src/_gettsim_tests/test_favorability_check.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_vorrangprüfungen(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_full_taxes_and_transfers(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_ges_rente_hinzuverdienst.py
+++ b/src/_gettsim_tests/test_ges_rente_hinzuverdienst.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_gesetzliche_rente_hinzuverdienst(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_ges_rentenalter.py
+++ b/src/_gettsim_tests/test_ges_rentenalter.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_altersrente_altersgrenzen(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_groupings.py
+++ b/src/_gettsim_tests/test_groupings.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_groupings(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_grundrente.py
+++ b/src/_gettsim_tests/test_grundrente.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -37,8 +37,8 @@ def test_grundrente(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()
@@ -74,8 +74,8 @@ def test_grundrente_proxy_rente(
         },
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_result_previous_year = flatten_dict.flatten(result_previous_year)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_result_previous_year = dt.flatten_to_qual_names(result_previous_year)
     assert_array_almost_equal(
         flat_result["sozialversicherung__rente__grundrente__proxy_rente_vorjahr_m"],
         flat_result_previous_year[

--- a/src/_gettsim_tests/test_grunds_im_alter.py
+++ b/src/_gettsim_tests/test_grunds_im_alter.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_grundsicherung_im_alter(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_kindergeld.py
+++ b/src/_gettsim_tests/test_kindergeld.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_kindergeld(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_kinderzuschl.py
+++ b/src/_gettsim_tests/test_kinderzuschl.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_kinderzuschlag(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_lohnst.py
+++ b/src/_gettsim_tests/test_lohnst.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -36,8 +36,8 @@ def test_lohnsteuer(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_minijobgrenze.py
+++ b/src/_gettsim_tests/test_minijobgrenze.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_minijobgrenze(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_renten_anspr.py
+++ b/src/_gettsim_tests/test_renten_anspr.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_gesetzliche_rente(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_rounding.py
+++ b/src/_gettsim_tests/test_rounding.py
@@ -1,9 +1,9 @@
 import datetime
 
+import dags.tree as dt
 import pandas as pd
 import pytest
 import yaml
-from optree import tree_flatten
 from pandas._testing import assert_series_equal
 
 from _gettsim.config import (
@@ -277,9 +277,9 @@ def test_decorator_for_all_functions_with_rounding_spec():
     # addressed.
     time_dependent_functions = {}
     for year in range(1990, 2023):
-        year_functions = tree_flatten(
+        year_functions = dt.flatten_to_tree_paths(
             load_functions_tree_for_date(datetime.date(year=year, month=1, day=1))
-        )[0]
+        ).values()
         function_name_to_leaf_name_dict = {
             func.function.__name__: func.leaf_name for func in year_functions
         }

--- a/src/_gettsim_tests/test_soli_st.py
+++ b/src/_gettsim_tests/test_soli_st.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_solidaritätszuschlag(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_sozialv_beitr.py
+++ b/src/_gettsim_tests/test_sozialv_beitr.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_sozialversicherungsbeiträge(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_time_conversion.py
+++ b/src/_gettsim_tests/test_time_conversion.py
@@ -1,7 +1,7 @@
 import inspect
 
+import dags.tree as dt
 import pytest
-from optree import tree_paths
 
 from _gettsim.function_types import policy_function
 from _gettsim.time_conversion import (
@@ -282,8 +282,8 @@ class TestCreateFunctionsForTimeUnits:
     def test_should_return_nested_dict(self, functions_tree, expected) -> None:
         time_conversion_functions = create_time_conversion_functions(functions_tree, {})
 
-        expected_path = tree_paths(expected)
-        result_path = tree_paths(time_conversion_functions)
+        expected_path = dt.tree_paths(expected)
+        result_path = dt.tree_paths(time_conversion_functions)
 
         assert expected_path == result_path
 

--- a/src/_gettsim_tests/test_unterhalt.py
+++ b/src/_gettsim_tests/test_unterhalt.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_unterhalt(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_unterhaltsvors.py
+++ b/src/_gettsim_tests/test_unterhaltsvors.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_unterhaltsvorschuss(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_vectorization.py
+++ b/src/_gettsim_tests/test_vectorization.py
@@ -2,9 +2,9 @@ import datetime
 import inspect
 import string
 
+import dags.tree as dt
 import numpy
 import pytest
-from optree import tree_flatten
 
 from _gettsim.config import USE_JAX
 
@@ -373,9 +373,9 @@ for year in range(1990, 2023):
         "func",
         [
             pf.function
-            for pf in tree_flatten(
+            for pf in dt.flatten_to_tree_paths(
                 load_functions_tree_for_date(datetime.date(year=year, month=1, day=1))
-            )[0]
+            ).values()
             if not isinstance(pf, GroupByFunction)
         ],
     )

--- a/src/_gettsim_tests/test_vorsorgeaufw.py
+++ b/src/_gettsim_tests/test_vorsorgeaufw.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_vorsorgeaufwand(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_wohngeld.py
+++ b/src/_gettsim_tests/test_wohngeld.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_wohngeld(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()

--- a/src/_gettsim_tests/test_zu_verst_eink.py
+++ b/src/_gettsim_tests/test_zu_verst_eink.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING
 
-import flatten_dict
+import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
@@ -35,8 +35,8 @@ def test_zu_versteuerndes_einkommen(
         data_tree=input_tree, environment=environment, targets_tree=target_structure
     )
 
-    flat_result = flatten_dict.flatten(result)
-    flat_expected_output_tree = flatten_dict.flatten(expected_output_tree)
+    flat_result = dt.flatten_to_qual_names(result)
+    flat_expected_output_tree = dt.flatten_to_qual_names(expected_output_tree)
 
     for result, expected in zip(
         flat_result.values(), flat_expected_output_tree.values()


### PR DESCRIPTION
- Convention is to `import dags.tree as dt`
- This should have all flattening/unflattening utilities for dicts of functions etc.
- Simplifies lots of code
- Remove usage of `flatten_dict` everywhere (still left in the tests), reduce usage of optree.