### PR TITLE
Update loader, fixes #830

### DIFF
--- a/src/ttsim/__init__.py
+++ b/src/ttsim/__init__.py
@@ -5,7 +5,6 @@ from ttsim.compute_taxes_and_transfers import (
     FunctionsAndColumnsOverlapWarning,
     compute_taxes_and_transfers,
 )
-from ttsim.loader import ConflictingTimeDependentObjectsError
 from ttsim.piecewise_polynomial import piecewise_polynomial
 from ttsim.plot_dag import plot_dag
 from ttsim.policy_environment import PolicyEnvironment, set_up_policy_environment
@@ -38,7 +37,6 @@ __all__ = [
     "AggByGroupFunction",
     "AggByPIDFunction",
     "AggType",
-    "ConflictingTimeDependentObjectsError",
     "FKType",
     "FunctionsAndColumnsOverlapWarning",
     "GroupCreationFunction",

--- a/src/ttsim/loader.py
+++ b/src/ttsim/loader.py
@@ -94,7 +94,9 @@ def get_active_ttsim_objects_tree_from_module(
     }
 
     return create_tree_from_path_and_value(
-        path=_convert_path_to_tree_path(path=path, root_path=root_path),
+        path=_convert_path_to_tree_path(
+            path=path, root_path=root_path, remove_module=True
+        ),
         value=active_ttsim_objects,
     )
 
@@ -199,7 +201,9 @@ def _load_module(path: Path, root_path: Path) -> ModuleType:
     return module
 
 
-def _convert_path_to_tree_path(path: Path, root_path: Path) -> tuple[str, ...]:
+def _convert_path_to_tree_path(
+    *, path: Path, root_path: Path, remove_module: bool
+) -> tuple[str, ...]:
     """
     Convert the path from the package root to a tree path.
 
@@ -225,5 +229,7 @@ def _convert_path_to_tree_path(path: Path, root_path: Path) -> tuple[str, ...]:
     ("dir")
     """
     parts = path.relative_to(root_path).parts
-
-    return parts[:-1]
+    if remove_module:
+        return parts[:-1]
+    else:
+        return parts

--- a/src/ttsim/loader.py
+++ b/src/ttsim/loader.py
@@ -2,26 +2,22 @@ from __future__ import annotations
 
 import importlib.util
 import inspect
-import itertools
 import sys
 from typing import TYPE_CHECKING
 
-from ttsim.shared import (
-    create_tree_from_path_and_value,
-    merge_trees,
-)
-from ttsim.ttsim_objects import TTSIMFunction, TTSIMObject
+import dags.tree as dt
+
+from ttsim.ttsim_objects import TTSIMObject
 
 if TYPE_CHECKING:
     import datetime
-    from collections.abc import Iterable
     from pathlib import Path
     from types import ModuleType
 
-    from ttsim.typing import NestedTTSIMObjectDict
+    from ttsim.typing import FlatTTSIMObjectDict, NestedTTSIMObjectDict
 
 
-def load_objects_tree_for_date(
+def active_ttsim_objects_tree(
     resource_dir: Path, date: datetime.date
 ) -> NestedTTSIMObjectDict:
     """
@@ -38,27 +34,44 @@ def load_objects_tree_for_date(
     -------
     A tree of active TTSIMObjects.
     """
-    paths_to_objects = _find_python_files_recursively(resource_dir)
 
-    objects_tree: NestedTTSIMObjectDict = {}
+    orig_flat_objects_tree = orig_ttsim_objects_tree(resource_dir)
 
-    for path in paths_to_objects:
-        new_objects_tree = get_active_ttsim_objects_tree_from_module(
-            path=path, date=date, root_path=resource_dir
-        )
+    flat_objects_tree = {
+        (*orig_path[:-2], obj.leaf_name): obj
+        for orig_path, obj in orig_flat_objects_tree.items()
+        if obj.is_active(date)
+    }
 
-        objects_tree = merge_trees(
-            left=objects_tree,
-            right=new_objects_tree,
-        )
-    return objects_tree
+    return dt.unflatten_from_tree_paths(flat_objects_tree)
 
 
-def get_active_ttsim_objects_tree_from_module(
+def orig_ttsim_objects_tree(resource_dir: Path) -> FlatTTSIMObjectDict:
+    """
+    Load the original TTSIMObjects tree from the resource directory.
+
+    "Original" means:
+    - Module names are not removed from the path.
+    - The last path element is the TTSIMObject's original name, not the leaf name.
+
+    Parameters
+    ----------
+    resource_dir:
+        The resource directory to load the TTSIMObjects tree from.
+    """
+    return {
+        k: v
+        for path in _find_modules_recursively(resource_dir)
+        for k, v in _get_orig_ttsim_objects_from_module(
+            path=path, root_path=resource_dir
+        ).items()
+    }
+
+
+def _get_orig_ttsim_objects_from_module(
     path: Path,
     root_path: Path,
-    date: datetime.date,
-) -> dict[str, TTSIMFunction]:
+) -> FlatTTSIMObjectDict:
     """Extract all active PolicyFunctions and GroupByFunctions from a module.
 
     Parameters
@@ -72,105 +85,18 @@ def get_active_ttsim_objects_tree_from_module(
 
     Returns
     -------
-    The tree of active PolicyFunctions and GroupByFunctions.
+    A flat tree of TTSIMObjects.
     """
-    module = _load_module(path, root_path)
-
-    ttsim_objects_orig_names = {
-        name: obj
+    module = _load_module(path=path, root_path=root_path)
+    tree_path = path.relative_to(root_path).parts
+    return {
+        (*tree_path, name): obj
         for name, obj in inspect.getmembers(module)
         if isinstance(obj, TTSIMObject)
     }
 
-    _fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
-        ttsim_objects_orig_names.values(),
-        module_name=root_path / path,
-    )
 
-    active_ttsim_objects = {
-        obj.leaf_name: obj
-        for obj in ttsim_objects_orig_names.values()
-        if obj.is_active(date)
-    }
-
-    return create_tree_from_path_and_value(
-        path=_convert_path_to_tree_path(
-            path=path, root_path=root_path, remove_module=True
-        ),
-        value=active_ttsim_objects,
-    )
-
-
-def _fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
-    ttsim_objects: Iterable[TTSIMObject],
-    module_name: Path,
-) -> None:
-    """Raises an ConflictingTimeDependentObjectsError if multiple objects with the
-    same leaf name are active at the same time.
-
-    Parameters
-    ----------
-    ttsim_objects
-        List of TTSIMObjects to check for conflicts.
-    module_name
-        The name of the module from which the TTSIMObjects are extracted.
-
-    Raises
-    ------
-    ConflictingTimeDependentObjectsError
-        If multiple objects with the same leaf name are active at the same time.
-    """
-    # Create mapping from leaf names to objects.
-    leaf_names_to_objects: dict[str, list[TTSIMObject]] = {}
-    for obj in ttsim_objects:
-        if obj.leaf_name in leaf_names_to_objects:
-            leaf_names_to_objects[obj.leaf_name].append(obj)
-        else:
-            leaf_names_to_objects[obj.leaf_name] = [obj]
-
-    # Check for overlapping start and end dates for time-dependent functions.
-    for leaf_name, objects in leaf_names_to_objects.items():
-        dates_active = [(f.start_date, f.end_date) for f in objects]
-        for (start1, end1), (start2, end2) in itertools.combinations(dates_active, 2):
-            if start1 <= end2 and start2 <= end1:
-                raise ConflictingTimeDependentObjectsError(
-                    affected_ttsim_objects=objects,
-                    leaf_name=leaf_name,
-                    module_name=module_name,
-                    overlap_start=max(start1, start2),
-                    overlap_end=min(end1, end2),
-                )
-
-
-class ConflictingTimeDependentObjectsError(Exception):
-    def __init__(
-        self,
-        affected_ttsim_objects: list[TTSIMObject],
-        leaf_name: str,
-        module_name: Path,
-        overlap_start: datetime.date,
-        overlap_end: datetime.date,
-    ) -> None:
-        self.affected_ttsim_objects = affected_ttsim_objects
-        self.leaf_name = leaf_name
-        self.module_name = module_name
-        self.overlap_start = overlap_start
-        self.overlap_end = overlap_end
-
-    def __str__(self) -> str:
-        overlapping_objects = [
-            obj.__getattribute__("original_function_name", obj.leaf_name)
-            for obj in self.affected_ttsim_objects
-            if obj
-        ]
-        return f"""
-        Functions with leaf name {self.leaf_name} in module {self.module_name} have
-        overlapping start and end dates. The following functions are affected: \n\n
-        {", ".join(overlapping_objects)} \n Overlapping
-        from {self.overlap_start} to {self.overlap_end}."""
-
-
-def _find_python_files_recursively(root_path: Path) -> list[Path]:
+def _find_modules_recursively(root_path: Path) -> list[Path]:
     """
     Find all Python files reachable from the given root path.
 
@@ -199,37 +125,3 @@ def _load_module(path: Path, root_path: Path) -> ModuleType:
     spec.loader.exec_module(module)
 
     return module
-
-
-def _convert_path_to_tree_path(
-    *, path: Path, root_path: Path, remove_module: bool
-) -> tuple[str, ...]:
-    """
-    Convert the path from the package root to a tree path.
-
-    Removes the package root and module name from the path.
-
-    Parameters
-    ----------
-    path:
-        The path to a Python module.
-    root_path:
-        The root path of GETTSIM's taxes and transfers modules.
-
-    Returns
-    -------
-    The tree path, to be used as a key in the functions tree.
-
-    Examples
-    --------
-    >>> _convert_path_to_tree_path(
-    ...     path=RESOURCE_DIR / "de" / "dir" / "functions.py",
-    ...     root_path=RESOURCE_DIR,
-    ... )
-    ("dir")
-    """
-    parts = path.relative_to(root_path).parts
-    if remove_module:
-        return parts[:-1]
-    else:
-        return parts

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -265,7 +265,10 @@ class ConflictingTimeDependentObjectsError(Exception):
 
         have overlapping start and end dates. The following functions are affected:
 
-          {"\n          ".join(overlapping_objects)}
+          {
+            '''
+          '''.join(overlapping_objects)
+        }
 
         Overlap from {self.overlap_start} to {self.overlap_end}."""
 

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import datetime
+import itertools
 from typing import TYPE_CHECKING, Any
 
 import dags.tree as dt
@@ -9,7 +10,7 @@ import numpy
 import optree
 import yaml
 
-from ttsim.loader import load_objects_tree_for_date
+from ttsim.loader import active_ttsim_objects_tree, orig_ttsim_objects_tree
 from ttsim.piecewise_polynomial import (
     check_and_get_thresholds,
     get_piecewise_parameters,
@@ -32,6 +33,7 @@ if TYPE_CHECKING:
 
     from ttsim.typing import (
         DashedISOString,
+        FlatTTSIMObjectDict,
         NestedTTSIMObjectDict,
     )
 
@@ -162,7 +164,10 @@ def set_up_policy_environment(
     # Check policy date for correct format and convert to datetime.date
     date = to_datetime(date)
 
-    functions_tree = load_objects_tree_for_date(resource_dir=resource_dir, date=date)
+    # Will move this line out eventually. Just include in tests, do not run every time.
+    fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
+        orig_ttsim_objects_tree=orig_ttsim_objects_tree(resource_dir)
+    )
 
     params = {}
     if "_gettsim" in resource_dir.name:
@@ -194,9 +199,75 @@ def set_up_policy_environment(
         params = _parse_vorsorgepauschale_rentenv_anteil(date, params)
 
     return PolicyEnvironment(
-        functions_tree,
-        params,
+        raw_objects_tree=active_ttsim_objects_tree(
+            resource_dir=resource_dir, date=date
+        ),
+        params=params,
     )
+
+
+def fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
+    orig_ttsim_objects_tree: FlatTTSIMObjectDict,
+) -> None:
+    """Check overlapping time periods of TTSIMObjects.
+
+    Raises
+    ------
+    ConflictingTimeDependentObjectsError
+        If multiple objects with the same leaf name are active at the same time.
+    """
+
+    # Create mapping from leaf names to objects.
+    checker: dict[tuple[str, ...], list[TTSIMObject]] = {}
+    for orig_path, obj in orig_ttsim_objects_tree.items():
+        path = (*orig_path[:-2], obj.leaf_name)
+        if path in checker:
+            checker[path].append(obj)
+        else:
+            checker[path] = [obj]
+
+    # Check for overlapping start and end dates for time-dependent functions.
+    for path, objects in checker.items():
+        dates_active = [(f.start_date, f.end_date) for f in objects]
+        for (start1, end1), (start2, end2) in itertools.combinations(dates_active, 2):
+            if start1 <= end2 and start2 <= end1:
+                raise ConflictingTimeDependentObjectsError(
+                    affected_ttsim_objects=objects,
+                    path=path,
+                    overlap_start=max(start1, start2),
+                    overlap_end=min(end1, end2),
+                )
+
+
+class ConflictingTimeDependentObjectsError(Exception):
+    def __init__(
+        self,
+        affected_ttsim_objects: list[TTSIMObject],
+        path: tuple[str, ...],
+        overlap_start: datetime.date,
+        overlap_end: datetime.date,
+    ) -> None:
+        self.affected_ttsim_objects = affected_ttsim_objects
+        self.path = path
+        self.overlap_start = overlap_start
+        self.overlap_end = overlap_end
+
+    def __str__(self) -> str:
+        overlapping_objects = [
+            obj.__getattribute__("original_function_name")
+            for obj in self.affected_ttsim_objects
+            if obj
+        ]
+        return f"""
+        Functions with path
+
+          {self.path}
+
+        have overlapping start and end dates. The following functions are affected:
+
+          {"\n          ".join(overlapping_objects)}
+
+        Overlap from {self.overlap_start} to {self.overlap_end}."""
 
 
 def _convert_to_policy_function_if_not_ttsim_object(

--- a/src/ttsim/typing.py
+++ b/src/ttsim/typing.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ttsim.ttsim_objects import PolicyInput, TTSIMFunction, TTSIMObject
 
     NestedTTSIMObjectDict = Mapping[str, TTSIMObject | "NestedTTSIMObjectDict"]
+    FlatTTSIMObjectDict = Mapping[tuple[str, ...], TTSIMObject]
     QualNameTTSIMObjectDict = Mapping[str, TTSIMObject]
 
     # Specialise from dags' GenericCallable types to GETTSIM's functions.

--- a/tests/ttsim/test_dates_active.py
+++ b/tests/ttsim/test_dates_active.py
@@ -134,6 +134,7 @@ def identity(x):
 @pytest.mark.parametrize(
     "orig_ttsim_objects_tree",
     [
+        # Same global module, no overlapping periods.
         {
             ("a",): policy_function(
                 start_date="2023-01-01",
@@ -146,6 +147,7 @@ def identity(x):
                 leaf_name="f",
             )(identity),
         },
+        # Same submodule, no overlapping periods.
         {
             ("c", "a"): policy_function(
                 start_date="2023-01-01",
@@ -153,6 +155,30 @@ def identity(x):
                 leaf_name="f",
             )(identity),
             ("c", "b"): policy_function(
+                start_date="2023-01-01",
+                end_date="2023-02-28",
+                leaf_name="g",
+            )(identity),
+        },
+        # Different modules, no overlapping periods.
+        {
+            ("c", "f"): policy_function(
+                start_date="2023-01-01",
+                end_date="2023-01-31",
+            )(identity),
+            ("d", "f"): policy_function(
+                start_date="2023-02-01",
+                end_date="2023-02-28",
+            )(identity),
+        },
+        # Different paths, overlapping periods.
+        {
+            ("x", "c", "a"): policy_function(
+                start_date="2023-01-01",
+                end_date="2023-01-31",
+                leaf_name="f",
+            )(identity),
+            ("y", "c", "b"): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-02-28",
                 leaf_name="g",
@@ -169,6 +195,7 @@ def test_dates_active_no_conflicts(orig_ttsim_objects_tree):
 @pytest.mark.parametrize(
     "orig_ttsim_objects_tree",
     [
+        # Exact overlap.
         {
             ("a",): policy_function(
                 start_date="2023-01-01",
@@ -181,18 +208,20 @@ def test_dates_active_no_conflicts(orig_ttsim_objects_tree):
                 leaf_name="f",
             )(identity),
         },
+        # Active period for "a" is subset of "b".
         {
-            ("c", "a"): policy_function(
+            ("a"): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-            ("c", "b"): policy_function(
+            ("b"): policy_function(
                 start_date="2021-01-02",
                 end_date="2023-02-01",
                 leaf_name="f",
             )(identity),
         },
+        # Some overlap.
         {
             ("a",): policy_function(
                 start_date="2023-01-02",
@@ -203,6 +232,30 @@ def test_dates_active_no_conflicts(orig_ttsim_objects_tree):
                 start_date="2022-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
+            )(identity),
+        },
+        # Same as before, but defined in different modules.
+        {
+            ("c", "a"): policy_function(
+                start_date="2023-01-02",
+                end_date="2023-02-01",
+                leaf_name="f",
+            )(identity),
+            ("d", "b"): policy_function(
+                start_date="2022-01-01",
+                end_date="2023-01-31",
+                leaf_name="f",
+            )(identity),
+        },
+        # Same as before, but defined in different modules without leaf name.
+        {
+            ("c", "f"): policy_function(
+                start_date="2023-01-02",
+                end_date="2023-02-01",
+            )(identity),
+            ("d", "f"): policy_function(
+                start_date="2022-01-01",
+                end_date="2023-01-31",
             )(identity),
         },
     ],

--- a/tests/ttsim/test_dates_active.py
+++ b/tests/ttsim/test_dates_active.py
@@ -1,11 +1,18 @@
+from __future__ import annotations
+
 import datetime
+from typing import TYPE_CHECKING
 
 import pytest
 
-from ttsim import ConflictingTimeDependentObjectsError, policy_function
-from ttsim.loader import _fail_if_multiple_ttsim_objects_are_active_at_the_same_time
+from ttsim import policy_function
+from ttsim.policy_environment import (
+    ConflictingTimeDependentObjectsError,
+    fail_if_multiple_ttsim_objects_are_active_at_the_same_time,
+)
 
-# Start date -----------------------------------------------
+if TYPE_CHECKING:
+    from ttsim.typing import FlatTTSIMObjectDict
 
 
 @pytest.mark.parametrize(
@@ -125,83 +132,83 @@ def identity(x):
 
 
 @pytest.mark.parametrize(
-    "functions",
+    "orig_ttsim_objects_tree",
     [
-        [
-            policy_function(
+        {
+            ("a",): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-            policy_function(
+            ("b",): policy_function(
                 start_date="2023-02-01",
                 end_date="2023-02-28",
                 leaf_name="f",
             )(identity),
-        ],
-        [
-            policy_function(
+        },
+        {
+            ("c", "a"): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-            policy_function(
+            ("c", "b"): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-02-28",
                 leaf_name="g",
             )(identity),
-        ],
+        },
     ],
 )
-def test_dates_active_no_conflicts(functions):
-    _fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
-        ttsim_objects=functions, module_name=""
+def test_dates_active_no_conflicts(orig_ttsim_objects_tree):
+    fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
+        orig_ttsim_objects_tree=orig_ttsim_objects_tree
     )
 
 
 @pytest.mark.parametrize(
-    "functions",
+    "orig_ttsim_objects_tree",
     [
-        [
-            policy_function(
+        {
+            ("a",): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-            policy_function(
+            ("b",): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-        ],
-        [
-            policy_function(
+        },
+        {
+            ("c", "a"): policy_function(
                 start_date="2023-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-            policy_function(
+            ("c", "b"): policy_function(
                 start_date="2021-01-02",
                 end_date="2023-02-01",
                 leaf_name="f",
             )(identity),
-        ],
-        [
-            policy_function(
+        },
+        {
+            ("a",): policy_function(
                 start_date="2023-01-02",
                 end_date="2023-02-01",
                 leaf_name="f",
             )(identity),
-            policy_function(
+            ("b",): policy_function(
                 start_date="2022-01-01",
                 end_date="2023-01-31",
                 leaf_name="f",
             )(identity),
-        ],
+        },
     ],
 )
-def test_dates_active_with_conflicts(functions):
+def test_dates_active_with_conflicts(orig_ttsim_objects_tree: FlatTTSIMObjectDict):
     with pytest.raises(ConflictingTimeDependentObjectsError):
-        _fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
-            ttsim_objects=functions, module_name=""
+        fail_if_multiple_ttsim_objects_are_active_at_the_same_time(
+            orig_ttsim_objects_tree=orig_ttsim_objects_tree
         )

--- a/tests/ttsim/test_docs.py
+++ b/tests/ttsim/test_docs.py
@@ -9,7 +9,7 @@ from _gettsim.config import (
     RESOURCE_DIR,
 )
 from ttsim import PolicyInput
-from ttsim.loader import load_objects_tree_for_date
+from ttsim.policy_environment import active_ttsim_objects_tree
 from ttsim.shared import remove_group_suffix
 
 SUPPORTED_GROUPINGS = ("hh", "sp", "fam")
@@ -35,7 +35,7 @@ def all_function_names():
 def time_indep_function_names(all_function_names):
     time_dependent_functions = {}
     for year in range(1990, 2023):
-        year_functions = load_objects_tree_for_date(
+        year_functions = active_ttsim_objects_tree(
             resource_dir=RESOURCE_DIR,
             date=datetime.date(year=year, month=1, day=1),
         )

--- a/tests/ttsim/test_loader.py
+++ b/tests/ttsim/test_loader.py
@@ -62,21 +62,30 @@ def test_vectorize_func(vectorized_function: Callable) -> None:
     (
         "path",
         "root_path",
+        "remove_module",
         "expected_tree_path",
     ),
     [
         (
             RESOURCE_DIR / "payroll_tax" / "child_tax_credit" / "child_tax_credit.py",
             RESOURCE_DIR,
+            True,
             ("payroll_tax", "child_tax_credit"),
         ),
-        (RESOURCE_DIR / "foo" / "bar.py", RESOURCE_DIR, ("foo",)),
-        (RESOURCE_DIR / "foo.py", RESOURCE_DIR, tuple()),  # noqa: C408
+        (RESOURCE_DIR / "foo" / "bar.py", RESOURCE_DIR, True, ("foo",)),
+        (RESOURCE_DIR / "foo" / "bar.py", RESOURCE_DIR, False, ("foo", "bar.py")),
+        (RESOURCE_DIR / "foo.py", RESOURCE_DIR, True, tuple()),  # noqa: C408
     ],
 )
 def test_convert_path_to_tree_path(
-    path: Path, root_path: Path, expected_tree_path: tuple[str, ...]
+    path: Path,
+    root_path: Path,
+    remove_module: bool,
+    expected_tree_path: tuple[str, ...],
 ) -> None:
     assert (
-        _convert_path_to_tree_path(path=path, root_path=root_path) == expected_tree_path
+        _convert_path_to_tree_path(
+            path=path, root_path=root_path, remove_module=remove_module
+        )
+        == expected_tree_path
     )

--- a/tests/ttsim/test_loader.py
+++ b/tests/ttsim/test_loader.py
@@ -8,15 +8,13 @@ from mettsim.config import RESOURCE_DIR
 
 from ttsim import policy_function
 from ttsim.loader import (
-    _convert_path_to_tree_path,
-    _find_python_files_recursively,
+    _find_modules_recursively,
     _load_module,
 )
 from ttsim.ttsim_objects import _vectorize_func
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 
 def test_load_path():
@@ -29,7 +27,7 @@ def test_load_path():
 def test_dont_load_init_py():
     """Don't load __init__.py files as sources for PolicyFunctions and
     AggregationSpecs."""
-    all_files = _find_python_files_recursively(RESOURCE_DIR)
+    all_files = _find_modules_recursively(RESOURCE_DIR)
     assert "__init__.py" not in [file.name for file in all_files]
 
 
@@ -55,37 +53,4 @@ def already_vectorized_func(x: numpy.ndarray) -> numpy.ndarray:
 def test_vectorize_func(vectorized_function: Callable) -> None:
     assert numpy.array_equal(
         vectorized_function(numpy.array([-1, 0, 2, 3])), numpy.array([0, 0, 4, 6])
-    )
-
-
-@pytest.mark.parametrize(
-    (
-        "path",
-        "root_path",
-        "remove_module",
-        "expected_tree_path",
-    ),
-    [
-        (
-            RESOURCE_DIR / "payroll_tax" / "child_tax_credit" / "child_tax_credit.py",
-            RESOURCE_DIR,
-            True,
-            ("payroll_tax", "child_tax_credit"),
-        ),
-        (RESOURCE_DIR / "foo" / "bar.py", RESOURCE_DIR, True, ("foo",)),
-        (RESOURCE_DIR / "foo" / "bar.py", RESOURCE_DIR, False, ("foo", "bar.py")),
-        (RESOURCE_DIR / "foo.py", RESOURCE_DIR, True, tuple()),  # noqa: C408
-    ],
-)
-def test_convert_path_to_tree_path(
-    path: Path,
-    root_path: Path,
-    remove_module: bool,
-    expected_tree_path: tuple[str, ...],
-) -> None:
-    assert (
-        _convert_path_to_tree_path(
-            path=path, root_path=root_path, remove_module=remove_module
-        )
-        == expected_tree_path
     )

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -21,7 +21,7 @@ from ttsim import (
 from ttsim.policy_environment import (
     _fail_if_name_of_last_branch_element_not_leaf_name_of_function,
     _load_parameter_group_from_yaml,
-    load_objects_tree_for_date,
+    active_ttsim_objects_tree,
 )
 
 if TYPE_CHECKING:
@@ -145,10 +145,10 @@ def test_load_functions_tree_for_date(
     function_name_last_day: str,
     function_name_next_day: str,
 ):
-    functions_last_day = load_objects_tree_for_date(
+    functions_last_day = active_ttsim_objects_tree(
         resource_dir=RESOURCE_DIR, date=last_day
     )
-    functions_next_day = load_objects_tree_for_date(
+    functions_next_day = active_ttsim_objects_tree(
         resource_dir=RESOURCE_DIR, date=last_day + timedelta(days=1)
     )
 

--- a/tests/ttsim/test_vectorization.py
+++ b/tests/ttsim/test_vectorization.py
@@ -16,7 +16,7 @@ if IS_JAX_INSTALLED:
 from numpy.testing import assert_array_equal
 
 from ttsim import GroupCreationFunction, PolicyInput, policy_function
-from ttsim.loader import load_objects_tree_for_date
+from ttsim.policy_environment import active_ttsim_objects_tree
 from ttsim.vectorization import (
     TranslateToVectorizableError,
     _is_lambda_function,
@@ -374,7 +374,7 @@ for year in range(1990, 2023):
         [
             pf.function
             for pf in dt.flatten_to_tree_paths(
-                load_objects_tree_for_date(
+                active_ttsim_objects_tree(
                     resource_dir=Path(__file__).parent / "mettsim",
                     date=datetime.date(year=year, month=1, day=1),
                 )


### PR DESCRIPTION
Update the loader so we first get all objects including module names and original function names. 

Then do checks based on that and filter for active objects in policy environment.