### PR TITLE
Infer groupings from objects tree

### DIFF
--- a/src/_gettsim/interface.py
+++ b/src/_gettsim/interface.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from _gettsim.config import RESOURCE_DIR, SUPPORTED_GROUPINGS
+from _gettsim.config import RESOURCE_DIR
 from ttsim import (
     compute_taxes_and_transfers,
     create_data_tree_from_df,
@@ -82,7 +82,6 @@ def oss(
         data_tree=data_tree,
         environment=policy_environment,
         targets_tree=targets_tree,
-        supported_groupings=SUPPORTED_GROUPINGS,
         rounding=True,
         debug=False,
         jit=False,

--- a/src/_gettsim_tests/test_full_taxes_and_transfers.py
+++ b/src/_gettsim_tests/test_full_taxes_and_transfers.py
@@ -1,7 +1,6 @@
 import dags.tree as dt
 import pytest
 
-from _gettsim.config import SUPPORTED_GROUPINGS
 from _gettsim_tests.utils import (
     PolicyTest,
     cached_set_up_policy_environment,
@@ -21,7 +20,6 @@ def test_full_taxes_transfers(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
 
@@ -33,7 +31,6 @@ def test_data_types(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_types_input_variables = {
@@ -71,5 +68,4 @@ def test_allow_none_as_target_tree(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=None,
-        groupings=SUPPORTED_GROUPINGS,
     )

--- a/src/_gettsim_tests/test_groupings.py
+++ b/src/_gettsim_tests/test_groupings.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from _gettsim.config import SUPPORTED_GROUPINGS
 from _gettsim_tests.utils import (
     PolicyTest,
     cached_set_up_policy_environment,
@@ -22,7 +21,6 @@ def test_groupings(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_result = dt.flatten_to_qual_names(result)
@@ -55,5 +53,4 @@ def test_fail_to_compute_sn_id_if_married_but_gemeinsam_veranlagt_differs():
             data_tree=data,
             environment=environment,
             targets_tree={"sn_id": None},
-            groupings=SUPPORTED_GROUPINGS,
         )

--- a/src/_gettsim_tests/test_grundrente_proxy_rente.py
+++ b/src/_gettsim_tests/test_grundrente_proxy_rente.py
@@ -4,7 +4,6 @@ import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from _gettsim.config import SUPPORTED_GROUPINGS
 from _gettsim_tests.utils import (
     PolicyTest,
     cached_set_up_policy_environment,
@@ -29,7 +28,6 @@ def test_grundrente_proxy_rente_vorjahr_comparison(test: PolicyTest):
                 "rente": {"grundrente": {"proxy_rente_vorjahr_m": None}}
             }
         },
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     # Calculate pension of last year
@@ -41,7 +39,6 @@ def test_grundrente_proxy_rente_vorjahr_comparison(test: PolicyTest):
         targets_tree={
             "sozialversicherung": {"rente": {"altersrente": {"bruttorente_m": None}}}
         },
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_result = dt.flatten_to_qual_names(result)

--- a/src/_gettsim_tests/test_household_links.py
+++ b/src/_gettsim_tests/test_household_links.py
@@ -2,7 +2,6 @@ import dags.tree as dt
 import pytest
 from numpy.testing import assert_array_almost_equal
 
-from _gettsim.config import SUPPORTED_GROUPINGS
 from _gettsim_tests.utils import (
     PolicyTest,
     cached_set_up_policy_environment,
@@ -21,7 +20,6 @@ def test_aggregate_by_p_id(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_result = dt.flatten_to_qual_names(result)

--- a/src/_gettsim_tests/utils.py
+++ b/src/_gettsim_tests/utils.py
@@ -7,7 +7,7 @@ import dags.tree as dt
 import pandas as pd
 import yaml
 
-from _gettsim.config import RESOURCE_DIR, SUPPORTED_GROUPINGS
+from _gettsim.config import RESOURCE_DIR
 from _gettsim_tests import TEST_DIR
 from ttsim import (
     PolicyEnvironment,
@@ -75,7 +75,6 @@ def execute_test(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_result = dt.flatten_to_qual_names(result)

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import inspect
-import re
 import warnings
 from typing import TYPE_CHECKING, Any
 
@@ -87,10 +86,7 @@ def compute_taxes_and_transfers(
     _fail_if_targets_tree_not_valid(targets_tree)
     _fail_if_data_tree_not_valid(data_tree)
     _fail_if_environment_not_valid(environment)
-    _fail_if_group_ids_are_outside_top_level_namespace(
-        environment=environment,
-        groupings=groupings,
-    )
+
     # Transform functions tree to qualified names dict with qualified arguments
     top_level_namespace = _get_top_level_namespace(
         environment=environment,
@@ -179,25 +175,6 @@ def compute_taxes_and_transfers(
         )
 
     return result_tree
-
-
-def _fail_if_group_ids_are_outside_top_level_namespace(
-    environment: PolicyEnvironment,
-    groupings: tuple[str, ...],
-) -> None:
-    """Fail if group ids are outside the top level namespace."""
-    group_id_pattern = re.compile(f"(?P<group>{'|'.join(groupings)})_id$")
-    group_ids_outside_top_level_namespace = {
-        tree_path
-        for tree_path in dt.flatten_to_tree_paths(environment.raw_objects_tree)
-        if len(tree_path) > 1 and group_id_pattern.match(tree_path[-1])
-    }
-    if group_ids_outside_top_level_namespace:
-        raise ValueError(
-            "Group identifiers must live in the top-level namespace. Got:\n\n"
-            f"{group_ids_outside_top_level_namespace}\n\n"
-            "To fix this error, move the group identifiers to the top-level namespace."
-        )
 
 
 def _get_top_level_namespace(

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -91,7 +91,6 @@ def compute_taxes_and_transfers(
         environment=environment,
         time_units=tuple(TIME_UNIT_LABELS.keys()),
     )
-    groupings = environment.grouping_levels
     # Flatten nested objects to qualified names
     targets = dt.qual_names(targets_tree)
     data = dt.flatten_to_qual_names(data_tree)
@@ -104,7 +103,7 @@ def compute_taxes_and_transfers(
         ttsim_objects=ttsim_objects,
         targets=targets,
         data=data,
-        groupings=groupings,
+        groupings=environment.grouping_levels,
     )
 
     functions_overridden, functions_to_be_used = partition_by_reference_dict(
@@ -134,7 +133,7 @@ def compute_taxes_and_transfers(
     _fail_if_group_variables_not_constant_within_groups(
         data=input_data,
         functions=functions,
-        groupings=groupings,
+        groupings=environment.grouping_levels,
     )
     _input_data_with_p_id = {
         "p_id": data["p_id"],
@@ -193,9 +192,8 @@ def _get_top_level_namespace(
         The top level namespace.
     """
     direct_top_level_names = set(environment.raw_objects_tree.keys())
-    groupings = environment.grouping_levels
     pattern_all = get_re_pattern_for_all_time_units_and_groupings(
-        groupings=groupings,
+        groupings=environment.grouping_levels,
         time_units=time_units,
     )
 
@@ -214,11 +212,11 @@ def _get_top_level_namespace(
                 all_top_level_names.add(f"{bngs[0]}_{time_unit}{bngs[1]}")
     fail_if_multiple_time_units_for_same_base_name_and_group(bngs_to_variations)
 
-    gp = group_pattern(groupings)
+    gp = group_pattern(environment.grouping_levels)
     potential_base_names = {n for n in all_top_level_names if not gp.match(n)}
 
     for name in potential_base_names:
-        for g in groupings:
+        for g in environment.grouping_levels:
             all_top_level_names.add(f"{name}_{g}")
 
     return all_top_level_names

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -607,9 +607,7 @@ def _fail_if_root_nodes_are_missing(
         raise ValueError(f"The following data columns are missing.\n{formatted}")
 
 
-def _func_depends_on_parameters_only(
-    func: TTSIMFunction,
-) -> bool:
+def _func_depends_on_parameters_only(func: TTSIMFunction) -> bool:
     """Check if a function depends on parameters only."""
     return (
         len(

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -51,7 +51,6 @@ def compute_taxes_and_transfers(
     data_tree: NestedDataDict,
     environment: PolicyEnvironment,
     targets_tree: NestedTargetDict,
-    groupings: tuple[str, ...],
     rounding: bool = True,
     debug: bool = False,
     jit: bool = False,
@@ -91,8 +90,8 @@ def compute_taxes_and_transfers(
     top_level_namespace = _get_top_level_namespace(
         environment=environment,
         time_units=tuple(TIME_UNIT_LABELS.keys()),
-        groupings=groupings,
     )
+    groupings = environment.grouping_levels
     # Flatten nested objects to qualified names
     targets = dt.qual_names(targets_tree)
     data = dt.flatten_to_qual_names(data_tree)
@@ -180,7 +179,6 @@ def compute_taxes_and_transfers(
 def _get_top_level_namespace(
     environment: PolicyEnvironment,
     time_units: tuple[str, ...],
-    groupings: tuple[str, ...],
 ) -> set[str]:
     """Get the top level namespace.
 
@@ -195,7 +193,7 @@ def _get_top_level_namespace(
         The top level namespace.
     """
     direct_top_level_names = set(environment.raw_objects_tree.keys())
-
+    groupings = environment.grouping_levels
     pattern_all = get_re_pattern_for_all_time_units_and_groupings(
         groupings=groupings,
         time_units=time_units,

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -31,7 +31,6 @@ from ttsim.shared import (
 )
 from ttsim.ttsim_objects import (
     FKType,
-    GroupCreationFunction,
     TTSIMFunction,
 )
 
@@ -132,7 +131,6 @@ def compute_taxes_and_transfers(
 
     _fail_if_group_variables_not_constant_within_groups(
         data=input_data,
-        functions=functions,
         groupings=environment.grouping_levels,
     )
     _input_data_with_p_id = {
@@ -378,7 +376,6 @@ def _fail_if_data_tree_not_valid(data_tree: NestedDataDict) -> None:
 
 def _fail_if_group_variables_not_constant_within_groups(
     data: QualNameDataDict,
-    functions: QualNameTTSIMFunctionDict,
     groupings: tuple[str, ...],
 ) -> None:
     """
@@ -391,19 +388,14 @@ def _fail_if_group_variables_not_constant_within_groups(
     ----------
     data
         Dictionary of data.
-    functions
-        Dictionary of functions.
+    groupings
+        The groupings available in the policy environment.
     """
-    group_by_functions = {
-        k: v for k, v in functions.items() if isinstance(v, GroupCreationFunction)
-    }
-
     faulty_data_columns = []
 
     for name, data_column in data.items():
         group_by_id = get_name_of_group_by_id(
             target_name=name,
-            group_by_functions=group_by_functions,
             groupings=groupings,
         )
         if group_by_id in data:

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -237,6 +237,23 @@ def _convert_to_policy_function_if_not_ttsim_object(
     return converted_object
 
 
+def _fail_if_group_ids_are_outside_top_level_namespace(
+    raw_objects_tree: NestedTTSIMObjectDict,
+) -> None:
+    """Fail if group ids are outside the top level namespace."""
+    group_ids_outside_top_level_namespace = {
+        tree_path
+        for tree_path in dt.flatten_to_tree_paths(raw_objects_tree)
+        if len(tree_path) > 1 and tree_path[-1].endswith("_id")
+    }
+    if group_ids_outside_top_level_namespace:
+        raise ValueError(
+            "Group identifiers must live in the top-level namespace. Got:\n\n"
+            f"{group_ids_outside_top_level_namespace}\n\n"
+            "To fix this error, move the group identifiers to the top-level namespace."
+        )
+
+
 def _parse_piecewise_parameters(tax_data):
     """Check if parameters are stored in implicit structures and align to general
     structure.
@@ -652,20 +669,3 @@ def add_progressionsfaktor(params_dict, parameter):
                 out_dict[key + 1]["rate_linear"] - out_dict[key]["rate_linear"]
             ) / (2 * (upper_thresholds[key] - lower_thresholds[key]))
     return out_dict
-
-
-def _fail_if_group_ids_are_outside_top_level_namespace(
-    raw_objects_tree: NestedTTSIMObjectDict,
-) -> None:
-    """Fail if group ids are outside the top level namespace."""
-    group_ids_outside_top_level_namespace = {
-        tree_path
-        for tree_path in dt.flatten_to_tree_paths(raw_objects_tree)
-        if len(tree_path) > 1 and tree_path[-1].endswith("_id")
-    }
-    if group_ids_outside_top_level_namespace:
-        raise ValueError(
-            "Group identifiers must live in the top-level namespace. Got:\n\n"
-            f"{group_ids_outside_top_level_namespace}\n\n"
-            "To fix this error, move the group identifiers to the top-level namespace."
-        )

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -65,6 +65,7 @@ class PolicyEnvironment:
             lambda leaf: _convert_to_policy_function_if_not_ttsim_object(leaf),
             raw_objects_tree,
         )
+        _fail_if_group_ids_are_outside_top_level_namespace(raw_objects_tree)
 
         # Read in parameters and aggregation specs
         self._params = params if params is not None else {}
@@ -81,6 +82,15 @@ class PolicyEnvironment:
     def params(self) -> dict[str, Any]:
         """The parameters of the policy environment."""
         return self._params
+
+    @property
+    def grouping_levels(self) -> tuple[str, ...]:
+        """The grouping levels of the policy environment."""
+        return tuple(
+            name.rsplit("_", 1)[0]
+            for name in self._raw_objects_tree
+            if name.endswith("_id") and name != "p_id"
+        )
 
     def upsert_objects(
         self, tree_to_upsert: NestedTTSIMObjectDict
@@ -113,6 +123,8 @@ class PolicyEnvironment:
             base={**self._raw_objects_tree},
             to_upsert=tree_to_upsert_with_correct_types,
         )
+
+        _fail_if_group_ids_are_outside_top_level_namespace(new_tree)
 
         result = object.__new__(PolicyEnvironment)
         result._raw_objects_tree = new_tree  # noqa: SLF001
@@ -640,3 +652,20 @@ def add_progressionsfaktor(params_dict, parameter):
                 out_dict[key + 1]["rate_linear"] - out_dict[key]["rate_linear"]
             ) / (2 * (upper_thresholds[key] - lower_thresholds[key]))
     return out_dict
+
+
+def _fail_if_group_ids_are_outside_top_level_namespace(
+    raw_objects_tree: NestedTTSIMObjectDict,
+) -> None:
+    """Fail if group ids are outside the top level namespace."""
+    group_ids_outside_top_level_namespace = {
+        tree_path
+        for tree_path in dt.flatten_to_tree_paths(raw_objects_tree)
+        if len(tree_path) > 1 and tree_path[-1].endswith("_id")
+    }
+    if group_ids_outside_top_level_namespace:
+        raise ValueError(
+            "Group identifiers must live in the top-level namespace. Got:\n\n"
+            f"{group_ids_outside_top_level_namespace}\n\n"
+            "To fix this error, move the group identifiers to the top-level namespace."
+        )

--- a/tests/ttsim/mettsim/config.py
+++ b/tests/ttsim/mettsim/config.py
@@ -8,4 +8,4 @@ from pathlib import Path
 
 RESOURCE_DIR = Path(__file__).parent
 
-SUPPORTED_GROUPINGS = ("fam", "sp", "hh")
+SUPPORTED_GROUPINGS = ("fam", "sp", "kin")

--- a/tests/ttsim/mettsim/demographics.py
+++ b/tests/ttsim/mettsim/demographics.py
@@ -2,7 +2,7 @@ from ttsim import AggType, agg_by_group_function
 
 
 @agg_by_group_function(agg_type=AggType.COUNT)
-def number_of_individuals_hh(
-    hh_id: int,  # noqa: ARG001
+def number_of_individuals_kin(
+    kin_id: int,  # noqa: ARG001
 ) -> int:
     return 1

--- a/tests/ttsim/mettsim/inputs.py
+++ b/tests/ttsim/mettsim/inputs.py
@@ -7,8 +7,8 @@ def p_id() -> int:
 
 
 @policy_input()
-def hh_id() -> int:
-    """Household ID."""
+def kin_id() -> int:
+    """Kinstead ID."""
 
 
 @policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)

--- a/tests/ttsim/mettsim/inputs.py
+++ b/tests/ttsim/mettsim/inputs.py
@@ -8,7 +8,7 @@ def p_id() -> int:
 
 @policy_input()
 def hh_id() -> int:
-    """Household id (will delete once fam_id is enough)."""
+    """Household ID."""
 
 
 @policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)

--- a/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
+++ b/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
@@ -41,15 +41,15 @@ def child_eligible(
 @policy_function(vectorization_strategy="not_required")
 def in_same_household_as_recipient(
     p_id: int,
-    hh_id: int,
+    kin_id: int,
     p_id_recipient: int,
 ) -> bool:
     return (
         join(
             foreign_key=p_id_recipient,
             primary_key=p_id,
-            target=hh_id,
+            target=kin_id,
             value_if_foreign_key_is_missing=-1,
         )
-        == hh_id
+        == kin_id
     )

--- a/tests/ttsim/test_combine_functions.py
+++ b/tests/ttsim/test_combine_functions.py
@@ -185,7 +185,6 @@ def test_create_agg_by_group_functions(
         environment=environment,
         data_tree=data_tree,
         targets_tree=targets_tree,
-        groupings=("hh",),
     )
 
 

--- a/tests/ttsim/test_combine_functions.py
+++ b/tests/ttsim/test_combine_functions.py
@@ -40,17 +40,17 @@ def p_id() -> int:
 
 
 @policy_input()
-def hh_id() -> int:
+def kin_id() -> int:
     pass
 
 
-@agg_by_group_function(leaf_name="y_hh", agg_type=AggType.SUM)
-def y_hh(hh_id: int, x: int) -> int:
+@agg_by_group_function(leaf_name="y_kin", agg_type=AggType.SUM)
+def y_kin(kin_id: int, x: int) -> int:
     pass
 
 
-@agg_by_group_function(leaf_name="y_hh", agg_type=AggType.SUM)
-def y_hh_namespaced_input(hh_id: int, inputs__x: int) -> int:
+@agg_by_group_function(leaf_name="y_kin", agg_type=AggType.SUM)
+def y_kin_namespaced_input(kin_id: int, inputs__x: int) -> int:
     pass
 
 
@@ -70,16 +70,16 @@ def some_x(x):
     return x
 
 
-def return_x_hh(x_hh: int) -> int:
-    return x_hh
+def return_x_kin(x_kin: int) -> int:
+    return x_kin
 
 
-def return_y_hh(y_hh: int) -> int:
-    return y_hh
+def return_y_kin(y_kin: int) -> int:
+    return y_kin
 
 
-def return_n1__x_hh(n1__x_hh: int) -> int:
-    return n1__x_hh
+def return_n1__x_kin(n1__x_kin: int) -> int:
+    return n1__x_kin
 
 
 @pytest.mark.parametrize(
@@ -92,84 +92,84 @@ def return_n1__x_hh(n1__x_hh: int) -> int:
         (
             # Aggregations derived from simple function arguments
             {
-                "hh_id": hh_id,
+                "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(leaf_name="f")(return_n1__x_hh),
+                    "f": policy_function(leaf_name="f")(return_n1__x_kin),
                     "x": x,
                 },
             },
             {"n1": {"f": None}},
             {
                 "n1": {"x": pd.Series([1, 1, 1])},
-                "hh_id": pd.Series([0, 0, 0]),
+                "kin_id": pd.Series([0, 0, 0]),
                 "p_id": pd.Series([0, 1, 2]),
             },
         ),
         (
             # Aggregations derived from namespaced function arguments
             {
-                "hh_id": hh_id,
+                "kin_id": kin_id,
                 "p_id": p_id,
-                "n1": {"f": policy_function(leaf_name="f")(return_x_hh), "x": x},
+                "n1": {"f": policy_function(leaf_name="f")(return_x_kin), "x": x},
             },
             {"n1": {"f": None}},
             {
                 "n1": {"x": pd.Series([1, 1, 1])},
-                "hh_id": pd.Series([0, 0, 0]),
+                "kin_id": pd.Series([0, 0, 0]),
                 "p_id": pd.Series([0, 1, 2]),
             },
         ),
         (
             # Aggregations derived from target
             {
-                "hh_id": hh_id,
+                "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
                     "f": policy_function(leaf_name="f")(some_x),
                     "x": x,
                 },
             },
-            {"n1": {"f_hh": None}},
+            {"n1": {"f_kin": None}},
             {
                 "n1": {"x": pd.Series([1, 1, 1])},
-                "hh_id": pd.Series([0, 0, 0]),
+                "kin_id": pd.Series([0, 0, 0]),
                 "p_id": pd.Series([0, 1, 2]),
             },
         ),
         (
             # Explicit aggregation via objects tree with leaf name input
             {
-                "hh_id": hh_id,
+                "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
                     "f": policy_function(leaf_name="f")(some_x),
                     "x": x,
                 },
-                "y_hh": y_hh,
+                "y_kin": y_kin,
             },
             {"n1": {"f": None}},
             {
                 "n1": {"x": pd.Series([1, 1, 1])},
-                "hh_id": pd.Series([0, 0, 0]),
+                "kin_id": pd.Series([0, 0, 0]),
                 "p_id": pd.Series([0, 1, 2]),
             },
         ),
         (
             # Explicit aggregation via objects tree with namespaced input
             {
-                "hh_id": hh_id,
+                "kin_id": kin_id,
                 "p_id": p_id,
                 "n1": {
-                    "f": policy_function(leaf_name="f")(return_y_hh),
-                    "y_hh": y_hh_namespaced_input,
+                    "f": policy_function(leaf_name="f")(return_y_kin),
+                    "y_kin": y_kin_namespaced_input,
                 },
                 "inputs": {"x": x},
             },
             {"n1": {"f": None}},
             {
                 "inputs": {"x": pd.Series([1, 1, 1])},
-                "hh_id": pd.Series([0, 0, 0]),
+                "kin_id": pd.Series([0, 0, 0]),
                 "p_id": pd.Series([0, 1, 2]),
             },
         ),
@@ -212,22 +212,22 @@ def test_fail_if_targets_are_not_among_functions(
     ),
     [
         (
-            {"foo": policy_function(leaf_name="foo")(return_x_hh)},
+            {"foo": policy_function(leaf_name="foo")(return_x_kin)},
             {},
             {"x": pd.Series([1])},
-            ("x_hh"),
+            ("x_kin"),
         ),
         (
-            {"n2__foo": policy_function(leaf_name="foo")(return_n1__x_hh)},
+            {"n2__foo": policy_function(leaf_name="foo")(return_n1__x_kin)},
             {},
             {"n1__x": pd.Series([1])},
-            ("n1__x_hh"),
+            ("n1__x_kin"),
         ),
         (
             {},
-            {"x_hh": None},
+            {"x_kin": None},
             {"x": pd.Series([1])},
-            ("x_hh"),
+            ("x_kin"),
         ),
     ],
 )
@@ -246,6 +246,6 @@ def test_derived_aggregation_functions_are_in_correct_namespace(
         ttsim_functions_with_time_conversions=functions,
         data=data,
         targets=targets,
-        groupings=("hh",),
+        groupings=("kin",),
     )
     assert expected in result

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -15,7 +15,6 @@ from ttsim import (
     agg_by_group_function,
     agg_by_p_id_function,
     compute_taxes_and_transfers,
-    group_creation_function,
     merge_trees,
     policy_function,
     policy_input,
@@ -240,33 +239,15 @@ def test_fail_if_foreign_key_points_to_same_row_if_allowed(mettsim_environment):
     )
 
 
-@pytest.mark.parametrize(
-    "data, functions",
-    [
-        (
-            {
-                "foo_hh": pd.Series([1, 2, 2], name="foo_hh"),
-                "hh_id": pd.Series([1, 1, 2], name="hh_id"),
-            },
-            {},
-        ),
-        (
-            {
-                "foo_fam": pd.Series([1, 2, 2], name="foo_fam"),
-                "fam_id": pd.Series([1, 1, 2], name="fam_id"),
-            },
-            {
-                "fam_id": group_creation_function()(lambda x: x),
-            },
-        ),
-    ],
-)
-def test_fail_if_group_variables_not_constant_within_groups(data, functions):
+def test_fail_if_group_variables_not_constant_within_groups():
+    data = {
+        "foo_kin": pd.Series([1, 2, 2], name="foo_kin"),
+        "kin_id": pd.Series([1, 1, 2], name="kin_id"),
+    }
     with pytest.raises(ValueError):
         _fail_if_group_variables_not_constant_within_groups(
             data=data,
-            functions=functions,
-            groupings=("hh", "fam"),
+            groupings=("kin",),
         )
 
 

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -23,7 +23,6 @@ from ttsim import (
 )
 from ttsim.compute_taxes_and_transfers import (
     _fail_if_foreign_keys_are_invalid_in_data,
-    _fail_if_group_ids_are_outside_top_level_namespace,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_p_id_is_non_unique,
     _get_top_level_namespace,
@@ -638,13 +637,3 @@ def test_get_top_level_namespace(environment, time_units, groupings, expected):
         groupings=groupings,
     )
     assert result == expected
-
-
-def test_fail_if_group_ids_are_outside_top_level_namespace():
-    with pytest.raises(
-        ValueError, match="Group identifiers must live in the top-level namespace. Got:"
-    ):
-        _fail_if_group_ids_are_outside_top_level_namespace(
-            environment=PolicyEnvironment(raw_objects_tree={"n1": {"fam_id": fam_id}}),
-            groupings=("fam",),
-        )

--- a/tests/ttsim/test_data/group_by_ids/2025-01-01/group_by_ids.yaml
+++ b/tests/ttsim/test_data/group_by_ids/2025-01-01/group_by_ids.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_high_income.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_no_children_low_income.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_high_income.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2000-01-01/amount_with_children_low_income.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_high_income.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_no_children_low_income.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_high_income.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_children_low_income.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_many_children.yaml
+++ b/tests/ttsim/test_data/housing_benefits/2025-01-01/amount_with_many_children.yaml
@@ -11,7 +11,7 @@ inputs:
       - 2
       - 3
       - 4
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children_high_wealth.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children_high_wealth.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children_noble_parents.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_no_children_noble_parents.yaml
@@ -8,7 +8,7 @@ inputs:
     p_id:
       - 0
       - 1
-    hh_id:
+    kin_id:
       - 0
       - 0
     p_id_parent_1:

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_children_inputs_need_to_be_converted.yaml
@@ -9,7 +9,7 @@ inputs:
       - 0
       - 1
       - 2
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_many_children.yaml
+++ b/tests/ttsim/test_data/payroll_tax/2025-01-01/amount_with_many_children.yaml
@@ -11,7 +11,7 @@ inputs:
       - 2
       - 3
       - 4
-    hh_id:
+    kin_id:
       - 0
       - 0
       - 0

--- a/tests/ttsim/test_docs.py
+++ b/tests/ttsim/test_docs.py
@@ -4,6 +4,7 @@ import datetime
 import inspect
 
 import pytest
+from mettsim.config import SUPPORTED_GROUPINGS
 
 from _gettsim.config import (
     RESOURCE_DIR,
@@ -11,8 +12,6 @@ from _gettsim.config import (
 from ttsim import PolicyInput
 from ttsim.loader import load_objects_tree_for_date
 from ttsim.shared import remove_group_suffix
-
-SUPPORTED_GROUPINGS = ("hh", "sp", "fam")
 
 
 def _nice_output_list_of_strings(list_of_strings):

--- a/tests/ttsim/test_jax_jit_kindergeld.py
+++ b/tests/ttsim/test_jax_jit_kindergeld.py
@@ -63,7 +63,6 @@ def test_compute_taxes_and_transfers_kindergeld(kindergeld_policy_test):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=(),
         jit=True,
     )
 

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -202,7 +202,7 @@ def test_input_is_recognized_as_potential_group_id():
     environment = set_up_policy_environment(
         resource_dir=RESOURCE_DIR, date="2020-01-01"
     )
-    assert "hh" in environment.grouping_levels
+    assert "kin" in environment.grouping_levels
 
 
 def test_p_id_not_recognized_as_potential_group_id():

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -42,6 +42,11 @@ def return_three():
     return 3
 
 
+@group_creation_function()
+def fam_id() -> int:
+    pass
+
+
 class TestPolicyEnvironment:
     def test_func_exists_in_tree(self):
         function = policy_function(leaf_name="foo")(return_one)
@@ -177,3 +182,31 @@ def test_dont_destroy_group_by_functions():
     }
     environment = PolicyEnvironment(functions_tree)
     assert isinstance(environment.raw_objects_tree["foo"], GroupCreationFunction)
+
+
+def test_creating_environment_fails_when_group_ids_are_outside_top_level_namespace():
+    with pytest.raises(
+        ValueError, match="Group identifiers must live in the top-level namespace. Got:"
+    ):
+        PolicyEnvironment({"n1": {"fam_id": fam_id}})
+
+
+def test_upserting_group_ids_outside_top_level_namespace_fails():
+    with pytest.raises(
+        ValueError, match="Group identifiers must live in the top-level namespace. Got:"
+    ):
+        PolicyEnvironment({}).upsert_objects({"n1": {"fam_id": fam_id}})
+
+
+def test_input_is_recognized_as_potential_group_id():
+    environment = set_up_policy_environment(
+        resource_dir=RESOURCE_DIR, date="2020-01-01"
+    )
+    assert "hh" in environment.grouping_levels
+
+
+def test_p_id_not_recognized_as_potential_group_id():
+    environment = set_up_policy_environment(
+        resource_dir=RESOURCE_DIR, date="2020-01-01"
+    )
+    assert "p" not in environment.grouping_levels

--- a/tests/ttsim/test_rounding.py
+++ b/tests/ttsim/test_rounding.py
@@ -115,7 +115,6 @@ def test_rounding(rounding_spec, input_values, exp_output):
         data_tree=data,
         environment=environment,
         targets_tree={"namespace": {"test_func": None}},
-        groupings=(),
     )
     assert_series_equal(
         pd.Series(calc_result["namespace"]["test_func"]),
@@ -149,7 +148,6 @@ def test_rounding_with_time_conversion():
         data_tree=data,
         environment=environment,
         targets_tree={"test_func_y": None},
-        groupings=(),
     )
     assert_series_equal(
         pd.Series(calc_result["test_func_y"]),
@@ -186,7 +184,6 @@ def test_no_rounding(
         data_tree=data,
         environment=environment,
         targets_tree={"test_func": None},
-        groupings=(),
         rounding=False,
     )
     assert_series_equal(

--- a/tests/ttsim/test_shared.py
+++ b/tests/ttsim/test_shared.py
@@ -191,103 +191,22 @@ def test_partition_tree_by_reference_tree(tree_to_partition, reference_tree, exp
 
 
 @pytest.mark.parametrize(
-    "target_name, group_by_functions, expected",
+    "target_name, expected",
     [
-        (("namespace1__foo"), {}, None),
-        (("namespace1__foo_hh"), {}, "hh_id"),
-        (
-            ("namespace1__foo_hh"),
-            {"namespace1__hh_id": None},
-            "hh_id",
-        ),
-        (
-            ("namespace1__foo_bg"),
-            {"arbeitslosengeld_2__bg_id": None},
-            "arbeitslosengeld_2__bg_id",
-        ),
-        (
-            ("namespace1__foo_eg"),
-            {"grundsicherung__eg_id": None},
-            "grundsicherung__eg_id",
-        ),
-        (
-            ("namespace1__foo_eg"),
-            {"arbeitslosengeld_2__eg_id": None},
-            "arbeitslosengeld_2__eg_id",
-        ),
-        (
-            ("arbeitslosengeld_2__einkommen_eg"),
-            {
-                "arbeitslosengeld_2__eg_id": None,
-                "grundsicherung__eg_id": None,
-            },
-            "arbeitslosengeld_2__eg_id",
-        ),
+        (("namespace1__foo"), None),
+        (("foo_kin"), "kin_id"),
+        (("namespace1__foo_kin"), "kin_id"),
+        (("namespace1__foo_fam"), "fam_id"),
     ],
 )
-def test_get_name_of_group_by_id(target_name, group_by_functions, expected):
+def test_get_name_of_group_by_id(target_name, expected):
     assert (
         get_name_of_group_by_id(
             target_name=target_name,
-            group_by_functions=group_by_functions,
-            groupings=("hh", "bg", "eg"),
+            groupings=("kin", "fam"),
         )
         == expected
     )
-
-
-@pytest.mark.parametrize(
-    "target_name, group_by_functions, expected_error_match",
-    [
-        (
-            ("outermost__foo_bg"),
-            {
-                "outermost__bg_id": None,
-                "outermost__nested__bg_id": None,
-            },
-            (
-                r"Group-by-identifier for target:[\s\S]+"
-                r"\('outermost', 'foo_bg'\)[\s\S]+is ambiguous[\s\S]+"
-                r"Found candidates[\s\S]+"
-                r"\('outermost', 'bg_id'\)[\s\S]+"
-                r"\('outermost', 'nested', 'bg_id'\)"
-            ),
-        ),
-        (
-            ("outermost__foo_bg"),
-            {
-                "outermost__inner1__bg_id": None,
-                "outermost__inner2__bg_id": None,
-            },
-            r"Group-by-identifier for target:[\s\S]+"
-            r"\('outermost', 'foo_bg'\)[\s\S]+is ambiguous[\s\S]+"
-            r"Found candidates[\s\S]+"
-            r"\('outermost', 'inner1', 'bg_id'\)[\s\S]+"
-            r"\('outermost', 'inner2', 'bg_id'\)",
-        ),
-        (
-            ("new_transfer__einkommen_eg"),
-            {
-                "arbeitslosengeld_2__eg_id": None,
-                "grundsicherung__eg_id": None,
-            },
-            r"Group-by-identifier for target:[\s\S]+"
-            r"\('new_transfer', 'einkommen_eg'\)[\s\S]+is ambiguous[\s\S]+"
-            r"Found candidates[\s\S]+"
-            r"\('arbeitslosengeld_2', 'eg_id'\)[\s\S]+"
-            r"\('grundsicherung', 'eg_id'\)",
-        ),
-    ],
-)
-def test_get_name_of_group_by_id_fails(
-    target_name, group_by_functions, expected_error_match
-):
-    with pytest.raises(ValueError, match=expected_error_match):
-        get_name_of_group_by_id(
-            target_name=target_name,
-            group_by_functions=group_by_functions,
-            groupings=("hh", "bg", "eg"),
-        )
 
 
 @pytest.mark.parametrize(
@@ -300,13 +219,13 @@ def test_get_name_of_group_by_id_fails(
         "expected_grouping",
     ),
     [
-        ("foo", ("m", "y"), ["hh"], "foo", None, None),
-        ("foo_m_hh", ("m", "y"), ["hh"], "foo", "m", "hh"),
-        ("foo_y_hh", ("m", "y"), ["hh"], "foo", "y", "hh"),
-        ("foo_m", ("m", "y"), ["hh"], "foo", "m", None),
-        ("foo_y", ("m", "y"), ["hh"], "foo", "y", None),
-        ("foo_hh", ("m", "y"), ["hh"], "foo", None, "hh"),
-        ("foo_hh_bar", ("m", "y"), ["hh"], "foo_hh_bar", None, None),
+        ("foo", ("m", "y"), ["kin"], "foo", None, None),
+        ("foo_m_kin", ("m", "y"), ["kin"], "foo", "m", "kin"),
+        ("foo_y_kin", ("m", "y"), ["kin"], "foo", "y", "kin"),
+        ("foo_m", ("m", "y"), ["kin"], "foo", "m", None),
+        ("foo_y", ("m", "y"), ["kin"], "foo", "y", None),
+        ("foo_kin", ("m", "y"), ["kin"], "foo", None, "kin"),
+        ("foo_kin_bar", ("m", "y"), ["kin"], "foo_kin_bar", None, None),
     ],
 )
 def test_get_re_pattern_for_time_units_and_groupings(
@@ -335,9 +254,9 @@ def test_get_re_pattern_for_time_units_and_groupings(
         "expected_match",
     ),
     [
-        ("foo", ["m", "y"], ["hh"], "foo_m_hh"),
-        ("foo", ["m", "y"], ["hh", "x"], "foo_m"),
-        ("foo", ["m", "y"], ["hh", "x"], "foo_hh"),
+        ("foo", ["m", "y"], ["kin"], "foo_m_kin"),
+        ("foo", ["m", "y"], ["kin", "x"], "foo_m"),
+        ("foo", ["m", "y"], ["kin", "x"], "foo_kin"),
     ],
 )
 def test_get_re_pattern_for_some_base_name(

--- a/tests/ttsim/test_time_conversion.py
+++ b/tests/ttsim/test_time_conversion.py
@@ -258,19 +258,19 @@ class TestCreateFunctionsForTimeUnits:
         ("name", "expected"),
         [
             ("test_y", ["test_m", "test_q", "test_w", "test_d"]),
-            ("test_y_hh", ["test_m_hh", "test_q_hh", "test_w_hh", "test_d_hh"]),
+            ("test_y_kin", ["test_m_kin", "test_q_kin", "test_w_kin", "test_d_kin"]),
             ("test_y_sn", ["test_m_sn", "test_q_sn", "test_w_sn", "test_d_sn"]),
             ("test_q", ["test_y", "test_m", "test_w", "test_d"]),
-            ("test_q_hh", ["test_y_hh", "test_m_hh", "test_w_hh", "test_d_hh"]),
+            ("test_q_kin", ["test_y_kin", "test_m_kin", "test_w_kin", "test_d_kin"]),
             ("test_q_sn", ["test_y_sn", "test_m_sn", "test_w_sn", "test_d_sn"]),
             ("test_m", ["test_y", "test_q", "test_w", "test_d"]),
-            ("test_m_hh", ["test_y_hh", "test_q_hh", "test_w_hh", "test_d_hh"]),
+            ("test_m_kin", ["test_y_kin", "test_q_kin", "test_w_kin", "test_d_kin"]),
             ("test_m_sn", ["test_y_sn", "test_q_sn", "test_w_sn", "test_d_sn"]),
             ("test_w", ["test_y", "test_m", "test_q", "test_d"]),
-            ("test_w_hh", ["test_y_hh", "test_m_hh", "test_q_hh", "test_d_hh"]),
+            ("test_w_kin", ["test_y_kin", "test_m_kin", "test_q_kin", "test_d_kin"]),
             ("test_w_sn", ["test_y_sn", "test_m_sn", "test_q_sn", "test_d_sn"]),
             ("test_d", ["test_y", "test_m", "test_q", "test_w"]),
-            ("test_d_hh", ["test_y_hh", "test_m_hh", "test_q_hh", "test_w_hh"]),
+            ("test_d_kin", ["test_y_kin", "test_m_kin", "test_q_kin", "test_w_kin"]),
             ("test_d_sn", ["test_y_sn", "test_m_sn", "test_q_sn", "test_w_sn"]),
         ],
     )
@@ -280,7 +280,7 @@ class TestCreateFunctionsForTimeUnits:
         time_conversion_functions = create_time_conversion_functions(
             ttsim_objects={name: policy_function(leaf_name=name)(return_one)},
             data={},
-            groupings=("sn", "hh"),
+            groupings=("sn", "kin"),
         )
 
         for expected_name in expected:
@@ -290,7 +290,7 @@ class TestCreateFunctionsForTimeUnits:
         time_conversion_functions = create_time_conversion_functions(
             ttsim_objects={"test1_d": policy_function(leaf_name="test1_d")(return_one)},
             data={"test2_y": None},
-            groupings=("sn", "hh"),
+            groupings=("sn", "kin"),
         )
 
         assert "test1_d" not in time_conversion_functions
@@ -302,7 +302,7 @@ class TestCreateFunctionsForTimeUnits:
         time_conversion_functions = create_time_conversion_functions(
             ttsim_objects={"test_d": policy_function(leaf_name="test_d")(return_one)},
             data={"test_y": None},
-            groupings=("sn", "hh"),
+            groupings=("sn", "kin"),
         )
 
         assert "test_d" in time_conversion_functions

--- a/tests/ttsim/test_visualizations.py
+++ b/tests/ttsim/test_visualizations.py
@@ -120,7 +120,7 @@ def test_plot_dag():
     """Make sure that minimal example doesn't produce an error."""
     plot_dag(
         environment=environment,
-        targets=["erwachsene_alle_rentenbezieher_hh"],
+        targets=["erwachsene_alle_rentenbezieher_kin"],
     )
 
 
@@ -131,7 +131,7 @@ def test_should_fail_if_target_is_missing():
     ):
         plot_dag(
             environment=PolicyEnvironment({}),
-            targets=["erwachsene_alle_rentenbezieher_hh"],
+            targets=["erwachsene_alle_rentenbezieher_kin"],
         )
 
 

--- a/tests/ttsim/utils.py
+++ b/tests/ttsim/utils.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import dags.tree as dt
 import pandas as pd
 import yaml
-from mettsim.config import RESOURCE_DIR, SUPPORTED_GROUPINGS
+from mettsim.config import RESOURCE_DIR
 
 from ttsim import compute_taxes_and_transfers, merge_trees, set_up_policy_environment
 from ttsim.shared import to_datetime
@@ -58,7 +58,6 @@ def execute_test(test: PolicyTest):
         data_tree=test.input_tree,
         environment=environment,
         targets_tree=test.target_structure,
-        groupings=SUPPORTED_GROUPINGS,
     )
 
     flat_result = dt.flatten_to_qual_names(result)


### PR DESCRIPTION
### What problem do you want to solve?

Infer groupings from the objects tree. This needs to be done by looking for names in the top-level namespace that end with "_id". Filtering for `group_creation_functions` does not work because this would miss `hh_id`.

**Changes**

- Removed explicit `groupings` argument from `compute_taxes_and_transfers`
- Added the `grouping_levels` property to the policy environment.
- Moved the `_fail_if_group_ids_are_outside_top_level_namespace` check to the policy environment.