### PR TITLE
Add test data for METTSIM

### DIFF
--- a/src/_gettsim_tests/utils.py
+++ b/src/_gettsim_tests/utils.py
@@ -186,32 +186,12 @@ def _get_policy_tests_from_raw_test_data(
 
     date: datetime.date = to_datetime(path_to_yaml.parent.name)
 
-    out = []
-    if expected_output_tree == {}:
-        out.append(
-            PolicyTest(
-                info=test_info,
-                input_tree=input_tree,
-                expected_output_tree={},
-                path=path_to_yaml,
-                date=date,
-            )
+    return [
+        PolicyTest(
+            info=test_info,
+            input_tree=input_tree,
+            expected_output_tree=expected_output_tree,
+            path=path_to_yaml,
+            date=date,
         )
-    else:
-        for target_name, output_data in dt.flatten_to_tree_paths(
-            expected_output_tree
-        ).items():
-            one_expected_output: NestedDataDict = dt.unflatten_from_tree_paths(
-                {target_name: output_data}
-            )
-            out.append(
-                PolicyTest(
-                    info=test_info,
-                    input_tree=input_tree,
-                    expected_output_tree=one_expected_output,
-                    path=path_to_yaml,
-                    date=date,
-                )
-            )
-
-    return out
+    ]

--- a/src/ttsim/combine_functions.py
+++ b/src/ttsim/combine_functions.py
@@ -384,6 +384,7 @@ def _create_derived_aggregations_specs(
                 agg=AggregationType.SUM,
                 source=_get_name_of_aggregation_source(
                     target_name=target_name,
+                    supported_groupings=supported_groupings,
                     top_level_namespace=top_level_namespace,
                 ),
             )
@@ -529,6 +530,7 @@ def _get_qual_name_of_source_col(
 
 def _get_name_of_aggregation_source(
     target_name: str,
+    supported_groupings: tuple[str, ...],
     top_level_namespace: set[str],
 ) -> str:
     """Get the name of the source column for an aggregation target.
@@ -538,6 +540,7 @@ def _get_name_of_aggregation_source(
     Example 1
     ---------
     > target_name = "arbeitslosengeld_2__vermögen_bg"
+    > supported_groupings = ("bg",)
     > top_level_namespace = {"vermögen", "arbeitslosengeld_2"}
     > _get_name_of_aggregation_source(target_name, top_level_namespace)
     "vermögen"
@@ -545,12 +548,16 @@ def _get_name_of_aggregation_source(
     Example 2
     ---------
     > target_name = "arbeitslosengeld_2__vermögen_bg"
+    > supported_groupings = ("bg",)
     > top_level_namespace = {"arbeitslosengeld_2"}
     > _get_name_of_aggregation_source(target_name, top_level_namespace)
     "arbeitslosengeld_2__vermögen"
     """
-    leaf_name = remove_group_suffix(dt.tree_path_from_qual_name(target_name)[-1])
+    leaf_name = remove_group_suffix(
+        dt.tree_path_from_qual_name(target_name)[-1],
+        supported_groupings=supported_groupings,
+    )
     if leaf_name in top_level_namespace:
         return leaf_name
     else:
-        return remove_group_suffix(target_name)
+        return remove_group_suffix(target_name, supported_groupings=supported_groupings)

--- a/src/ttsim/loader.py
+++ b/src/ttsim/loader.py
@@ -6,7 +6,6 @@ import itertools
 import sys
 from typing import TYPE_CHECKING
 
-from _gettsim.config import RESOURCE_DIR
 from ttsim.shared import (
     create_tree_from_path_and_value,
     insert_path_and_value,
@@ -229,7 +228,7 @@ def _convert_path_to_tree_path(path: Path, root_path: Path) -> tuple[str, ...]:
     return parts[:-1]
 
 
-def load_aggregation_specs_tree() -> NestedAggregationSpecDict:
+def load_aggregation_specs_tree(resource_dir: Path) -> NestedAggregationSpecDict:
     """
     Load the tree with aggregation specifications.
 
@@ -241,17 +240,17 @@ def load_aggregation_specs_tree() -> NestedAggregationSpecDict:
     -------
     The aggregation tree.
     """
-    paths_to_aggregation_specs = _find_python_files_recursively(RESOURCE_DIR)
+    paths_to_aggregation_specs = _find_python_files_recursively(resource_dir)
 
     aggregation_specs_tree = {}
 
     for path in paths_to_aggregation_specs:
         aggregation_specs = _load_aggregation_specs_from_module(
             path=path,
-            root_path=RESOURCE_DIR,
+            root_path=resource_dir,
         )
 
-        tree_path = _convert_path_to_tree_path(path=path, root_path=RESOURCE_DIR)
+        tree_path = _convert_path_to_tree_path(path=path, root_path=resource_dir)
 
         aggregation_specs_tree = insert_path_and_value(
             base=aggregation_specs_tree,

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -10,10 +10,6 @@ import optree
 import pandas as pd
 import yaml
 
-from _gettsim.config import (
-    INTERNAL_PARAMS_GROUPS,
-    RESOURCE_DIR,
-)
 from ttsim.loader import (
     load_aggregation_specs_tree,
     load_objects_tree_for_date,
@@ -193,15 +189,31 @@ def set_up_policy_environment(
     functions_tree = load_objects_tree_for_date(resource_dir=resource_dir, date=date)
 
     params = {}
-    for group in INTERNAL_PARAMS_GROUPS:
-        params_one_group = _load_parameter_group_from_yaml(date, group)
+    if "_gettsim" in resource_dir.name:
+        from _gettsim.config import INTERNAL_PARAMS_GROUPS as internal_params_groups
+    else:
+        internal_params_groups = [
+            "payroll_tax",
+            "housing_benefits",
+        ]
+    for group in internal_params_groups:
+        params_one_group = _load_parameter_group_from_yaml(
+            date=date,
+            group=group,
+            parameters=None,
+            yaml_path=resource_dir / "parameters",
+        )
 
         # Align parameters for piecewise polynomial functions
         params[group] = _parse_piecewise_parameters(params_one_group)
-    # Extend dictionary with date-specific values which do not need an own function
-    params = _parse_kinderzuschl_max(date, params)
-    params = _parse_einführungsfaktor_vorsorgeaufwendungen_alter_ab_2005(date, params)
-    params = _parse_vorsorgepauschale_rentenv_anteil(date, params)
+
+    if "_gettsim" in resource_dir.name:
+        # Extend dictionary with date-specific values which do not need an own function
+        params = _parse_kinderzuschl_max(date, params)
+        params = _parse_einführungsfaktor_vorsorgeaufwendungen_alter_ab_2005(
+            date, params
+        )
+        params = _parse_vorsorgepauschale_rentenv_anteil(date, params)
 
     aggregation_specs_tree = load_aggregation_specs_tree(resource_dir=resource_dir)
 
@@ -383,8 +395,8 @@ def _parse_vorsorgepauschale_rentenv_anteil(date, params):
 def _load_parameter_group_from_yaml(
     date: datetime.date,
     group: str,
+    yaml_path: Path,
     parameters: list[str] | None = None,
-    yaml_path: Path = RESOURCE_DIR / "parameters",
 ) -> dict[str, Any]:
     """Load data from raw yaml group file.
 
@@ -451,8 +463,8 @@ def _load_parameter_group_from_yaml(
                 if "." in future_policy["deviation_from"]:
                     path_list = future_policy["deviation_from"].split(".")
                     params_temp = _load_parameter_group_from_yaml(
-                        date,
-                        path_list[0],
+                        date=date,
+                        group=path_list[0],
                         parameters=[path_list[1]],
                         yaml_path=yaml_path,
                     )

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -203,7 +203,7 @@ def set_up_policy_environment(
     params = _parse_einführungsfaktor_vorsorgeaufwendungen_alter_ab_2005(date, params)
     params = _parse_vorsorgepauschale_rentenv_anteil(date, params)
 
-    aggregation_specs_tree = load_aggregation_specs_tree()
+    aggregation_specs_tree = load_aggregation_specs_tree(resource_dir=resource_dir)
 
     return PolicyEnvironment(
         functions_tree,

--- a/src/ttsim/shared.py
+++ b/src/ttsim/shared.py
@@ -11,8 +11,6 @@ import dags.tree as dt
 import numpy
 import optree
 
-from _gettsim.config import SUPPORTED_GROUPINGS
-
 if TYPE_CHECKING:
     from ttsim.ttsim_objects import PolicyFunction
     from ttsim.typing import (
@@ -420,9 +418,9 @@ def get_names_of_arguments_without_defaults(function: PolicyFunction) -> list[st
     return [p for p in parameters if parameters[p].default == parameters[p].empty]
 
 
-def remove_group_suffix(col):
+def remove_group_suffix(col, supported_groupings):
     out = col
-    for g in SUPPORTED_GROUPINGS:
+    for g in supported_groupings:
         out = out.removesuffix(f"_{g}")
 
     return out

--- a/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
+++ b/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
@@ -17,6 +17,11 @@ aggregation_specs = (
         source="child",
         agg=AggregationType.SUM,
     ),
+    AggregateByGroupSpec(
+        target="number_of_individuals_sp",
+        source=None,
+        agg=AggregationType.COUNT,
+    ),
 )
 
 

--- a/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
+++ b/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
@@ -56,3 +56,11 @@ def number_of_children_considered(
     return min(
         number_of_children_fam, housing_benefits_params["max_number_of_children"]
     )
+
+
+@policy_function(start_date="2020-01-01")
+def child(
+    age: int,
+    # housing_benefits_params: dict,
+) -> bool:
+    return age <= 18  # housing_benefits_params["max_age_children"]

--- a/tests/ttsim/mettsim/housing_benefits/income/income.py
+++ b/tests/ttsim/mettsim/housing_benefits/income/income.py
@@ -9,7 +9,7 @@ from ttsim import RoundingSpec, policy_function
     )
 )
 def amount_m(
-    gross_wage_m: float,
+    payroll_tax__income__gross_wage_m: float,
     payroll_tax__amount_m: float,
 ) -> float:
-    return gross_wage_m - payroll_tax__amount_m
+    return payroll_tax__income__gross_wage_m - payroll_tax__amount_m

--- a/tests/ttsim/mettsim/inputs.py
+++ b/tests/ttsim/mettsim/inputs.py
@@ -19,3 +19,13 @@ def p_id_parent_1() -> int:
 @policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)
 def p_id_parent_2() -> int:
     """Identifier of the second parent."""
+
+
+@policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)
+def p_id_spouse() -> int:
+    """Identifier of married partner."""
+
+
+@policy_input()
+def age() -> int:
+    """Age of the person."""

--- a/tests/ttsim/mettsim/parameters/housing_benefits.yaml
+++ b/tests/ttsim/mettsim/parameters/housing_benefits.yaml
@@ -9,3 +9,6 @@ eligibility:
 assistance_rate:
   1900-01-01:
     scalar: 0.5
+max_age_children:
+  2020-01-01:
+    scalar: 18

--- a/tests/ttsim/mettsim/parameters/payroll_tax.yaml
+++ b/tests/ttsim/mettsim/parameters/payroll_tax.yaml
@@ -4,6 +4,6 @@ child_tax_credit:
     child_amount_y: 100.0
     max_age: 18
 income:
-  1900-01-01: null
-  lump_sum_deduction_y: 100.0
-  rate: 0.3
+  1900-01-01:
+    lump_sum_deduction_y: 100.0
+    rate: 0.3

--- a/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
+++ b/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
@@ -3,9 +3,7 @@ from ttsim import (
     AggregationType,
     join_numpy,
     policy_function,
-    policy_input,
 )
-from ttsim.ttsim_objects import FKType
 
 aggregation_specs = (
     AggregateByPIDSpec(
@@ -15,11 +13,6 @@ aggregation_specs = (
         agg=AggregationType.SUM,
     ),
 )
-
-
-@policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF)
-def p_id_recipient() -> int:
-    """Identifier of the recipient of the child tax credit."""
 
 
 @policy_function()
@@ -37,13 +30,13 @@ def claim_of_child_y(
 def child_eligible(
     age: int,
     payroll_tax_params: dict,
-    child_in_same_household_as_recipient: float,
+    in_same_household_as_recipient: float,
 ) -> bool:
-    return age <= payroll_tax_params["max_age"] and child_in_same_household_as_recipient
+    return age <= payroll_tax_params["max_age"] and in_same_household_as_recipient
 
 
 @policy_function(skip_vectorization=True)
-def child_in_same_household_as_recipient(
+def in_same_household_as_recipient(
     p_id: int,
     hh_id: int,
     p_id_recipient: int,

--- a/tests/ttsim/mettsim/payroll_tax/child_tax_credit/inputs.py
+++ b/tests/ttsim/mettsim/payroll_tax/child_tax_credit/inputs.py
@@ -1,0 +1,6 @@
+from ttsim import FKType, policy_input
+
+
+@policy_input(foreign_key_type=FKType.MAY_POINT_TO_SELF)
+def p_id_recipient() -> int:
+    """Identifier of the recipient of the child tax credit."""

--- a/tests/ttsim/mettsim/payroll_tax/group_by_ids.py
+++ b/tests/ttsim/mettsim/payroll_tax/group_by_ids.py
@@ -1,11 +1,6 @@
 import numpy
 
-from ttsim import FKType, group_creation_function, policy_input
-
-
-@policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)
-def p_id_spouse() -> int:
-    """Identifier of married partner."""
+from ttsim import group_creation_function
 
 
 @group_creation_function()

--- a/tests/ttsim/mettsim/payroll_tax/income/deductions.py
+++ b/tests/ttsim/mettsim/payroll_tax/income/deductions.py
@@ -6,7 +6,8 @@ def deductions_y(
     payroll_tax__child_tax_credit__amount_y: float,
     payroll_tax_params: dict,
 ) -> float:
-    return (
+    return min(
         payroll_tax_params["lump_sum_deduction_y"]
-        + payroll_tax__child_tax_credit__amount_y
+        + payroll_tax__child_tax_credit__amount_y,
+        0.0,
     )

--- a/tests/ttsim/test_combine_functions.py
+++ b/tests/ttsim/test_combine_functions.py
@@ -924,27 +924,33 @@ def test_source_column_name_of_aggregate_by_p_id_func_is_qualified(
 @pytest.mark.parametrize(
     (
         "target_name",
+        "supported_groupings",
         "top_level_namespace",
         "expected",
     ),
     [
         (
             "arbeitslosengeld_2__vermögen_bg",
+            ("bg",),
             {"vermögen", "arbeitslosengeld_2"},
             "vermögen",
         ),
         (
             "arbeitslosengeld_2__vermögen_bg",
+            ("bg",),
             {"arbeitslosengeld_2"},
             "arbeitslosengeld_2__vermögen",
         ),
     ],
 )
-def test_get_name_of_aggregation_source(target_name, top_level_namespace, expected):
+def test_get_name_of_aggregation_source(
+    target_name, supported_groupings, top_level_namespace, expected
+):
     assert (
         _get_name_of_aggregation_source(
             target_name=target_name,
             top_level_namespace=top_level_namespace,
+            supported_groupings=supported_groupings,
         )
         == expected
     )

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
@@ -39,9 +39,3 @@ outputs:
   housing_benefits__eligibility__requirement_fulfilled_fam:
     - false
     - false
-  housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
-  housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
@@ -20,7 +20,7 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 1500
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
@@ -21,7 +21,7 @@ inputs:
       - 1
       - 0
     payroll_tax__gross_wage_m:
-      - 1500
+      - 800
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
@@ -31,17 +31,11 @@ inputs:
       - 30
 outputs:
   housing_benefits__amount_m_fam:
-    - 0.0
-    - 0.0
+    - (800 - (800 - 100/12)*0.3) * 0.5
+    - (800 - (800 - 100/12)*0.3) * 0.5
   housing_benefits__income__amount_m:
-    - 1500 - (1500 - 100/12) * 0.3
+    - 800 - (800 - 100/12)*0.3
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
-    - false
-    - false
-  housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
-  housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0
+    - true
+    - true

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
@@ -20,7 +20,7 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 800
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 1500
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
@@ -8,40 +8,44 @@ inputs:
     p_id:
       - 0
       - 1
+      - 2
     hh_id:
+      - 0
       - 0
       - 0
     p_id_parent_1:
       - -1
       - -1
+      - 0
     p_id_parent_2:
       - -1
       - -1
+      - 1
     p_id_spouse:
       - 1
       - 0
+      - -1
     payroll_tax__gross_wage_m:
       - 1500
+      - 0
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
       - -1
+      - 0
     age:
       - 30
       - 30
+      - 10
 outputs:
   housing_benefits__amount_m_fam:
     - 0.0
     - 0.0
   housing_benefits__income__amount_m:
-    - 1500 - (1500 - 100/12) * 0.3
+    - 1500 - (1500 - 200/12) * 0.3
+    - 0.0
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
     - false
     - false
-  housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
-  housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0
+    - false

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
@@ -8,40 +8,45 @@ inputs:
     p_id:
       - 0
       - 1
+      - 2
     hh_id:
+      - 0
       - 0
       - 0
     p_id_parent_1:
       - -1
       - -1
+      - 0
     p_id_parent_2:
       - -1
       - -1
+      - 1
     p_id_spouse:
       - 1
       - 0
+      - -1
     payroll_tax__gross_wage_m:
-      - 1500
+      - 800
+      - 0
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
       - -1
+      - 0
     age:
       - 30
       - 30
+      - 10
 outputs:
   housing_benefits__amount_m_fam:
-    - 0.0
-    - 0.0
+    - (800 - (800 - 200/12)*0.3) * 0.5
+    - (800 - (800 - 200/12)*0.3) * 0.5
+    - (800 - (800 - 200/12)*0.3) * 0.5
   housing_benefits__income__amount_m:
-    - 1500 - (1500 - 100/12) * 0.3
+    - 800 - (800 - 200/12)*0.3
+    - 0.0
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
-    - false
-    - false
-  housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
-  housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0
+    - true
+    - true
+    - true

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 800
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
@@ -1,0 +1,47 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+    p_id_parent_2:
+      - -1
+      - -1
+    p_id_spouse:
+      - 1
+      - 0
+    payroll_tax__gross_wage_y:
+      - 10000
+      - 0
+    payroll_tax__child_tax_credit__p_id_recipient:
+      - -1
+      - -1
+    age:
+      - 30
+      - 30
+outputs:
+  housing_benefits__amount_m_fam:
+    - 0.0
+    - 0.0
+  housing_benefits__income__amount_m:
+    - 10000 - 9900 * 0.3
+    - 0.0
+  housing_benefits__eligibility__requirement_fulfilled_fam:
+    - false
+    - false
+  housing_benefits__eligibility__number_of_children_considered:
+    - 0
+    - 0
+  housing_benefits__eligibility__number_of_children_fam:
+    - 0
+    - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
@@ -20,7 +20,7 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 1500
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
@@ -20,7 +20,7 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 800
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
@@ -20,8 +20,8 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_y:
-      - 200
+    payroll_tax__gross_wage_m:
+      - 800
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
@@ -31,10 +31,10 @@ inputs:
       - 30
 outputs:
   housing_benefits__amount_m_fam:
-    - (200 - 100 * 0.3) * 0.5
-    - (200 - 100 * 0.3) * 0.5
+    - (800 - (800 - 100/12)*0.3) * 0.5
+    - (800 - (800 - 100/12)*0.3) * 0.5
   housing_benefits__income__amount_m:
-    - 200 - 100 * 0.3
+    - 800 - (800 - 100/12)*0.3
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
     - true

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
@@ -1,0 +1,47 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+    p_id_parent_2:
+      - -1
+      - -1
+    p_id_spouse:
+      - 1
+      - 0
+    payroll_tax__gross_wage_y:
+      - 200
+      - 0
+    payroll_tax__child_tax_credit__p_id_recipient:
+      - -1
+      - -1
+    age:
+      - 30
+      - 30
+outputs:
+  housing_benefits__amount_m_fam:
+    - (200 - 100 * 0.3) * 0.5
+    - (200 - 100 * 0.3) * 0.5
+  housing_benefits__income__amount_m:
+    - 200 - 100 * 0.3
+    - 0.0
+  housing_benefits__eligibility__requirement_fulfilled_fam:
+    - true
+    - true
+  housing_benefits__eligibility__number_of_children_considered:
+    - 0
+    - 0
+  housing_benefits__eligibility__number_of_children_fam:
+    - 0
+    - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 1500
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
@@ -8,40 +8,53 @@ inputs:
     p_id:
       - 0
       - 1
+      - 2
     hh_id:
+      - 0
       - 0
       - 0
     p_id_parent_1:
       - -1
       - -1
+      - 0
     p_id_parent_2:
       - -1
       - -1
+      - 0
     p_id_spouse:
       - 1
       - 0
+      - -1
     payroll_tax__gross_wage_m:
       - 1500
+      - 0
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
       - -1
+      - 0
     age:
       - 30
       - 30
+      - 10
 outputs:
   housing_benefits__amount_m_fam:
-    - 0.0
-    - 0.0
+    - (1500 - (1500 - 200/12) * 0.3) * 0.5
+    - (1500 - (1500 - 200/12) * 0.3) * 0.5
+    - (1500 - (1500 - 200/12) * 0.3) * 0.5
   housing_benefits__income__amount_m:
-    - 1500 - (1500 - 100/12) * 0.3
+    - 1500 - (1500 - 200/12) * 0.3
+    - 0.0
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
-    - false
-    - false
+    - true
+    - true
+    - true
   housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
+    - 1
+    - 1
+    - 1
   housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0
+    - 1
+    - 1
+    - 1

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
@@ -8,40 +8,53 @@ inputs:
     p_id:
       - 0
       - 1
+      - 2
     hh_id:
+      - 0
       - 0
       - 0
     p_id_parent_1:
       - -1
       - -1
+      - 0
     p_id_parent_2:
       - -1
       - -1
+      - 0
     p_id_spouse:
       - 1
       - 0
+      - -1
     payroll_tax__gross_wage_m:
-      - 1500
+      - 800
+      - 0
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:
       - -1
       - -1
+      - 0
     age:
       - 30
       - 30
+      - 10
 outputs:
   housing_benefits__amount_m_fam:
-    - 0.0
-    - 0.0
+    - (800 - (800 - 200/12) * 0.3) * 0.5
+    - (800 - (800 - 200/12) * 0.3) * 0.5
+    - (800 - (800 - 200/12) * 0.3) * 0.5
   housing_benefits__income__amount_m:
-    - 1500 - (1500 - 100/12) * 0.3
+    - 800 - (800 - 200/12) * 0.3
+    - 0.0
     - 0.0
   housing_benefits__eligibility__requirement_fulfilled_fam:
-    - false
-    - false
+    - true
+    - true
+    - true
   housing_benefits__eligibility__number_of_children_considered:
-    - 0
-    - 0
+    - 1
+    - 1
+    - 1
   housing_benefits__eligibility__number_of_children_fam:
-    - 0
-    - 0
+    - 1
+    - 1
+    - 1

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 800
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
@@ -1,0 +1,50 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+    hh_id:
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+    p_id_parent_2:
+      - -1
+      - -1
+    p_id_spouse:
+      - 1
+      - 0
+    payroll_tax__gross_wage_y:
+      - 10000
+      - 0
+    payroll_tax__child_tax_credit__p_id_recipient:
+      - -1
+      - -1
+    age:
+      - 30
+      - 30
+outputs:
+  payroll_tax__income__deductions_y:
+    - 100
+    - 0.0
+  payroll_tax__income__amount_y:
+    - 10000 - 100
+    - 0.0
+  payroll_tax__amount_y:
+    - 9900 * 0.3
+    - 0.0
+  payroll_tax__child_tax_credit__claim_of_child_y:
+    - 0.0
+    - 0.0
+  payroll_tax__child_tax_credit__child_eligible:
+    - false
+    - false
+  payroll_tax__child_tax_credit__in_same_household_as_recipient:
+    - false
+    - false

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
@@ -20,7 +20,7 @@ inputs:
     p_id_spouse:
       - 1
       - 0
-    payroll_tax__gross_wage_y:
+    payroll_tax__income__gross_wage_y:
       - 10000
       - 0
     payroll_tax__child_tax_credit__p_id_recipient:

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
@@ -1,0 +1,68 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+      - 2
+    hh_id:
+      - 0
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+      - 0
+    p_id_parent_2:
+      - -1
+      - -1
+      - 1
+    p_id_spouse:
+      - 1
+      - 0
+      - -1
+    payroll_tax__gross_wage_y:
+      - 10000
+      - 0
+      - 0
+    payroll_tax__child_tax_credit__p_id_recipient:
+      - -1
+      - -1
+      - 0
+    age:
+      - 30
+      - 30
+      - 30
+outputs:
+  payroll_tax__income__deductions_y:
+    - 100
+    - 0.0
+    - 0.0
+  payroll_tax__income__amount_y:
+    - 9800
+    - 0.0
+    - 0.0
+  payroll_tax__amount_y:
+    - 9800 * 0.3
+    - 0.0
+    - 0.0
+  payroll_tax__child_tax_credit__claim_of_child_y:
+    - 0.0
+    - 0.0
+    - 100.0
+  payroll_tax__child_tax_credit__amount_m:
+    - 100.0
+    - 0.0
+    - 0.0
+  payroll_tax__child_tax_credit__child_eligible:
+    - false
+    - false
+    - true
+  payroll_tax__child_tax_credit__in_same_household_as_recipient:
+    - false
+    - false
+    - true

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_y:
+    payroll_tax__income__gross_wage_y:
       - 10000
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
@@ -1,0 +1,68 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+      - 2
+    hh_id:
+      - 0
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+      - 0
+    p_id_parent_2:
+      - -1
+      - -1
+      - 1
+    p_id_spouse:
+      - 1
+      - 0
+      - -1
+    payroll_tax__gross_wage_m:
+      - 833.333333
+      - 0
+      - 0
+    payroll_tax__child_tax_credit__p_id_recipient:
+      - -1
+      - -1
+      - 0
+    age:
+      - 30
+      - 30
+      - 30
+outputs:
+  payroll_tax__income__deductions_y:
+    - 100
+    - 0.0
+    - 0.0
+  payroll_tax__income__amount_y:
+    - 9800
+    - 0.0
+    - 0.0
+  payroll_tax__amount_y:
+    - 9800 * 0.3
+    - 0.0
+    - 0.0
+  payroll_tax__child_tax_credit__claim_of_child_y:
+    - 0.0
+    - 0.0
+    - 100.0
+  payroll_tax__child_tax_credit__amount_m:
+    - 8.333333
+    - 0.0
+    - 0.0
+  payroll_tax__child_tax_credit__child_eligible:
+    - false
+    - false
+    - true
+  payroll_tax__child_tax_credit__in_same_household_as_recipient:
+    - false
+    - false
+    - true

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
@@ -25,7 +25,7 @@ inputs:
       - 1
       - 0
       - -1
-    payroll_tax__gross_wage_m:
+    payroll_tax__income__gross_wage_m:
       - 833.333333
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/group_by_ids.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/group_by_ids.yaml
@@ -1,0 +1,44 @@
+---
+info:
+  note: ''
+  precision: 0.01
+  source: ''
+inputs:
+  provided:
+    p_id:
+      - 0
+      - 1
+      - 2
+    hh_id:
+      - 0
+      - 0
+      - 0
+    p_id_parent_1:
+      - -1
+      - -1
+      - 0
+    p_id_parent_2:
+      - -1
+      - -1
+      - 1
+    p_id_spouse:
+      - 1
+      - 0
+      - -1
+    age:
+      - 30
+      - 30
+      - 10
+    gross_wage_y:
+      - 10000
+      - 0
+      - 0
+outputs:
+  sp_id:
+    - 0
+    - 0
+    - 1
+  payroll_tax__fam_id:
+    - 0
+    - 0
+    - 0

--- a/tests/ttsim/test_docs.py
+++ b/tests/ttsim/test_docs.py
@@ -14,6 +14,8 @@ from ttsim.loader import (
 )
 from ttsim.shared import remove_group_suffix
 
+SUPPORTED_GROUPINGS = ("hh", "sp", "fam")
+
 
 def _nice_output_list_of_strings(list_of_strings):
     my_str = "\n".join(sorted(list_of_strings))
@@ -91,7 +93,10 @@ def test_all_input_vars_documented(
         c
         for c in arguments
         if (c not in defined_functions)
-        and (remove_group_suffix(c) not in defined_functions)
+        and (
+            remove_group_suffix(c, supported_groupings=SUPPORTED_GROUPINGS)
+            not in defined_functions
+        )
         and (not c.endswith("_params"))
     ]
 

--- a/tests/ttsim/test_visualizations.py
+++ b/tests/ttsim/test_visualizations.py
@@ -15,7 +15,7 @@ from ttsim.visualization import (
 environment = set_up_policy_environment(date="2020-01-01", resource_dir=RESOURCE_DIR)
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, node, order, expected",
     [(5, 3, 1, {2, 3, 4}), (5, 1, 2, {0, 1, 2, 3})],
@@ -26,7 +26,7 @@ def test_kth_order_neighbors(n_nodes, node, order, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, node, order, expected",
     [(5, 3, None, {0, 1, 2, 3}), (5, 1, None, {0, 1})],
@@ -37,7 +37,7 @@ def test_node_and_ancestors(n_nodes, node, order, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, node, order, expected",
     [(5, 3, 1, {2, 3}), (5, 1, 2, {0, 1})],
@@ -48,7 +48,7 @@ def test_node_and_ancestors_order(n_nodes, node, order, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, node, order, expected",
     [(5, 3, None, {3, 4, 5}), (5, 1, None, {1, 2, 3, 4, 5})],
@@ -59,7 +59,7 @@ def test_node_and_descendants(n_nodes, node, order, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, node, order, expected",
     [(5, 3, 1, {3, 4}), (5, 1, 2, {1, 2, 3})],
@@ -70,7 +70,7 @@ def test_node_and_descendants_order(n_nodes, node, order, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, selector, expected",
     [
@@ -89,7 +89,7 @@ def test_get_selected_nodes(n_nodes, selector, expected):
     assert nodes == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 @pytest.mark.parametrize(
     "n_nodes, selectors, expected",
     [
@@ -116,7 +116,7 @@ def test_select_nodes_in_dag(n_nodes, selectors, expected):
     assert set(dag.nodes) == expected
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_plot_dag():
     """Make sure that minimal example doesn't produce an error."""
     plot_dag(
@@ -125,7 +125,7 @@ def test_plot_dag():
     )
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_should_fail_if_target_is_missing():
     with pytest.raises(
         ValueError, match="The following targets have no corresponding function"
@@ -136,14 +136,14 @@ def test_should_fail_if_target_is_missing():
         )
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_one_dot_plot_dag():
     """Make sure that the one dot graph example doesn't produce an error."""
     selectors = "einkommensteuer__einkünfte__aus_kapitalvermögen__kapitalerträge_y_sn"
     plot_dag(environment=environment, selectors=selectors)
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_10_dots_plot_dag():
     """Make sure that when No.of nodes is larger than 10 or show_labels is false, the
     graph example doesn't produce an error and hover information works properly."""
@@ -154,7 +154,7 @@ def test_10_dots_plot_dag():
     plot_dag(environment=environment, selectors=selector, orientation="h")
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_horizontal_plot_dag():
     """Make sure that when we choose horizontal orientation, the graph example doesn't
     produce an error."""
@@ -170,7 +170,7 @@ def test_horizontal_plot_dag():
     )
 
 
-@pytest.mark.xfail(reason="Visualization module was not updated to the new interface.")
+@pytest.mark.skip(reason="Visualization module was not updated to the new interface.")
 def test_hover_source_code_plot_dag():
     """Make sure that when hover information is source code, the graph example doesn't
     produce an error and works properly."""

--- a/tests/ttsim/utils.py
+++ b/tests/ttsim/utils.py
@@ -165,32 +165,12 @@ def _get_policy_tests_from_raw_test_data(
 
     date: datetime.date = to_datetime(path_to_yaml.parent.name)
 
-    out = []
-    if expected_output_tree == {}:
-        out.append(
-            PolicyTest(
-                info=test_info,
-                input_tree=input_tree,
-                expected_output_tree={},
-                path=path_to_yaml,
-                date=date,
-            )
+    return [
+        PolicyTest(
+            info=test_info,
+            input_tree=input_tree,
+            expected_output_tree=expected_output_tree,
+            path=path_to_yaml,
+            date=date,
         )
-    else:
-        for target_name, output_data in dt.flatten_to_tree_paths(
-            expected_output_tree
-        ).items():
-            one_expected_output: NestedDataDict = dt.unflatten_from_tree_paths(
-                {target_name: output_data}
-            )
-            out.append(
-                PolicyTest(
-                    info=test_info,
-                    input_tree=input_tree,
-                    expected_output_tree=one_expected_output,
-                    path=path_to_yaml,
-                    date=date,
-                )
-            )
-
-    return out
+    ]

--- a/tests/ttsim/utils.py
+++ b/tests/ttsim/utils.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING
 import dags.tree as dt
 import pandas as pd
 import yaml
-from mettsim.config import SUPPORTED_GROUPINGS
+from mettsim.config import RESOURCE_DIR, SUPPORTED_GROUPINGS
 
 from ttsim import merge_trees, set_up_policy_environment
 from ttsim.shared import to_datetime
 
-TEST_DIR = Path(__file__).parent / "test_data"
+TEST_DIR = Path(__file__).parent
 
 if TYPE_CHECKING:
     import datetime
@@ -53,7 +53,7 @@ def execute_test(test: PolicyTest):
 
     from ttsim import compute_taxes_and_transfers
 
-    environment = set_up_policy_environment(date=test.date)
+    environment = set_up_policy_environment(date=test.date, resource_dir=RESOURCE_DIR)
 
     result = compute_taxes_and_transfers(
         data_tree=test.input_tree,


### PR DESCRIPTION
### What problem do you want to solve?

Add policy test data for METTSIM.

Todo
- [x] Introduce `resource_dir` arg for parameters in `set_up_policy_environment`, it currently reads in GETTSIM parameters.
- [x] Fix testing infrastructure such that a merged df is used for testing. Currently, we only test the first expected output column in each testing yaml.

