### PR TITLE
Fix JAX-Jit tests

### DIFF
--- a/src/ttsim/ttsim_objects.py
+++ b/src/ttsim/ttsim_objects.py
@@ -63,7 +63,7 @@ class FKType(StrEnum):
     MUST_NOT_POINT_TO_SELF = "must not point to self"
 
 
-@dataclass
+@dataclass(frozen=True)
 class TTSIMObject:
     """
     Abstract base class for all TTSIM Functions and Inputs.
@@ -86,7 +86,7 @@ class TTSIMObject:
         raise NotImplementedError("Subclasses must implement this method.")
 
 
-@dataclass
+@dataclass(frozen=True)
 class PolicyInput(TTSIMObject):
     """
     A dummy function representing an input variable.
@@ -157,7 +157,31 @@ def policy_input(
     return inner
 
 
-@dataclass
+def _update_wrapper_frozen_dataclass_safe(wrapper: object, wrapped: Callable) -> None:
+    """Update a wrapper dataclass to look like the wrapped function.
+
+    This is necessary because the wrapper is a frozen dataclass, so we cannot
+    use the `functools.update_wrapper` function or `self.__signature__ = ...`
+    assigments in the `__post_init__` method.
+
+    Args:
+        wrapper: The wrapper dataclass to update.
+        wrapped: The function to update the wrapper to.
+
+    """
+    object.__setattr__(wrapper, "__signature__", inspect.signature(wrapped))
+    object.__setattr__(wrapper, "__globals__", wrapped.__globals__)
+    object.__setattr__(wrapper, "__closure__", wrapped.__closure__)
+    object.__setattr__(wrapper, "__doc__", wrapped.__doc__)
+    object.__setattr__(wrapper, "__name__", wrapped.__name__)
+    object.__setattr__(wrapper, "__qualname__", wrapped.__qualname__)
+    object.__setattr__(wrapper, "__module__", wrapped.__module__)
+    object.__setattr__(wrapper, "__annotations__", wrapped.__annotations__)
+    object.__setattr__(wrapper, "__type_params__", wrapped.__type_params__)
+    getattr(wrapper, "__dict__", {}).update(getattr(wrapped, "__dict__", {}))
+
+
+@dataclass(frozen=True)
 class TTSIMFunction(TTSIMObject):
     """
     Base class for all TTSIM functions.
@@ -169,12 +193,8 @@ class TTSIMFunction(TTSIMObject):
 
     def __post_init__(self):
         self._fail_if_rounding_has_wrong_type(self.rounding_spec)
-
         # Expose the signature of the wrapped function for dependency resolution
-        functools.update_wrapper(self, self.function)
-        self.__signature__ = inspect.signature(self.function)
-        self.__globals__ = self.function.__globals__
-        self.__closure__ = self.function.__closure__
+        _update_wrapper_frozen_dataclass_safe(self, self.function)
 
     def _fail_if_rounding_has_wrong_type(
         self, rounding_spec: RoundingSpec | None
@@ -213,7 +233,7 @@ class TTSIMFunction(TTSIMObject):
         return self.start_date <= date <= self.end_date
 
 
-@dataclass
+@dataclass(frozen=True)
 class PolicyFunction(TTSIMFunction):
     """
     A function that computes an output vector based on some input vectors and/or
@@ -340,7 +360,7 @@ def _vectorize_func(
     return vectorized
 
 
-@dataclass
+@dataclass(frozen=True)
 class GroupCreationFunction(TTSIMFunction):
     """
     A function that computes endogenous group_by IDs.
@@ -400,7 +420,7 @@ def group_creation_function(
     return decorator
 
 
-@dataclass
+@dataclass(frozen=True)
 class AggByGroupFunction(TTSIMFunction):
     """
     A function that is an aggregation of another column by some group id.
@@ -524,7 +544,7 @@ def _fail_if_other_arg_is_invalid(other_args: set[str], orig_location: str):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class AggByPIDFunction(TTSIMFunction):
     """
     A function that is an aggregation of another column by some group id.
@@ -651,7 +671,7 @@ def _fail_if_other_p_id_is_invalid(other_p_ids: set[str], orig_location: str):
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class TimeConversionFunction(TTSIMFunction):
     """
     A function that is a time conversion of another function.

--- a/tests/ttsim/test_jax_jit_kindergeld.py
+++ b/tests/ttsim/test_jax_jit_kindergeld.py
@@ -46,11 +46,11 @@ def test_kindergeld_policy_func():
 @pytest.fixture
 def kindergeld_policy_test():
     name = "alleinerz_2_children_low_unterhalt.yaml"
-    kindergeld_2024 = load_policy_test_data("kindergeld/2024")
+    kindergeld_2024 = load_policy_test_data("kindergeld/2024-01-01")
     single_test = [
         test_data for test_data in kindergeld_2024 if test_data.path.name == name
     ]
-    return single_test[1]  # index=1 -> betrag_m
+    return single_test[0]
 
 
 @pytest.mark.skipif(not IS_JAX_INSTALLED, reason="JAX is not installed")
@@ -63,6 +63,7 @@ def test_compute_taxes_and_transfers_kindergeld(kindergeld_policy_test):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
+        groupings=(),
         jit=True,
     )
 


### PR DESCRIPTION
### What problem do you want to solve?

Tests in `test_jax_jit_kindergeld.py` were failing because policy functions were not jittable.

### Problems and Solutions

#### Non-Hashable Function in `jit`

The policy functions were non-jittable because the dataclasses were non-frozen and had the equality argument set to True. This implies that the dataclass get an equality method which compares the fields. To not break the equality/hash contract (a == b implies hash(a) == hash(b)), a dataclass with equality method that is not frozen has a deactivated hash. This does not work with `jax.jit`, because for caching JAX requires a hash of the object. By freezing the dataclasses they get their hash back, and everything works nicely again with JAX.

### Todo

- [x] Freeze ttsim_objects dataclasses and update post init of `TTSIMFunction` to be compatible 
- [ ] Understand why list `single_test` in  `kindergeld_policy_test` fixture has only one entry, although the yaml file says there are two outputs
- [ ] Fix `test_compute_taxes_and_transfers_kindergeld`