### PR TITLE
Make top-level namespace include potential derived functions

### DIFF
--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -37,7 +37,7 @@ from ttsim.shared import (
     merge_trees,
     partition_by_reference_dict,
 )
-from ttsim.time_conversion import _TIME_UNITS
+from ttsim.time_conversion import TIME_UNITS
 from ttsim.typing import (
     check_series_has_expected_type,
     convert_series_to_internal_type,
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
         NestedTargetDict,
         QualNameDataDict,
         QualNameTargetList,
+        QualNameTTSIMFunctionDict,
         QualNameTTSIMObjectDict,
     )
 
@@ -94,8 +95,8 @@ def compute_taxes_and_transfers(
     # Transform functions tree to qualified names dict with qualified arguments
     top_level_namespace = _get_top_level_namespace(
         environment=environment,
-        supported_time_conversions=list(_TIME_UNITS.keys()),
-        supported_groupings=list(SUPPORTED_GROUPINGS.keys()),
+        supported_time_conversions=tuple(TIME_UNITS.keys()),
+        supported_groupings=tuple(SUPPORTED_GROUPINGS.keys()),
     )
     functions = dt.functions_without_tree_logic(
         functions=environment.functions_tree, top_level_namespace=top_level_namespace
@@ -137,7 +138,7 @@ def compute_taxes_and_transfers(
 
     # Remove unnecessary elements from user-provided data.
     input_data = _create_input_data_for_concatenated_function(
-        data=data_with_correct_types,
+        data=data,
         functions=functions_with_partialled_parameters,
         targets=targets,
     )
@@ -174,8 +175,8 @@ def compute_taxes_and_transfers(
 
 def _get_top_level_namespace(
     environment: PolicyEnvironment,
-    supported_time_conversions: list[str],
-    supported_groupings: list[str],
+    supported_time_conversions: tuple[str, ...],
+    supported_groupings: tuple[str, ...],
 ) -> set[str]:
     """Get the top level namespace.
 

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -33,7 +33,7 @@ from ttsim.shared import (
     format_list_linewise,
     get_name_of_group_by_id,
     get_names_of_arguments_without_defaults,
-    get_re_pattern_for_time_units_and_groupings,
+    get_re_pattern_for_all_time_units_and_groupings,
     merge_trees,
     partition_by_reference_dict,
 )
@@ -193,12 +193,12 @@ def _get_top_level_namespace(
     direct_top_level_names = set(environment.raw_objects_tree.keys()) | set(
         environment.aggregation_specs_tree.keys()
     )
-    all_top_level_names = set()
-    re_pattern = get_re_pattern_for_time_units_and_groupings(
+    re_pattern = get_re_pattern_for_all_time_units_and_groupings(
         supported_groupings=supported_groupings,
         supported_time_units=supported_time_conversions,
     )
 
+    all_top_level_names = set()
     for name in direct_top_level_names:
         match = re_pattern.fullmatch(name)
         function_base_name = match.group("base_name")

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -196,14 +196,17 @@ def _get_top_level_namespace(
         if match := re_pattern.fullmatch(element):
             function_base_name = match.group("base_name")
             create_conversions_for_time_units = bool(match.group("time_unit"))
+        else:
+            function_base_name = element
+            create_conversions_for_time_units = False
 
-            potential_derived_functions = potential_target_names_from_base_name(
-                base_name=function_base_name,
-                supported_time_conversions=supported_time_conversions,
-                supported_groupings=supported_groupings,
-                create_conversions_for_time_units=create_conversions_for_time_units,
-            )
-            potential_function_names.update(potential_derived_functions)
+        potential_derived_functions = potential_target_names_from_base_name(
+            base_name=function_base_name,
+            supported_time_conversions=supported_time_conversions,
+            supported_groupings=supported_groupings,
+            create_conversions_for_time_units=create_conversions_for_time_units,
+        )
+        potential_function_names.update(potential_derived_functions)
 
     return potential_function_names
 

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -201,11 +201,11 @@ def _get_top_level_namespace(
     all_top_level_names = set()
     for name in direct_top_level_names:
         match = re_pattern.fullmatch(name)
-        function_base_name = match.group("base_name")
+        base_name = match.group("base_name")
         create_conversions_for_time_units = bool(match.group("time_unit"))
 
         all_top_level_names_for_name = all_variations_of_base_name(
-            base_name=function_base_name,
+            base_name=base_name,
             supported_time_conversions=supported_time_conversions,
             supported_groupings=supported_groupings,
             create_conversions_for_time_units=create_conversions_for_time_units,

--- a/src/ttsim/function_types.py
+++ b/src/ttsim/function_types.py
@@ -379,8 +379,6 @@ class DerivedTimeConversionFunction(TTSIMFunction):
     def __post_init__(self):
         if self.source is None:
             raise ValueError("The source must be specified.")
-        if self.conversion_target is None:
-            raise ValueError("The conversion target must be specified.")
 
 
 def _convert_and_validate_dates(

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -38,7 +38,7 @@ def validate_date_range(start: datetime.date, end: datetime.date):
 
 
 def get_re_pattern_for_time_units_and_groupings(
-    supported_groupings: list[str], supported_time_units: list[str]
+    supported_groupings: tuple[str, ...], supported_time_units: tuple[str, ...]
 ) -> re.Pattern:
     """Get a regex pattern for time units and groupings.
 

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -70,6 +70,41 @@ def get_re_pattern_for_time_units_and_groupings(
     )
 
 
+def get_re_pattern_for_some_base_name(
+    base_name: str, supported_time_units: list[str], supported_groupings: list[str]
+) -> re.Pattern:
+    """Get a regex for a specific base name with optional time unit and aggregation.
+
+    The pattern matches strings in any of these formats:
+    - <specific_base_name>
+    - <specific_base_name>_<time_unit>
+    - <specific_base_name>_<aggregation>
+    - <specific_base_name>_<time_unit>_<aggregation>
+
+    Parameters
+    ----------
+    base_name
+        The specific base name to match.
+    supported_time_units
+        The supported time units.
+    supported_groupings
+        The supported groupings.
+
+    Returns
+    -------
+    pattern
+        The regex pattern.
+    """
+    units = "".join(supported_time_units)
+    groupings = "|".join(supported_groupings)
+    return re.compile(
+        f"(?P<base_name>{re.escape(base_name)})"
+        f"(?:_(?P<time_unit>[{units}]))?"
+        f"(?:_(?P<aggregation>{groupings}))?"
+        f"$"
+    )
+
+
 def all_variations_of_base_name(
     base_name: str,
     supported_time_conversions: list[str],

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -43,7 +43,7 @@ def get_re_pattern_for_time_units_and_groupings(
     """Get a regex pattern for time units and groupings.
 
     The pattern matches strings in any of these formats:
-    - <base_name>  (can contain underscores)
+    - <base_name>  (may contain underscores)
     - <base_name>_<time_unit>
     - <base_name>_<aggregation>
     - <base_name>_<time_unit>_<aggregation>
@@ -70,17 +70,17 @@ def get_re_pattern_for_time_units_and_groupings(
     )
 
 
-def potential_target_names_from_base_name(
+def all_variations_of_base_name(
     base_name: str,
     supported_time_conversions: list[str],
     supported_groupings: list[str],
     create_conversions_for_time_units: bool,
 ) -> set[str]:
-    """Get all derived function names given a base function name.
+    """Get possible derived function names given a base function name.
 
     Examples
     --------
-    >>> potential_target_names_from_base_name(
+    >>> all_variations_of_base_name(
         base_name="income",
         supported_time_conversions=["y", "m"],
         supported_groupings=["hh"],
@@ -88,7 +88,7 @@ def potential_target_names_from_base_name(
     )
     {'income_m', 'income_y', 'income_hh_y', 'income_hh_m'}
 
-    >>> potential_target_names_from_base_name(
+    >>> all_variations_of_base_name(
         base_name="claims_benefits",
         supported_time_conversions=["y", "m"],
         supported_groupings=["hh"],

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -37,7 +37,7 @@ def validate_date_range(start: datetime.date, end: datetime.date):
         raise ValueError(f"The start date {start} must be before the end date {end}.")
 
 
-def get_re_pattern_for_time_units_and_groupings(
+def get_re_pattern_for_all_time_units_and_groupings(
     supported_groupings: tuple[str, ...], supported_time_units: tuple[str, ...]
 ) -> re.Pattern:
     """Get a regex pattern for time units and groupings.
@@ -70,8 +70,10 @@ def get_re_pattern_for_time_units_and_groupings(
     )
 
 
-def get_re_pattern_for_some_base_name(
-    base_name: str, supported_time_units: list[str], supported_groupings: list[str]
+def get_re_pattern_for_specific_time_units_and_groupings(
+    base_name: str,
+    supported_time_units: tuple[str, ...],
+    supported_groupings: tuple[str, ...],
 ) -> re.Pattern:
     """Get a regex for a specific base name with optional time unit and aggregation.
 

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import itertools
 import re
 import textwrap
 from typing import TYPE_CHECKING, Any, TypeVar
@@ -34,6 +35,91 @@ def validate_dashed_iso_date(date: str | datetime.date):
 def validate_date_range(start: datetime.date, end: datetime.date):
     if start > end:
         raise ValueError(f"The start date {start} must be before the end date {end}.")
+
+
+def get_re_pattern_for_time_units_and_groupings(
+    supported_groupings: list[str], supported_time_units: list[str]
+) -> re.Pattern:
+    """Get a regex pattern for time units and groupings.
+
+    The pattern is of the form:
+    <base_name>_<time_unit>_<aggregation>
+    where <base_name> is optional, <time_unit> is one of the supported time units, and
+    <aggregation> is one of the supported groupings.
+
+    Parameters
+    ----------
+    supported_groupings
+        The supported groupings.
+    supported_time_units
+        The supported time units.
+
+    Returns
+    -------
+    pattern
+        The regex pattern.
+    """
+    units = "".join(supported_time_units)
+    groupings = "|".join([f"_{grouping}" for grouping in supported_groupings])
+    return re.compile(
+        f"(?P<base_name>.*_)(?P<time_unit>[{units}])(?P<aggregation>{groupings})?"
+    )
+
+
+def potential_target_names_from_base_name(
+    base_name: str,
+    supported_time_conversions: list[str],
+    supported_groupings: list[str],
+    create_conversions_for_time_units: bool,
+) -> set[str]:
+    """Get all derived function names given a base function name.
+
+    Examples
+    --------
+    >>> potential_target_names_from_base_name(
+        base_name="income",
+        supported_time_conversions=["y", "m"],
+        supported_groupings=["hh"],
+        create_conversions_for_time_units=True,
+    )
+    {'income_m', 'income_y', 'income_hh_y', 'income_hh_m'}
+
+    >>> potential_target_names_from_base_name(
+        base_name="claims_benefits",
+        supported_time_conversions=["y", "m"],
+        supported_groupings=["hh"],
+        create_conversions_for_time_units=False,
+    )
+    {'claims_benefits_hh'}
+
+    Parameters
+    ----------
+    base_name
+        The base function name.
+    supported_time_conversions
+        The supported time conversions.
+    supported_groupings
+        The supported groupings.
+    create_conversions_for_time_units
+        Whether to create conversions for time units.
+
+    Returns
+    -------
+    The names of all potential targets based on the base name.
+    """
+    result = set()
+    if create_conversions_for_time_units:
+        for time_unit in supported_time_conversions:
+            result.add(f"{base_name}_{time_unit}")
+        for time_unit, aggregation in itertools.product(
+            supported_time_conversions, supported_groupings
+        ):
+            result.add(f"{base_name}_{time_unit}_{aggregation}")
+    else:
+        result.add(base_name)
+        for aggregation in supported_groupings:
+            result.add(f"{base_name}_{aggregation}")
+    return result
 
 
 class KeyErrorMessage(str):

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -42,10 +42,11 @@ def get_re_pattern_for_time_units_and_groupings(
 ) -> re.Pattern:
     """Get a regex pattern for time units and groupings.
 
-    The pattern is of the form:
-    <base_name>_<time_unit>_<aggregation>
-    where <base_name> is optional, <time_unit> is one of the supported time units, and
-    <aggregation> is one of the supported groupings.
+    The pattern matches strings in any of these formats:
+    - <base_name>  (can contain underscores)
+    - <base_name>_<time_unit>
+    - <base_name>_<aggregation>
+    - <base_name>_<time_unit>_<aggregation>
 
     Parameters
     ----------
@@ -60,9 +61,12 @@ def get_re_pattern_for_time_units_and_groupings(
         The regex pattern.
     """
     units = "".join(supported_time_units)
-    groupings = "|".join([f"_{grouping}" for grouping in supported_groupings])
+    groupings = "|".join(supported_groupings)
     return re.compile(
-        f"(?P<base_name>.*_)(?P<time_unit>[{units}])(?P<aggregation>{groupings})?"
+        f"(?P<base_name>.*?)"
+        f"(?:_(?P<time_unit>[{units}]))?"
+        f"(?:_(?P<aggregation>{groupings}))?"
+        f"$"
     )
 
 

--- a/src/ttsim/time_conversion.py
+++ b/src/ttsim/time_conversion.py
@@ -458,7 +458,7 @@ def _create_time_conversion_functions(
     source_name: str,
     ttsim_object: TTSIMObject,
     time_unit_pattern: re.Pattern,
-    all_time_units: list[str],
+    all_time_units: tuple[str, ...],
 ) -> dict[str, DerivedTimeConversionFunction]:
     result: dict[str, DerivedTimeConversionFunction] = {}
     match = time_unit_pattern.fullmatch(source_name)

--- a/src/ttsim/time_conversion.py
+++ b/src/ttsim/time_conversion.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import inspect
-import re
 from typing import TYPE_CHECKING
 
 import dags.tree as dt
@@ -9,6 +8,7 @@ from dags import rename_arguments
 
 from _gettsim.config import SUPPORTED_GROUPINGS
 from ttsim.function_types import DerivedTimeConversionFunction, PolicyFunction
+from ttsim.shared import get_re_pattern_for_time_units_and_groupings
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -447,15 +447,13 @@ def _create_time_conversion_functions(
     name: str, func: PolicyFunction | None = None
 ) -> dict[str, DerivedTimeConversionFunction]:
     result: dict[str, DerivedTimeConversionFunction] = {}
-
     all_time_units = list(_TIME_UNITS)
 
-    units = "".join(all_time_units)
-    groupings = "|".join([f"_{grouping}" for grouping in SUPPORTED_GROUPINGS])
-    function_with_time_unit = re.compile(
-        f"(?P<base_name>.*_)(?P<time_unit>[{units}])(?P<aggregation>{groupings})?"
+    time_unit_pattern = get_re_pattern_for_time_units_and_groupings(
+        supported_groupings=SUPPORTED_GROUPINGS,
+        supported_time_units=all_time_units,
     )
-    match = function_with_time_unit.fullmatch(name)
+    match = time_unit_pattern.fullmatch(name)
     dependencies = set(inspect.signature(func).parameters) if func else set()
 
     if match:

--- a/src/ttsim/time_conversion.py
+++ b/src/ttsim/time_conversion.py
@@ -453,17 +453,22 @@ def _create_time_conversion_functions(
         supported_groupings=SUPPORTED_GROUPINGS,
         supported_time_units=all_time_units,
     )
+
     match = time_unit_pattern.fullmatch(name)
+    base_name = match.group("base_name") or ""
+    time_unit = match.group("time_unit") or ""
+    aggregation = match.group("aggregation") or ""
+
     dependencies = set(inspect.signature(func).parameters) if func else set()
 
-    if match:
-        base_name = match.group("base_name")
-        time_unit = match.group("time_unit")
-        aggregation = match.group("aggregation") or ""
-
+    if match and time_unit:
         missing_time_units = [unit for unit in all_time_units if unit != time_unit]
         for missing_time_unit in missing_time_units:
-            new_name = f"{base_name}{missing_time_unit}{aggregation}"
+            new_name = (
+                f"{base_name}_{missing_time_unit}{aggregation}"
+                if aggregation
+                else f"{base_name}_{missing_time_unit}"
+            )
 
             # Without this check, we could create cycles in the DAG: Consider a
             # hard-coded function `var_y` that takes `var_m` as an input, assuming it

--- a/src/ttsim/time_conversion.py
+++ b/src/ttsim/time_conversion.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from ttsim.typing import QualNameDataDict, QualNameTTSIMObjectDict
 
-_TIME_UNITS = {
+TIME_UNITS = {
     "y": "year",
     "q": "quarter",
     "m": "month",
@@ -421,7 +421,7 @@ def create_time_conversion_functions(
     converted_ttsim_objects = {}
 
     for source_name, ttsim_object in ttsim_objects.items():
-        all_time_units = list(_TIME_UNITS)
+        all_time_units = tuple(TIME_UNITS)
         time_unit_pattern = get_re_pattern_for_time_units_and_groupings(
             supported_groupings=SUPPORTED_GROUPINGS,
             supported_time_units=all_time_units,

--- a/src/ttsim/time_conversion.py
+++ b/src/ttsim/time_conversion.py
@@ -455,7 +455,7 @@ def _create_time_conversion_functions(
     )
 
     match = time_unit_pattern.fullmatch(name)
-    base_name = match.group("base_name") or ""
+    base_name = match.group("base_name")
     time_unit = match.group("time_unit") or ""
     aggregation = match.group("aggregation") or ""
 

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -6,6 +6,7 @@ from ttsim.shared import (
     all_variations_of_base_name,
     create_tree_from_path_and_value,
     get_name_of_group_by_id,
+    get_re_pattern_for_some_base_name,
     get_re_pattern_for_time_units_and_groupings,
     insert_path_and_value,
     merge_trees,
@@ -379,3 +380,27 @@ def test_get_re_pattern_for_time_units_and_groupings(
     assert match.group("base_name") == expected_base_name
     assert match.group("time_unit") == expected_time_unit
     assert match.group("aggregation") == expected_aggregation
+
+
+@pytest.mark.parametrize(
+    (
+        "base_name",
+        "supported_time_units",
+        "supported_groupings",
+        "expected_match",
+    ),
+    [
+        ("foo", ["m", "y"], ["hh"], "foo_m_hh"),
+        ("foo", ["m", "y"], ["hh", "x"], "foo_m"),
+        ("foo", ["m", "y"], ["hh", "x"], "foo_hh"),
+    ],
+)
+def test_get_re_pattern_for_some_base_name(
+    base_name, supported_time_units, supported_groupings, expected_match
+):
+    re_pattern = get_re_pattern_for_some_base_name(
+        base_name=base_name,
+        supported_time_units=supported_time_units,
+        supported_groupings=supported_groupings,
+    )
+    assert re_pattern.fullmatch(expected_match)

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -355,13 +355,13 @@ def test_all_variations_of_base_name(
         "expected_aggregation",
     ),
     [
-        ("foo", ["m", "y"], ["hh"], "foo", None, None),
-        ("foo_m_hh", ["m", "y"], ["hh"], "foo", "m", "hh"),
-        ("foo_y_hh", ["m", "y"], ["hh"], "foo", "y", "hh"),
-        ("foo_m", ["m", "y"], ["hh"], "foo", "m", None),
-        ("foo_y", ["m", "y"], ["hh"], "foo", "y", None),
-        ("foo_hh", ["m", "y"], ["hh"], "foo", None, "hh"),
-        ("foo_hh_bar", ["m", "y"], ["hh"], "foo_hh_bar", None, None),
+        ("foo", ("m", "y"), ["hh"], "foo", None, None),
+        ("foo_m_hh", ("m", "y"), ["hh"], "foo", "m", "hh"),
+        ("foo_y_hh", ("m", "y"), ["hh"], "foo", "y", "hh"),
+        ("foo_m", ("m", "y"), ["hh"], "foo", "m", None),
+        ("foo_y", ("m", "y"), ["hh"], "foo", "y", None),
+        ("foo_hh", ("m", "y"), ["hh"], "foo", None, "hh"),
+        ("foo_hh_bar", ("m", "y"), ["hh"], "foo_hh_bar", None, None),
     ],
 )
 def test_get_re_pattern_for_time_units_and_groupings(

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -6,8 +6,8 @@ from ttsim.shared import (
     all_variations_of_base_name,
     create_tree_from_path_and_value,
     get_name_of_group_by_id,
-    get_re_pattern_for_some_base_name,
-    get_re_pattern_for_time_units_and_groupings,
+    get_re_pattern_for_all_time_units_and_groupings,
+    get_re_pattern_for_specific_time_units_and_groupings,
     insert_path_and_value,
     merge_trees,
     partition_tree_by_reference_tree,
@@ -372,7 +372,7 @@ def test_get_re_pattern_for_time_units_and_groupings(
     expected_time_unit,
     expected_aggregation,
 ):
-    result = get_re_pattern_for_time_units_and_groupings(
+    result = get_re_pattern_for_all_time_units_and_groupings(
         supported_time_units=supported_time_units,
         supported_groupings=supported_groupings,
     )
@@ -398,7 +398,7 @@ def test_get_re_pattern_for_time_units_and_groupings(
 def test_get_re_pattern_for_some_base_name(
     base_name, supported_time_units, supported_groupings, expected_match
 ):
-    re_pattern = get_re_pattern_for_some_base_name(
+    re_pattern = get_re_pattern_for_specific_time_units_and_groupings(
         base_name=base_name,
         supported_time_units=supported_time_units,
         supported_groupings=supported_groupings,

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass
 import pytest
 
 from ttsim.shared import (
+    all_variations_of_base_name,
     create_tree_from_path_and_value,
     get_name_of_group_by_id,
     get_re_pattern_for_time_units_and_groupings,
     insert_path_and_value,
     merge_trees,
     partition_tree_by_reference_tree,
-    potential_target_names_from_base_name,
     upsert_path_and_value,
     upsert_tree,
 )
@@ -326,7 +326,7 @@ def test_get_name_of_group_by_id_fails(
         ),
     ],
 )
-def test_potential_target_names_from_base_name(
+def test_all_variations_of_base_name(
     base_name,
     supported_time_conversions,
     supported_groupings,
@@ -334,7 +334,7 @@ def test_potential_target_names_from_base_name(
     expected,
 ):
     assert (
-        potential_target_names_from_base_name(
+        all_variations_of_base_name(
             base_name=base_name,
             supported_time_conversions=supported_time_conversions,
             supported_groupings=supported_groupings,

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -360,6 +360,7 @@ def test_potential_target_names_from_base_name(
         ("foo_m", ["m", "y"], ["hh"], "foo", "m", None),
         ("foo_y", ["m", "y"], ["hh"], "foo", "y", None),
         ("foo_hh", ["m", "y"], ["hh"], "foo", None, "hh"),
+        ("foo_hh_bar", ["m", "y"], ["hh"], "foo_hh_bar", None, None),
     ],
 )
 def test_get_re_pattern_for_time_units_and_groupings(

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -8,6 +8,7 @@ from ttsim.shared import (
     insert_path_and_value,
     merge_trees,
     partition_tree_by_reference_tree,
+    potential_target_names_from_base_name,
     upsert_path_and_value,
     upsert_tree,
 )
@@ -283,3 +284,60 @@ def test_get_name_of_group_by_id_fails(
         get_name_of_group_by_id(
             target_name=target_name, group_by_functions=group_by_functions
         )
+
+
+@pytest.mark.parametrize(
+    (
+        "base_name",
+        "supported_time_conversions",
+        "supported_groupings",
+        "create_conversions_for_time_units",
+        "expected",
+    ),
+    [
+        (
+            "income",
+            ["y", "m"],
+            ["hh"],
+            True,
+            {"income_m", "income_y", "income_m_hh", "income_y_hh"},
+        ),
+        (
+            "income",
+            ["y", "m"],
+            ["hh", "x"],
+            True,
+            {
+                "income_m",
+                "income_y",
+                "income_m_hh",
+                "income_y_hh",
+                "income_m_x",
+                "income_y_x",
+            },
+        ),
+        (
+            "claims_benefits",
+            ["y", "m"],
+            ["hh", "x"],
+            False,
+            {"claims_benefits", "claims_benefits_hh", "claims_benefits_x"},
+        ),
+    ],
+)
+def test_potential_target_names_from_base_name(
+    base_name,
+    supported_time_conversions,
+    supported_groupings,
+    create_conversions_for_time_units,
+    expected,
+):
+    assert (
+        potential_target_names_from_base_name(
+            base_name=base_name,
+            supported_time_conversions=supported_time_conversions,
+            supported_groupings=supported_groupings,
+            create_conversions_for_time_units=create_conversions_for_time_units,
+        )
+        == expected
+    )

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -5,6 +5,7 @@ import pytest
 from ttsim.shared import (
     create_tree_from_path_and_value,
     get_name_of_group_by_id,
+    get_re_pattern_for_time_units_and_groupings,
     insert_path_and_value,
     merge_trees,
     partition_tree_by_reference_tree,
@@ -341,3 +342,39 @@ def test_potential_target_names_from_base_name(
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    (
+        "func_name",
+        "supported_time_units",
+        "supported_groupings",
+        "expected_base_name",
+        "expected_time_unit",
+        "expected_aggregation",
+    ),
+    [
+        ("foo", ["m", "y"], ["hh"], "foo", None, None),
+        ("foo_m_hh", ["m", "y"], ["hh"], "foo", "m", "hh"),
+        ("foo_y_hh", ["m", "y"], ["hh"], "foo", "y", "hh"),
+        ("foo_m", ["m", "y"], ["hh"], "foo", "m", None),
+        ("foo_y", ["m", "y"], ["hh"], "foo", "y", None),
+        ("foo_hh", ["m", "y"], ["hh"], "foo", None, "hh"),
+    ],
+)
+def test_get_re_pattern_for_time_units_and_groupings(
+    func_name,
+    supported_time_units,
+    supported_groupings,
+    expected_base_name,
+    expected_time_unit,
+    expected_aggregation,
+):
+    result = get_re_pattern_for_time_units_and_groupings(
+        supported_time_units=supported_time_units,
+        supported_groupings=supported_groupings,
+    )
+    match = result.fullmatch(func_name)
+    assert match.group("base_name") == expected_base_name
+    assert match.group("time_unit") == expected_time_unit
+    assert match.group("aggregation") == expected_aggregation

--- a/tests/ttsim/test_time_conversion.py
+++ b/tests/ttsim/test_time_conversion.py
@@ -280,34 +280,6 @@ class TestCreateFunctionsForTimeUnits:
         for expected_name in expected:
             assert expected_name in time_conversion_functions
 
-    @pytest.mark.parametrize(
-        ("name", "expected"),
-        [
-            ("test_y", ["test_m", "test_q", "test_w", "test_d"]),
-            ("test_y_hh", ["test_m_hh", "test_q_hh", "test_w_hh", "test_d_hh"]),
-            ("test_y_sn", ["test_m_sn", "test_q_sn", "test_w_sn", "test_d_sn"]),
-            ("test_q", ["test_y", "test_m", "test_w", "test_d"]),
-            ("test_q_hh", ["test_y_hh", "test_m_hh", "test_w_hh", "test_d_hh"]),
-            ("test_q_sn", ["test_y_sn", "test_m_sn", "test_w_sn", "test_d_sn"]),
-            ("test_m", ["test_y", "test_q", "test_w", "test_d"]),
-            ("test_m_hh", ["test_y_hh", "test_q_hh", "test_w_hh", "test_d_hh"]),
-            ("test_m_sn", ["test_y_sn", "test_q_sn", "test_w_sn", "test_d_sn"]),
-            ("test_w", ["test_y", "test_q", "test_m", "test_d"]),
-            ("test_w_hh", ["test_y_hh", "test_q_hh", "test_m_hh", "test_d_hh"]),
-            ("test_w_sn", ["test_y_sn", "test_q_sn", "test_m_sn", "test_d_sn"]),
-            ("test_d", ["test_y", "test_q", "test_m", "test_w"]),
-            ("test_d_hh", ["test_y_hh", "test_q_hh", "test_m_hh", "test_w_hh"]),
-            ("test_d_sn", ["test_y_sn", "test_q_sn", "test_m_sn", "test_w_sn"]),
-        ],
-    )
-    def test_should_create_functions_for_other_time_units_for_data_cols(
-        self, name: str, expected: list[str]
-    ) -> None:
-        time_conversion_functions = create_time_conversion_functions({}, {name: None})
-
-        for expected_name in expected:
-            assert expected_name in time_conversion_functions
-
     def test_should_not_create_functions_automatically_that_exist_already(self) -> None:
         time_conversion_functions = create_time_conversion_functions(
             {"test1_d": policy_function(leaf_name="test1_d")(lambda: 1)},


### PR DESCRIPTION
### What problem do you want to solve?

The top-level namespace did not account for derived functions that are created later. We now add place-holders when creating the top-level namespace for those derived functions.

Because tests don't work currently, I'm not 100% sure that the changes don't crash time conversions (but I'm optimistic that they didn't). Have to keep that in mind if we run into bugs when wrapping up #804.