### PR TITLE
Remove custom type conversions.

### DIFF
--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -1,4 +1,3 @@
-import dags.tree as dt
 import pytest
 
 from _gettsim.config import FOREIGN_KEYS, SUPPORTED_GROUPINGS
@@ -8,8 +7,6 @@ from _gettsim_tests.utils import (
     load_policy_test_data,
 )
 from ttsim import compute_taxes_and_transfers
-from ttsim.function_types import PolicyInput
-from ttsim.typing import check_series_has_expected_type
 
 test_data = load_policy_test_data("full_taxes_and_transfers")
 
@@ -25,42 +22,6 @@ def test_full_taxes_transfers(test: PolicyTest):
         foreign_keys=FOREIGN_KEYS,
         supported_groupings=SUPPORTED_GROUPINGS,
     )
-
-
-@pytest.mark.parametrize("test", test_data, ids=lambda x: x.test_name)
-def test_data_types(test: PolicyTest):
-    environment = cached_set_up_policy_environment(date=test.date)
-
-    result = compute_taxes_and_transfers(
-        data_tree=test.input_tree,
-        environment=environment,
-        targets_tree=test.target_structure,
-        foreign_keys=FOREIGN_KEYS,
-        supported_groupings=SUPPORTED_GROUPINGS,
-    )
-
-    flat_types_input_variables = {
-        n: pi.data_type
-        for n, pi in dt.flatten_to_qual_names(environment.raw_objects_tree).items()
-        if isinstance(pi, PolicyInput)
-    }
-    flat_functions = dt.flatten_to_qual_names(environment.raw_objects_tree)
-
-    for column_name, result_array in dt.flatten_to_qual_names(result).items():
-        if column_name in flat_types_input_variables:
-            internal_type = flat_types_input_variables[column_name]
-        elif column_name in flat_functions:
-            internal_type = flat_functions[column_name].__annotations__["return"]
-        else:
-            # TODO (@hmgaudecker): Implement easy way to find out expected type of
-            #     aggregated functions
-            # https://github.com/iza-institute-of-labor-economics/gettsim/issues/604
-            if column_name.endswith(("_sn", "_hh", "_fg", "_bg", "_eg", "_ehe")):
-                internal_type = None
-            else:
-                raise ValueError(f"Column name {column_name} unknown.")
-        if internal_type:
-            assert check_series_has_expected_type(result_array, internal_type)
 
 
 @pytest.mark.skip(

--- a/src/ttsim/function_types.py
+++ b/src/ttsim/function_types.py
@@ -7,6 +7,12 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, TypeVar
 
 import numpy
+from pandas.api.types import (
+    is_bool_dtype,
+    is_datetime64_any_dtype,
+    is_float_dtype,
+    is_integer_dtype,
+)
 
 from ttsim.rounding import RoundingSpec
 from ttsim.shared import to_datetime, validate_date_range
@@ -14,6 +20,9 @@ from ttsim.shared import to_datetime, validate_date_range
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    import pandas as pd
+
+    from ttsim.config import numpy_or_jax as np
     from ttsim.typing import DashedISOString
 
 T = TypeVar("T")
@@ -423,3 +432,31 @@ def _convert_and_validate_dates(
     validate_date_range(start_date, end_date)
 
     return start_date, end_date
+
+
+def check_series_has_expected_type(series: pd.Series, internal_type: np.dtype) -> bool:
+    """Checks whether used series has already expected internal type.
+
+    Parameters
+    ----------
+    series : pandas.Series or pandas.DataFrame or dict of pandas.Series
+        Data provided by the user.
+    internal_type : TypeVar
+        One of the internal gettsim types.
+
+    Returns
+    -------
+    Bool
+
+    """
+    if (
+        (internal_type == float) & (is_float_dtype(series))
+        or (internal_type == int) & (is_integer_dtype(series))
+        or (internal_type == bool) & (is_bool_dtype(series))
+        or (internal_type == numpy.datetime64) & (is_datetime64_any_dtype(series))
+    ):
+        out = True
+    else:
+        out = False
+
+    return out

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -1,19 +1,9 @@
 from typing import TYPE_CHECKING, NewType
 
-import numpy
-import pandas as pd
-from pandas.api.types import (
-    is_bool_dtype,
-    is_datetime64_any_dtype,
-    is_float_dtype,
-    is_integer_dtype,
-    is_object_dtype,
-)
-
-from ttsim.config import numpy_or_jax as np
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    import pandas as pd
 
     # Make these available for import from other modules.
     from dags.tree.typing import (  # noqa: F401
@@ -24,6 +14,7 @@ if TYPE_CHECKING:
     )
 
     from ttsim.aggregation import AggregateByGroupSpec, AggregateByPIDSpec
+    from ttsim.config import numpy_or_jax as np
     from ttsim.function_types import PolicyInput, TTSIMFunction, TTSIMObject
 
     NestedTTSIMObjectDict = Mapping[str, TTSIMObject | "NestedTTSIMObjectDict"]
@@ -47,128 +38,3 @@ if TYPE_CHECKING:
 
     DashedISOString = NewType("DashedISOString", str)
     """A string representing a date in the format 'YYYY-MM-DD'."""
-
-
-def check_series_has_expected_type(series: pd.Series, internal_type: np.dtype) -> bool:
-    """Checks whether used series has already expected internal type.
-
-    Parameters
-    ----------
-    series : pandas.Series or pandas.DataFrame or dict of pandas.Series
-        Data provided by the user.
-    internal_type : TypeVar
-        One of the internal gettsim types.
-
-    Returns
-    -------
-    Bool
-
-    """
-    if (
-        (internal_type == float) & (is_float_dtype(series))
-        or (internal_type == int) & (is_integer_dtype(series))
-        or (internal_type == bool) & (is_bool_dtype(series))
-        or (internal_type == numpy.datetime64) & (is_datetime64_any_dtype(series))
-    ):
-        out = True
-    else:
-        out = False
-
-    return out
-
-
-def convert_series_to_internal_type(
-    series: pd.Series, internal_type: np.dtype
-) -> pd.Series:
-    """Check if data type of series fits to the internal type of gettsim and otherwise
-    convert data type of series to the internal type of gettsim.
-
-    Parameters
-    ----------
-    series : pd.Series
-        Some data series.
-    internal_type : TypeVar
-        One of the internal gettsim types.
-
-    Returns
-    -------
-    out : adjusted pd.Series
-
-    """
-    # Copy input series in out
-    out = series.copy()
-
-    basic_error_msg = (
-        f"Conversion from input type {out.dtype} to {internal_type.__name__} failed."
-    )
-    if is_object_dtype(out):
-        raise ValueError(basic_error_msg + " Object type is not supported as input.")
-    else:
-        # Conversion to float
-        if internal_type == float:
-            # Conversion from boolean to float fails
-            if is_bool_dtype(out):
-                raise ValueError(basic_error_msg + " This conversion is not supported.")
-            else:
-                try:
-                    out = out.astype(float)
-                except ValueError as e:
-                    raise ValueError(basic_error_msg) from e
-
-        # Conversion to int
-        elif internal_type == int:
-            if is_float_dtype(out):
-                # checking if decimal places are equal to 0, if not return error
-                if np.array_equal(out, out.astype(np.int64)):
-                    out = out.astype(np.int64)
-                else:
-                    raise ValueError(
-                        basic_error_msg + " This conversion is only supported if all"
-                        " decimal places of input data are equal to 0."
-                    )
-            else:
-                try:
-                    out = out.astype(np.int64)
-                except ValueError as e:
-                    raise ValueError(basic_error_msg) from e
-
-        # Conversion to boolean
-        elif internal_type == bool:
-            # if input data type is integer
-            if is_integer_dtype(out):
-                # check if series consists only of 1 or 0
-                if len([v for v in out.unique() if v not in [1, 0]]) == 0:
-                    out = out.astype(bool)
-                else:
-                    raise ValueError(
-                        basic_error_msg + " This conversion is only supported if"
-                        " input data exclusively contains the values 1 and 0."
-                    )
-            # if input data type is float
-            elif is_float_dtype(out):
-                # check if series consists only of 1.0 or 0.0
-                if len([v for v in out.unique() if v not in [1, 0]]) == 0:
-                    out = out.astype(bool)
-                else:
-                    raise ValueError(
-                        basic_error_msg + " This conversion is only supported if"
-                        " input data exclusively contains the values 1.0 and 0.0."
-                    )
-
-            else:
-                raise ValueError(
-                    basic_error_msg + " Conversion to boolean is only supported for"
-                    " int and float columns."
-                )
-
-        # Conversion to DateTime
-        elif internal_type == np.datetime64:
-            if not is_datetime64_any_dtype(out):
-                try:
-                    out = out.astype(np.datetime64)
-                except ValueError as e:
-                    raise ValueError(basic_error_msg) from e
-        else:
-            raise ValueError(f"The internal type {internal_type} is not yet supported.")
-
-    return out

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -7,12 +7,10 @@ import numpy
 import pandas as pd
 import pytest
 from mettsim.config import FOREIGN_KEYS, SUPPORTED_GROUPINGS
-from mettsim.payroll_tax.group_by_ids import fam_id, sp_id
 
 from ttsim.aggregation import AggregateByGroupSpec, AggregateByPIDSpec, AggregationType
 from ttsim.compute_taxes_and_transfers import (
     FunctionsAndColumnsOverlapWarning,
-    _convert_data_to_correct_types,
     _fail_if_foreign_keys_are_invalid,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_p_id_is_non_unique,
@@ -686,68 +684,68 @@ def test_fail_if_cannot_be_converted_to_internal_type(
         convert_series_to_internal_type(input_data, expected_type)
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize(
-    "data, functions_overridden",
-    [
-        (
-            {"sp_id": pd.Series([1, 2, 3])},
-            {"sp_id": sp_id},
-        ),
-        (
-            {"fam_id": pd.Series([1, 2, 3])},
-            {"fam_id": fam_id},
-        ),
-    ],
-)
-def test_provide_endogenous_groupings(data, functions_overridden):
-    """Test whether GETTSIM handles user-provided grouping IDs, which would otherwise be
-    set endogenously."""
-    _convert_data_to_correct_types(data, functions_overridden)
+# @pytest.mark.skip
+# @pytest.mark.parametrize(
+#     "data, functions_overridden",
+#     [
+#         (
+#             {"sp_id": pd.Series([1, 2, 3])},
+#             {"sp_id": sp_id},
+#         ),
+#         (
+#             {"fam_id": pd.Series([1, 2, 3])},
+#             {"fam_id": fam_id},
+#         ),
+#     ],
+# )
+# def test_provide_endogenous_groupings(data, functions_overridden):
+#     """Test whether TTSIM handles user-provided grouping IDs, which would otherwise be
+#     set endogenously."""
+#     _convert_data_to_correct_types(data, functions_overridden)
 
 
-@pytest.mark.skip
-@pytest.mark.parametrize(
-    "data, functions_overridden, error_match",
-    [
-        (
-            {"hh_id": pd.Series([1, 1.1, 2])},
-            {},
-            "- hh_id: Conversion from input type float64 to int",
-        ),
-        (
-            {"gondorian": pd.Series([1.1, 0.0, 1.0])},
-            {},
-            "- gondorian: Conversion from input type float64 to bool",
-        ),
-        (
-            {
-                "hh_id": pd.Series([1.0, 2.0, 3.0]),
-                "gondorian": pd.Series([2, 0, 1]),
-            },
-            {},
-            "- gondorian: Conversion from input type int64 to bool",
-        ),
-        (
-            {"gondorian": pd.Series(["True", "False"])},
-            {},
-            "- gondorian: Conversion from input type object to bool",
-        ),
-        (
-            {
-                "hh_id": pd.Series([1, "1", 2]),
-                "payroll_tax__amount": pd.Series(["2000", 3000, 4000]),
-            },
-            {},
-            "- hh_id: Conversion from input type object to int failed.",
-        ),
-    ],
-)
-def test_fail_if_cannot_be_converted_to_correct_type(
-    data, functions_overridden, error_match
-):
-    with pytest.raises(ValueError, match=error_match):
-        _convert_data_to_correct_types(data, functions_overridden)
+# @pytest.mark.skip
+# @pytest.mark.parametrize(
+#     "data, functions_overridden, error_match",
+#     [
+#         (
+#             {"hh_id": pd.Series([1, 1.1, 2])},
+#             {},
+#             "- hh_id: Conversion from input type float64 to int",
+#         ),
+#         (
+#             {"gondorian": pd.Series([1.1, 0.0, 1.0])},
+#             {},
+#             "- gondorian: Conversion from input type float64 to bool",
+#         ),
+#         (
+#             {
+#                 "hh_id": pd.Series([1.0, 2.0, 3.0]),
+#                 "gondorian": pd.Series([2, 0, 1]),
+#             },
+#             {},
+#             "- gondorian: Conversion from input type int64 to bool",
+#         ),
+#         (
+#             {"gondorian": pd.Series(["True", "False"])},
+#             {},
+#             "- gondorian: Conversion from input type object to bool",
+#         ),
+#         (
+#             {
+#                 "hh_id": pd.Series([1, "1", 2]),
+#                 "payroll_tax__amount": pd.Series(["2000", 3000, 4000]),
+#             },
+#             {},
+#             "- hh_id: Conversion from input type object to int failed.",
+#         ),
+#     ],
+# )
+# def test_fail_if_cannot_be_converted_to_correct_type(
+#     data, functions_overridden, error_match
+# ):
+#     with pytest.raises(ValueError, match=error_match):
+#         _convert_data_to_correct_types(data, functions_overridden)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -22,7 +22,6 @@ from ttsim.config import numpy_or_jax as np
 from ttsim.function_types import group_by_function, policy_function, policy_input
 from ttsim.policy_environment import PolicyEnvironment
 from ttsim.shared import assert_valid_ttsim_pytree
-from ttsim.typing import convert_series_to_internal_type
 
 
 @policy_input()
@@ -579,109 +578,109 @@ def test_user_provided_aggregate_by_p_id_specs(
     numpy.testing.assert_array_almost_equal(out, expected)
 
 
-@pytest.mark.parametrize(
-    "input_data, expected_type, expected_output_data",
-    [
-        (pd.Series([0, 1, 0]), bool, pd.Series([False, True, False])),
-        (pd.Series([1.0, 0.0, 1]), bool, pd.Series([True, False, True])),
-        (pd.Series([200, 550, 237]), float, pd.Series([200.0, 550.0, 237.0])),
-        (pd.Series([1.0, 4.0, 10.0]), int, pd.Series([1, 4, 10])),
-        (pd.Series([200.0, 567.0]), int, pd.Series([200, 567])),
-        (pd.Series([1.0, 0.0]), bool, pd.Series([True, False])),
-    ],
-)
-def test_convert_series_to_internal_types(
-    input_data, expected_type, expected_output_data
-):
-    adjusted_input = convert_series_to_internal_type(input_data, expected_type)
-    pd.testing.assert_series_equal(adjusted_input, expected_output_data)
+# @pytest.mark.parametrize(
+#     "input_data, expected_type, expected_output_data",
+#     [
+#         (pd.Series([0, 1, 0]), bool, pd.Series([False, True, False])),
+#         (pd.Series([1.0, 0.0, 1]), bool, pd.Series([True, False, True])),
+#         (pd.Series([200, 550, 237]), float, pd.Series([200.0, 550.0, 237.0])),
+#         (pd.Series([1.0, 4.0, 10.0]), int, pd.Series([1, 4, 10])),
+#         (pd.Series([200.0, 567.0]), int, pd.Series([200, 567])),
+#         (pd.Series([1.0, 0.0]), bool, pd.Series([True, False])),
+#     ],
+# )
+# def test_convert_series_to_internal_types(
+#     input_data, expected_type, expected_output_data
+# ):
+#     adjusted_input = convert_series_to_internal_type(input_data, expected_type)
+#     pd.testing.assert_series_equal(adjusted_input, expected_output_data)
 
 
-@pytest.mark.parametrize(
-    "input_data, expected_type, error_match",
-    [
-        (
-            pd.Series(["Hallo", 200, 325]),
-            float,
-            "Conversion from input type object to float failed.",
-        ),
-        (
-            pd.Series([True, False]),
-            float,
-            "Conversion from input type bool to float failed.",
-        ),
-        (
-            pd.Series(["a", "b", "c"]).astype("category"),
-            float,
-            "Conversion from input type category to float failed.",
-        ),
-        (
-            pd.Series(["2.0", "3.0"]),
-            int,
-            "Conversion from input type object to int failed.",
-        ),
-        (
-            pd.Series([1.5, 1.0, 2.9]),
-            int,
-            "Conversion from input type float64 to int failed.",
-        ),
-        (
-            pd.Series(["a", "b", "c"]).astype("category"),
-            int,
-            "Conversion from input type category to int failed.",
-        ),
-        (
-            pd.Series([5, 2, 3]),
-            bool,
-            "Conversion from input type int64 to bool failed.",
-        ),
-        (
-            pd.Series([1.5, 1.0, 35.0]),
-            bool,
-            "Conversion from input type float64 to bool failed.",
-        ),
-        (
-            pd.Series(["a", "b", "c"]).astype("category"),
-            bool,
-            "Conversion from input type category to bool failed.",
-        ),
-        (
-            pd.Series(["richtig"]),
-            bool,
-            "Conversion from input type object to bool failed.",
-        ),
-        (
-            pd.Series(["True", "False", ""]),
-            bool,
-            "Conversion from input type object to bool failed.",
-        ),
-        (
-            pd.Series(["true"]),
-            bool,
-            "Conversion from input type object to bool failed.",
-        ),
-        (
-            pd.Series(["zweitausendzwanzig"]),
-            numpy.datetime64,
-            "Conversion from input type object to datetime64 failed.",
-        ),
-        (
-            pd.Series([True, True]),
-            numpy.datetime64,
-            "Conversion from input type bool to datetime64 failed.",
-        ),
-        (
-            pd.Series([2020]),
-            str,
-            "The internal type <class 'str'> is not yet supported.",
-        ),
-    ],
-)
-def test_fail_if_cannot_be_converted_to_internal_type(
-    input_data, expected_type, error_match
-):
-    with pytest.raises(ValueError, match=error_match):
-        convert_series_to_internal_type(input_data, expected_type)
+# @pytest.mark.parametrize(
+#     "input_data, expected_type, error_match",
+#     [
+#         (
+#             pd.Series(["Hallo", 200, 325]),
+#             float,
+#             "Conversion from input type object to float failed.",
+#         ),
+#         (
+#             pd.Series([True, False]),
+#             float,
+#             "Conversion from input type bool to float failed.",
+#         ),
+#         (
+#             pd.Series(["a", "b", "c"]).astype("category"),
+#             float,
+#             "Conversion from input type category to float failed.",
+#         ),
+#         (
+#             pd.Series(["2.0", "3.0"]),
+#             int,
+#             "Conversion from input type object to int failed.",
+#         ),
+#         (
+#             pd.Series([1.5, 1.0, 2.9]),
+#             int,
+#             "Conversion from input type float64 to int failed.",
+#         ),
+#         (
+#             pd.Series(["a", "b", "c"]).astype("category"),
+#             int,
+#             "Conversion from input type category to int failed.",
+#         ),
+#         (
+#             pd.Series([5, 2, 3]),
+#             bool,
+#             "Conversion from input type int64 to bool failed.",
+#         ),
+#         (
+#             pd.Series([1.5, 1.0, 35.0]),
+#             bool,
+#             "Conversion from input type float64 to bool failed.",
+#         ),
+#         (
+#             pd.Series(["a", "b", "c"]).astype("category"),
+#             bool,
+#             "Conversion from input type category to bool failed.",
+#         ),
+#         (
+#             pd.Series(["richtig"]),
+#             bool,
+#             "Conversion from input type object to bool failed.",
+#         ),
+#         (
+#             pd.Series(["True", "False", ""]),
+#             bool,
+#             "Conversion from input type object to bool failed.",
+#         ),
+#         (
+#             pd.Series(["true"]),
+#             bool,
+#             "Conversion from input type object to bool failed.",
+#         ),
+#         (
+#             pd.Series(["zweitausendzwanzig"]),
+#             numpy.datetime64,
+#             "Conversion from input type object to datetime64 failed.",
+#         ),
+#         (
+#             pd.Series([True, True]),
+#             numpy.datetime64,
+#             "Conversion from input type bool to datetime64 failed.",
+#         ),
+#         (
+#             pd.Series([2020]),
+#             str,
+#             "The internal type <class 'str'> is not yet supported.",
+#         ),
+#     ],
+# )
+# def test_fail_if_cannot_be_converted_to_internal_type(
+#     input_data, expected_type, error_match
+# ):
+#     with pytest.raises(ValueError, match=error_match):
+#         convert_series_to_internal_type(input_data, expected_type)
 
 
 # @pytest.mark.skip


### PR DESCRIPTION
We put some effort into trying to convert types. However, the code was a mess and it would be a pain to maintain it. What Python/Pandas/Numpy/Jax do is more than good enough for GETTSIM, too. Now that we have the explicitly annotated `policy_inputs`, it will be easy to check and throw errors if users want to be strict.

This PR removes the code which has been stale for the last week, anyhow.