### PR TITLE
Make unit and reference period required

### DIFF
--- a/src/_gettsim/arbeitslosengeld_2/freibeträge_vermögen.py
+++ b/src/_gettsim/arbeitslosengeld_2/freibeträge_vermögen.py
@@ -170,7 +170,8 @@ def freibetrag_vermögen_bg_bis_2022(
     """
     out = (
         grundfreibetrag_vermögen_bg
-        + anzahl_kinder_bis_17_bg * arbeitsl_geld_2_params["vermögensfreibetrag_kind"]
+        + anzahl_kinder_bis_17_bg
+        * arbeitsl_geld_2_params["vermögensgrundfreibetrag_je_kind"]
         + anzahl_personen_bg * arbeitsl_geld_2_params["vermögensfreibetrag_austattung"]
     )
     return out

--- a/src/_gettsim/einkommensteuer/abzüge/altersfreibetrag.py
+++ b/src/_gettsim/einkommensteuer/abzüge/altersfreibetrag.py
@@ -43,7 +43,7 @@ def altersfreibetrag_y_bis_2004(
     )
     if alter > altersgrenze:
         out = min(
-            eink_st_abzuege_params["altersentlastung_quote"]
+            eink_st_abzuege_params["altersentlastungsquote"]
             * (
                 einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y
                 + weiteres_einkommen
@@ -120,7 +120,7 @@ def altersfreibetrag_y_ab_2005(
         + einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_y,
         0.0,
     )
-    out_quote = eink_st_abzuege_params["altersentlastung_quote"][selected_bin] * (
+    out_quote = eink_st_abzuege_params["altersentlastungsquote"][selected_bin] * (
         einkommen_lohn + weiteres_einkommen
     )
 

--- a/src/_gettsim/parameters/abgelt_st.yaml
+++ b/src/_gettsim/parameters/abgelt_st.yaml
@@ -7,6 +7,7 @@ satz:
     de: §32d (1) EStG
     en: §32d (1) EStG
   unit: Share
+  reference_period: null
   type: scalar
   2009-01-01:
     scalar: 0.25

--- a/src/_gettsim/parameters/arbeitsl_geld.yaml
+++ b/src/_gettsim/parameters/arbeitsl_geld.yaml
@@ -26,6 +26,7 @@ sozialversicherungspauschale:
       Elterngeld gibt es eine ähnliche Größe.
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   1984-01-01:
     scalar: 0.1727
@@ -98,6 +99,7 @@ satz:
       Kinder im Sinne des EStG.
     en: null
   unit: Share
+  reference_period: null
   type: dict
   1998-08-01:
     allgemein: 0.6
@@ -140,6 +142,7 @@ anspruchsdauer_nach_alter:
       The length of ALG 1 eligibility depends on age and on how many months a
       person was subject to compulsory insurance
   unit: Months
+  reference_period: null
   type: piecewise_constant
   1997-03-24:
     0:
@@ -172,6 +175,7 @@ anspruchsdauer_nach_versicherungspflichtigen_monaten:
       The length of ALG 1 eligibility depends on age and on how many months a
       person was subject to compulsory insurance
   unit: Months
+  reference_period: null
   type: piecewise_constant
   1997-03-24:
     0:

--- a/src/_gettsim/parameters/arbeitsl_geld_2.yaml
+++ b/src/_gettsim/parameters/arbeitsl_geld_2.yaml
@@ -14,8 +14,9 @@ parameter_anrechnungsfreies_einkommen_ohne_kinder_in_bg:
       in § 11 SGB II, s. § 67 SGB II. Seit 01.04.2011 § 11b (2) SGB II (neugefasst durch
       B. v. 13.05.2011 BGBl. I S. 850. Artikel 2 G. v. 24.03.2011 BGBl. I S. 453).
     en: null
-  type: piecewise_linear
+  unit: Euros
   reference_period: Month
+  type: piecewise_linear
   2005-01-01:
     reference: Artikel 1. G. v. 24.12.2003 BGBl. I S. 2954.
     0:
@@ -108,6 +109,8 @@ parameter_anrechnungsfreies_einkommen_mit_kindern_in_bg:
       24.03.2011 BGBl. I S. 453). Ersetzt Parameter in
       parameter_anrechnungsfreies_einkommen_ohne_kinder_in_bg, falls nicht vorhanden
     en: null
+  unit: Euros
+  reference_period: Month
   type: require_converter
   2005-10-01:
     reference: Artikel 1 G. v. 14.08.2005 BGBl. I S. 2407.
@@ -122,16 +125,16 @@ parameter_anrechnungsfreies_einkommen_mit_kindern_in_bg:
       upper_threshold: 1500
 regelsatz_anteilsbasiert:
   name:
-    de: Regelsatz
-    en: Standard rate
+    de: Berechnungsgrundlagen für den Regelsatz
+    en: Calculation basis for the standard rate
   description:
     de: >-
-      § 20 V SGB II. Für 2005 bis 2010 siehe Bekanntmachungen zu § 20.
+      § 20 V SGB II, siehe Bekanntmachungen zu § 20.
     en: >-
-      § 20 V SGB II. Für 2005 bis 2010 see regulations for § 20.
-  unit: Euros
-  type: require_converter
+      § 20 V SGB II, see regulations for § 20.
+  unit: null
   reference_period: Month
+  type: require_converter
   2005-01-01:
     basissatz: 338
     anteil_vom_basissatz_bei_zwei_erwachsenen: 0.9
@@ -226,8 +229,8 @@ regelsatz_nach_regelbedarfsstufen:
       5: Older children
       6: Youngest children
   unit: Euros
-  type: require_converter
   reference_period: Month
+  type: require_converter
   2011-01-01:
     1: 364
     2: 328
@@ -483,8 +486,8 @@ kindersofortzuschlag:
       or social benefits (Regelbedarfsstufen 3, 4, 5, 6) receive an instant surcharge
       of 20 Euro.
   unit: Euros
-  type: scalar
   reference_period: Month
+  type: scalar
   2022-07-01:
     value: 20
   2025-01-01:
@@ -509,8 +512,8 @@ anteil_mehrbedarf_alleinerziehend:
     de: § 21 (3) Nr. 1 SGB II.
     en: null
   unit: Share
-  type: dict
   reference_period: Month
+  type: dict
   2005-01-01:
     min_1_kind: 0.12
     kind_bis_6_oder_mehrere_bis_15: 0.36
@@ -526,6 +529,7 @@ obergrenze_vermögensgrundfreibetrag:
       wurden.
     en: Differs by birth year.
   unit: Euros
+  reference_period: null
   type: dict
   2005-01-01:
     1947: 33800
@@ -556,6 +560,7 @@ vermögensgrundfreibetrag_je_lebensjahr:
     de: § 12 (2) Satz 1 Nr. 1 SGB II.  Gestaffelt nach Geburtsjahr
     en: Differs by year of birth.
   unit: Euros
+  reference_period: null
   type: dict
   2005-01-01:
     1947: 520
@@ -585,6 +590,7 @@ schonvermögen_bürgergeld:
       the first person in a needs-based community and 15,000 Euro for each additional
       person.
   unit: Euros
+  reference_period: null
   type: dict
   2023-01-01:
     während_karenzzeit: 40000
@@ -599,6 +605,7 @@ vermögensfreibetrag_austattung:
     de: § 12 (2) Satz 1 Nr. 4 SGB II.
     en: null
   unit: Euros
+  reference_period: null
   type: scalar
   2005-01-01:
     value: 750
@@ -606,14 +613,15 @@ vermögensfreibetrag_austattung:
   2023-01-01:
     reference: G. v. 20.12.2022 BGBl. I S. 2328.
     note: Ceased to exist with Bürgergeld-Gesetz
-vermögensfreibetrag_kind:
+vermögensgrundfreibetrag_je_kind:
   name:
     de: Vermögensgrundfreibetrag je Kind
-    en: Allowance for furniture
+    en: Wealth exemption per child
   description:
     de: § 12 (2) Satz 1 Nr. 1 SGB II.
     en: null
   unit: Euros
+  reference_period: null
   type: scalar
   2005-01-01:
     value: 4100
@@ -635,8 +643,8 @@ abzugsfähige_pauschalen:
       § 3 Alg II-V. Seit 01.01.2008 in § 6 Alg II-V.
     en: null
   unit: Euros
-  type: dict
   reference_period: Month
+  type: dict
   2005-01-01:
     versicherung: 30
     werbung: 15.33
@@ -657,13 +665,13 @@ mietobergrenze_pro_qm:
       eligible for ALG2. This limit is not specifically laid down in the law, but is a
       rule of thumb used by the employment agencies.
   unit: Euros / Square Meter
-  type: dict
   reference_period: Month
+  type: dict
   1984-01-01:
     max: 10
 berechtigte_wohnfläche_miete:
   name:
-    de: Berechtigte Miet-Wohnfläche für ALG2-Empfänger*innen
+    de: Berechtigte Mietwohnfläche für ALG2-Empfänger*innen
     en: Living rental space eligible for ALG2-recipients
   description:
     de: >-
@@ -673,6 +681,7 @@ berechtigte_wohnfläche_miete:
       A rental apartment may be 45 square meters for a single person (+15 for each
       additional person).
   unit: Square Meters
+  reference_period: null
   type: dict
   1984-01-01:
     single: 45
@@ -689,6 +698,7 @@ berechtigte_wohnfläche_eigentum:
       After 2023, this upper limit only applies to owner-occupied homes. Condominiums
       may only be up to 130 square meters in size.
   unit: Square Meters
+  reference_period: null
   type: require_converter
   1984-01-01:
     1: 80

--- a/src/_gettsim/parameters/arbeitslosenversicherung.yaml
+++ b/src/_gettsim/parameters/arbeitslosenversicherung.yaml
@@ -7,6 +7,7 @@ beitragssatz:
     de: Arbeitnehmerbeitragssatz zur Arbeitslosenversicherung
     en: Employees' contribution rate to unemployment insurance.
   unit: Share
+  reference_period: null
   type: scalar
   access_different_date: jahresanfang
   1984-01-01:

--- a/src/_gettsim/parameters/eink_st.yaml
+++ b/src/_gettsim/parameters/eink_st.yaml
@@ -13,6 +13,8 @@ parameter_einkommensteuertarif:
       §32a EStG
       The quadratic rate is calculated by gettsim with the formula of the
       Progressionsfaktor. For details see the docstring of add_progressionsfaktor.
+  unit: null
+  reference_period: null
   type: piecewise_quadratic
   2002-01-01:
     0:
@@ -277,6 +279,8 @@ parameter_ertragsanteil_an_rente:
       Diese Funktion ist hier ab 2002 angegeben. Vor 2002 das Steuersystem ist nicht
       implementiert.
     en: null
+  unit: null
+  reference_period: null
   type: piecewise_linear
   #   type: require_converter
   2002-01-01:

--- a/src/_gettsim/parameters/eink_st_abzuege.yaml
+++ b/src/_gettsim/parameters/eink_st_abzuege.yaml
@@ -10,8 +10,8 @@ parameter_kinderfreibetrag:
       veranlagte Paare. §32 (6) EStG.
     en: null
   unit: Euros
-  type: require_converter
   reference_period: Year
+  type: require_converter
   1983-01-01:
     sächliches_existenzminimum: 110
     reference: Art. 1 G. v. 23.12.1982 BGBl. I S. 1857.
@@ -117,8 +117,8 @@ vorsorgeaufwendungen_regime_bis_2004:
       gekürzt bei abhängig Beschäftigten (vereinfacht).
     en: null
   unit: Euros
-  type: require_converter
   reference_period: Year
+  type: require_converter
   1985-01-01:
     vorwegabzug: 1534
     grundhöchstbetrag: 1196
@@ -178,8 +178,8 @@ werbungskostenpauschale:
     de: § 9a Nr. 1a) EStG
     en: This is the minimum amount deducted from any employment income.
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   1975-01-01:
     value: 288
     note: 564 DM
@@ -206,8 +206,8 @@ sonderausgabenpauschbetrag:
     de: § 10c EStG
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   1984-01-01:
     single: 138
   1988-01-01:
@@ -227,8 +227,8 @@ sparerfreibetrag:
       gemeinsam veranlagte Paare.
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   1975-01-01:
     value: 153
     note: 300 DM.
@@ -260,8 +260,8 @@ sparer_werbungskostenpauschbetrag:
     de: § 9a EStG
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   1975-01-01:
     value: 51
     note: 100 DM.
@@ -279,8 +279,8 @@ sparerpauschbetrag:
       gemeinsam veranlagte Paare.
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2009-01-01:
     value: 801
     reference: Art. 1 G. v. 14.08.2007 BGBl. I S. 1912
@@ -305,8 +305,8 @@ maximaler_altersentlastungsbetrag:
       amount is deducted. Since 2005, this amount additionally depends on the birth
       year.
   unit: Euros
-  type: require_converter
   reference_period: Year
+  type: require_converter
   1984-01-01:
     value: 1534
   1989-01-01:
@@ -351,7 +351,7 @@ maximaler_altersentlastungsbetrag:
     1973: 76
     1974: 38
     1975: 0
-altersentlastung_quote:
+altersentlastungsquote:
   name:
     de: Anteil des Altersentlastungsbetrags
     en: Income share deducted for older employees.
@@ -365,6 +365,7 @@ altersentlastung_quote:
       If someone receives employment income above the age of 64, this share of income is
       deducted. Since 2005, this share additionally depends on the birth year.
   unit: Share
+  reference_period: null
   type: require_converter
   1984-01-01:
     value: 0.4
@@ -421,6 +422,7 @@ altersentlastungsbetrag_altersgrenze:
       The old-age relief amount is granted to a taxpayer who, before the start of the
       calendar year in which he received his income, had reached the age of 64.
   unit: Years
+  reference_period: null
   type: require_converter
   1984-01-01:
     value: 64
@@ -443,6 +445,7 @@ einführungsfaktor:
       100% are reached in 2025. Deviating from this plan, the deductible contributions
       were set to 100% already in 2023.
   unit: null
+  reference_period: null
   # type: require_converter
   type: piecewise_linear
   2005-01-01:
@@ -481,8 +484,8 @@ alleinerziehendenfreibetrag:
     de: § 24b (1) EStG. vor 2004 "Haushaltsfreibetrag", § 32 (7) EStG
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   1984-01-01:
     value: 2154
   1986-01-01:
@@ -514,8 +517,8 @@ alleinerziehendenfreibetrag_zusatz:
       dem 2. Kind.
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2015-01-01:
     value: 240
     reference: Art. 1 G. vs. 16.07.2015 BGBl. I S.1202
@@ -529,8 +532,8 @@ maximalbetrag_sonstige_vorsorgeaufwendungen:
     de: §10 Abs. 4 S.1 EStG
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2005-01-01:
     value: 1500
     reference: Art. 1 G. v. 05.07.2004 BGBl. I S.1427
@@ -545,8 +548,8 @@ maximalbetrag_altersvorsorgeaufwendungen:
     de: §10 (3) EStG, Anlage 2 SGB VI
     en: null
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2005-01-01:
     value: 20000
     note: Art. 1 G. v. 05.07.2004 BGBl. I S.1427
@@ -589,6 +592,7 @@ minderungsanteil_vorsorgeaufwendungen_für_krankenversicherungsbeiträge:
     de: §10 (3) a) S.4 EStG
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2009-07-23:
     value: 0.04
@@ -601,8 +605,8 @@ behindertenpauschbetrag:
     de: § 33b (3) EStG.
     en: null
   unit: Euros
-  type: dict
   reference_period: Year
+  type: dict
   1975-01-01:
     reference: G. v. 05.08.1974 BGBl. I S. 1769.
     0: 0
@@ -650,6 +654,7 @@ anteil_absetzbare_kinderbetreuungskosten:
     de: §10 (1) Nr. 5 EStG
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2012-01-01:
     value: 0.6666666
@@ -685,6 +690,7 @@ anteil_absetzbare_rentenversicherungskosten:
       rises between 2005 and 2025 by 4 percentage points annually. In 2023, it was
       prematurely set to 100 percent.
   unit: Share
+  reference_period: null
   # type: require_converter
   type: piecewise_linear
   2005-01-01:
@@ -734,6 +740,7 @@ vorsorgepauschale_mindestanteil:
       Minimum share of minimum contributions to health care and care insurance deducted
       from Mindestvorsorgepauschale
   unit: Share
+  reference_period: null
   type: scalar
   2009-07-23:
     value: 0.12

--- a/src/_gettsim/parameters/elterngeld.yaml
+++ b/src/_gettsim/parameters/elterngeld.yaml
@@ -9,6 +9,7 @@ satz:
       Faktor bei der ElG-Berechung, 2. Stufe.
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2007-01-01:
     scalar: 0.67
@@ -83,6 +84,7 @@ prozent_korrektur:
     de: § 2 (2) BEEG
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2007-01-01:
     scalar: 0.001
@@ -95,6 +97,7 @@ prozent_minimum:
     de: § 2 (2) BEEG
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2007-01-01:
     scalar: 0.67
@@ -130,8 +133,9 @@ geschwisterbonus_altersgrenzen:
       § 2a BEEG
       If there are two children under the age of 3 or more than two under the age of 6
       living in the household, Elterngeld increases.
-  type: dict
   unit: Years
+  reference_period: null
+  type: dict
   2007-01-01:
     3: 2
     6: 3
@@ -143,6 +147,7 @@ geschwisterbonus_aufschlag:
     de: § 2a (1) BEEG. Früher § 2 (4) BEEG
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2007-01-01:
     scalar: 0.1
@@ -181,6 +186,7 @@ sozialversicherungspauschale:
     de: §2f BEEG. Vor 2012 waren es die eigentlichen Pflichtbeiträge.
     en: null
   unit: Share
+  reference_period: null
   type: scalar
   2012-09-18:
     scalar: 0.21
@@ -196,8 +202,9 @@ max_bezugsmonate:
       § 4 (3) BEEG
       Basismonate plus "Partnermonate" bei gleichzeitiger Inanspruchnahme von Elterngeld
       bei Paaren. Basismonate bei Alleinerziehenden.
-  type: dict
   unit: Months
+  reference_period: null
+  type: dict
   2007-01-01:
     basismonate: 12
     partnermonate: 2
@@ -215,6 +222,7 @@ max_zu_versteuerndes_einkommen_vorjahr_nach_alleinerziehendenstatus:
       Maximum taxable income in the year before the birth of the child. Income above
       this threshold disqualifies the parent from receiving Elterngeld.
   unit: Euros
+  reference_period: null
   type: dict
   2011-01-01:
     alleinerziehend: 250000.0
@@ -240,6 +248,7 @@ max_zu_versteuerndes_einkommen_vorjahr_pauschal:
       Maximum taxable income in the year before the birth of the child. Income above
       this threshold disqualifies the parent from receiving Elterngeld.
   unit: Euros
+  reference_period: null
   type: scalar
   2024-04-01:
     scalar: 200000.0

--- a/src/_gettsim/parameters/erwerbsm_rente.yaml
+++ b/src/_gettsim/parameters/erwerbsm_rente.yaml
@@ -17,6 +17,7 @@ parameter_altersgrenze_abschlagsfrei:
       From then on gradual increase until 65.
       https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/295-erwerbsminderungsrente-und-rentenabschlaege.html
   unit: Years
+  reference_period: null
   type: scalar
   2001-01-01:
     scalar: 63
@@ -72,6 +73,7 @@ parameter_altersgrenze_langjährig_versicherte_abschlagsfrei:
       without deductions under certain time conditions.
       These conditions are defined in § 77 4 SGB VI.
   unit: Years
+  reference_period: null
   type: scalar
   2001-01-01:
     scalar: 63
@@ -89,6 +91,7 @@ wartezeitgrenze_langjährig_versicherte_abschlagsfrei:
       Number of waiting time years in accordance with § 51 Absatz 3a SGB VI,
       which must be proven for a public disability pension at 63 without deductions.
   unit: Years
+  reference_period: null
   type: scalar
   2001-01-01:
     scalar: 35
@@ -115,6 +118,7 @@ zurechnungszeitgrenze:
       Increase from 2020 to 2027 by 1 month per year, and from 2028
       by 2 months each year until 67 is reached.
   unit: Years
+  reference_period: null
   type: scalar
   2001-01-01:
     scalar: 62.916666
@@ -228,6 +232,7 @@ min_zugangsfaktor:
       http://www.portal-sozialpolitik.de/index.php?page=rentenversicherung
     en: Deductions for early retirement are capped at 10.8%.
   unit: null
+  reference_period: null
   type: scalar
   2000-01-01:
     scalar: 0.892
@@ -248,6 +253,7 @@ rentenartfaktor:
       pension.
       https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/1051-rentenartfaktor.html
   unit: null
+  reference_period: null
   type: dict
   2001-01-01:
     teilw: 0.5
@@ -266,6 +272,7 @@ altersgrenze_grundbewertung:
       As part of the "Grundbewertung" the "belegungsfähige Gesamtzeitraum" will be
       calculated, which is the period from the age of 17 until the start of the pension.
   unit: Years
+  reference_period: null
   type: scalar
   2001-01-01:
     scalar: 16

--- a/src/_gettsim/parameters/erziehungsgeld.yaml
+++ b/src/_gettsim/parameters/erziehungsgeld.yaml
@@ -7,8 +7,8 @@ einkommensgrenze:
     de: Einkommensgrenze für abzugsfreies Erziehungsgeld
     en: Income threshold for deduction-free parental leave benefit
   unit: Euros
-  type: require_converter
   reference_period: Year
+  type: require_converter
   2004-02-09:
     reference: 09.02.2004 BGBl. I S. 209
     note: >-
@@ -37,8 +37,8 @@ aufschlag_einkommen:
     de: Erhöhung der Einkommensgrenze pro weiterem Kind
     en: Increase in the income threshold per additional child
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2004-02-09:
     reference: 09.02.2004 BGBl. I S. 209
     note: >-
@@ -52,8 +52,8 @@ satz:
     de: Höhe des Erziehungsgeldes abhängig vom beantragtem Satz
     en: Amount of the parental leave benefit depending on the rate applied for
   unit: Euros
-  type: dict
   reference_period: Month
+  type: dict
   2004-02-09:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 208
     note: >-
@@ -76,6 +76,7 @@ abschlagsfaktor:
       The factor is multiplied by the relevant income and
       the product is deducted from the parental leave benefit entitlement accordingly.
   unit: null
+  reference_period: null
   type: scalar
   2004-02-09:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 207
@@ -94,6 +95,7 @@ pauschaler_abzug_vom_einkommen:
       Factor by which the income is reduced in a lump sum in order to calculate the
       relevant income
   unit: null
+  reference_period: null
   type: scalar
   2004-02-09:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 209
@@ -110,8 +112,8 @@ maximale_wochenarbeitszeit:
     en: >-
       Limit of weekly working hours up to which parental leave benefit is paid
   unit: Hours
-  type: scalar
   reference_period: Week
+  type: scalar
   2004-02-09:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 211
     note: >-
@@ -127,6 +129,7 @@ maximales_kindsalter_regelsatz:
     en: >-
       Age of the child in months up to which the Regelsatz can be claimed.
   unit: Months
+  reference_period: null
   type: scalar
   2004-01-01:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 208
@@ -141,6 +144,7 @@ maximales_kindsalter_budgetsatz:
     en: >-
       Age of the child in months up to which the Budgetsatz can be claimed.
   unit: Months
+  reference_period: null
   type: scalar
   2004-01-01:
     reference: § 5 G. v. 09.02.2004 BGBl. I S. 208
@@ -155,6 +159,7 @@ abolishment_cohort:
     en: >-
       Erziehungsgeld is replaced by Elterngeld.
   unit: Years
+  reference_period: null
   type: scalar
   2006-12-11:
     reference: Art. 3 G. v. 5.12.2006 BGBl. I S. 2748

--- a/src/_gettsim/parameters/geringfügige_einkommen.yaml
+++ b/src/_gettsim/parameters/geringfügige_einkommen.yaml
@@ -113,6 +113,7 @@ faktor_minijobformel_zähler:
       Factor by which the minimum wage is multiplied to calculate the threshold for
       marginal employment.
   unit: null
+  reference_period: null
   type: scalar
   # type: require_converter
   2022-10-01:
@@ -134,6 +135,7 @@ faktor_minijobformel_nenner:
       Amount by which the minimum wage is divided to obtain the marginal employment
       threshold.
   unit: null
+  reference_period: null
   type: scalar
   2022-10-01:
     scalar: 3
@@ -148,6 +150,7 @@ arbeitgeberpauschale_lohnsteuer:
       (§40a II EStG)
     en: Fixed income tax rate for marginal employment (§40a II EStG)
   unit: Share
+  reference_period: null
   type: scalar
   access_different_date: jahresanfang
   1984-01-01:
@@ -175,8 +178,8 @@ mindestlohn:
       The minimum wage is the lowest hourly wage that an employer must pay for a
       regular, not more than 45 hours weekly work.
   unit: Euros
-  type: scalar
   reference_period: Hour
+  type: scalar
   2015-01-01:
     scalar: 8.5
   2017-01-01:

--- a/src/_gettsim/parameters/ges_krankenv.yaml
+++ b/src/_gettsim/parameters/ges_krankenv.yaml
@@ -16,6 +16,7 @@ beitragssatz:
       contribution rate, since 2009 sonderbeitrag - paid by employees, Jul 2005 to
       2014 ermäßigt - reduced rate zusatz - average top-up contribution rate
   unit: Share
+  reference_period: null
   type: dict
   access_different_date: jahresanfang
   1984-01-01:
@@ -125,8 +126,8 @@ beitragsbemessungsgrenze_m:
     de: Die Beitragsbemessungsgrenze für Kranken- und Pflegeversicherung ist identisch.
     en: The income threshold is the same for health and long-term care insurance.
   unit: Euros
-  type: require_converter
   reference_period: Month
+  type: require_converter
   1984-01-01:
     west: 1994
   1985-01-01:
@@ -244,6 +245,7 @@ arbeitgeberpauschale_bei_geringfügiger_beschäftigung:
       geringfügiger Beschäftigung
     en: Fixed health insurance contributions for marginal employment (§ 249b SGB V)
   unit: Share
+  reference_period: null
   type: scalar
   access_different_date: jahresanfang
   1984-01-01:
@@ -262,8 +264,9 @@ bezugsgröße_selbstständige_m:
     de: §18 SGB IV ynd https://de.wikipedia.org/wiki/Bezugsgr%C3%B6%C3%9Fe
     en: §18 SGB IV and https://de.wikipedia.org/wiki/Bezugsgr%C3%B6%C3%9Fe
   unit: Euros
-  type: dict
   reference_period: Month
+  type: dict
+  access_different_date: jahresanfang
   1984-01-01:
     west: 1396
     mindestanteil: 0.33333333
@@ -409,6 +412,7 @@ mindestanteil_bezugsgröße_selbstständige:
       Health Insurance contributions have to be payed, at the minimum, on the ninetieth
       part of the monthly Bezugsgröße for each calender day
   unit: Share
+  reference_period: null
   type: scalar
   1990-01-01:
     note: Exact date of introduction of this parameter unclear (was in place in 2006)

--- a/src/_gettsim/parameters/ges_pflegev.yaml
+++ b/src/_gettsim/parameters/ges_pflegev.yaml
@@ -14,6 +14,7 @@ beitragssatz:
       employees contribution rate zusatz_kinderlos - contribution rate for insured
       people without children and at least 23 years old. paid by employees. est. 2005
   unit: Share
+  reference_period: null
   type: dict
   access_different_date: jahresanfang
   1995-01-01:
@@ -63,8 +64,8 @@ beitragsbemessungsgrenze_m:
     de: Die Beitragsbemessungsgrenze für Kranken- und Pflegeversicherung ist identisch.
     en: The income threshold is the same for health and long-term care insurance.
   unit: Euros
-  type: dict
   reference_period: Month
+  type: dict
   1995-01-01:
     west: 2991
     ost: 2454
@@ -185,6 +186,7 @@ zusatz_kinderlos_mindestalter:
       Childless members of the social care insurance, who have reached the age of 23,
       have to pay a higher contribution rate since January 1, 2005.
   unit: Years
+  reference_period: null
   type: scalar
   2005-01-01:
     scalar: 23

--- a/src/_gettsim/parameters/ges_rente.yaml
+++ b/src/_gettsim/parameters/ges_rente.yaml
@@ -11,8 +11,8 @@ beitragspflichtiges_durchschnittsentgelt:
       Anlage 1 SGB VI, Mean wage of all insured people in the sense of the German social
       insurance, which is needed to calculate the Entgeltpunkte.
   unit: Euros
-  type: scalar
   reference_period: Year
+  type: scalar
   2005-01-01:
     value: 29202
   2006-01-01:
@@ -260,8 +260,8 @@ parameter_rentenwert:
       The current pension value expresses the amount of monthly pension paid for one
       Entgeltpunkt.
   unit: Euros
-  type: require_converter
   reference_period: null
+  type: require_converter
   access_different_date: vorjahr
   1992-01-01:
     west: 21.19
@@ -412,7 +412,7 @@ grundrente_berücksichtigte_wartezeit:
       Minimal number of Grundrentenzeiten required to be entitled to Grundrente and
       maximum number of months that are considered for Grundrente.
   unit: Months
-  reference_period: Months
+  reference_period: Month
   type: dict
   2021-01-01:
     min: 396

--- a/src/_gettsim/parameters/ges_rentenv.yaml
+++ b/src/_gettsim/parameters/ges_rentenv.yaml
@@ -9,6 +9,7 @@ beitragssatz:
     en: >-
       Employees contribution rate for pension insurance.
   unit: Share
+  reference_period: null
   access_different_date: jahresanfang
   1984-01-01:
     scalar: 0.0925
@@ -225,6 +226,7 @@ arbeitgeberpauschale_bei_geringfügiger_beschäftigung:
       Fixed pension insurance contributions for marginal employment
       (§ 168 I Nr. 1b SGB VI)
   unit: Share
+  reference_period: null
   access_different_date: jahresanfang
   1984-01-01:
     scalar: 0

--- a/src/_gettsim/parameters/ges_rentenv.yaml
+++ b/src/_gettsim/parameters/ges_rentenv.yaml
@@ -65,8 +65,8 @@ parameter_beitragsbemessungsgrenze:
     de: Beitragsbemessungsgrenze für die gesetzliche Rentenversicherung.
     en: Income threshold for statutory pension insurance.
   unit: Euros
-  type: dict
   reference_period: Month
+  type: dict
   1984-01-01:
     west: 2659
   1985-01-01:

--- a/src/_gettsim/parameters/grunds_im_alter.yaml
+++ b/src/_gettsim/parameters/grunds_im_alter.yaml
@@ -15,6 +15,8 @@ vermögensfreibetrag:
       § 1 Verordnung zur Durchführung des § 90 Abs. 2 Nr. 9 des Zwölften Buches
       Sozialgesetzbuch
   unit: Euros
+  reference_period: null
+  type: dict
   1984-01-01:
     adult: 0
     child: 0
@@ -40,6 +42,7 @@ ges_rente_anr_frei:
       Public pension shares not subject to transfer withdrawal for subjects whose
       Grundrentenzeiten exceeds 33 years.
   unit: Share
+  reference_period: null
   type: piecewise_linear
   1984-01-01:
     reference: No income could be deducted
@@ -76,6 +79,7 @@ kapitaleink_anr_frei:
       the Grundsicherung im Alter.
   unit: Euros
   reference_period: Year
+  type: scalar
   1984-01-01:
     scalar: 0
   2016-01-01:
@@ -94,9 +98,8 @@ erwerbseink_anr_frei:
       Share of income, which is not added to the total income when calculating the
       Grundsicherung.
   unit: Share
-  1984-01-01:
-    scalar: 0
-    note: Unclear how it was handled before 2005
+  reference_period: null
+  type: scalar
   2005-01-01:
     scalar: 0.3
 priv_rente_anr_frei:
@@ -113,6 +116,7 @@ priv_rente_anr_frei:
       Share of privat pension, which is not added to total income when calculating the
       Grundsicherung.
   unit: Share
+  reference_period: null
   type: piecewise_linear
   1984-01-01:
     reference: Unclear how it was handled before 2005
@@ -141,14 +145,16 @@ mehrbedarf_bei_schwerbehinderungsgrad_g:
   description:
     de: >-
       § 30 Abs. 1 SGB XII, https://www.buzer.de/gesetz/3415/al0-3758.htm
-      Dieser Prozentanteil des Regelbedarfs wird Menschen mit Schwerbehindertenausweis
-      mit Merkzeichen G, die Grundsicherung im Alter oder bei Erwerbsminderung bekommen,
-      als Mehrbedarf anerkannt.
+      Dieser Anteil des Regelbedarfs wird Menschen mit Schwerbehindertenausweis mit
+      Merkzeichen G, die Grundsicherung im Alter oder bei Erwerbsminderung bekommen, als
+      Mehrbedarf anerkannt.
     en: >-
       § 30 Abs. 1 SGB XII, https://www.buzer.de/gesetz/3415/al0-3758.htm
-      This percentage of the normal requirement is added as an additional requirement
-      for someone who has a severly disabled ID card which shows the code 'G' and is
-      entitled to the Grundsicherung.
-  unit: Percent
+      This share of the Regelbedarf is added as an additional requirement for someone
+      who has a severly disabled ID card which shows the code 'G' and is entitled to the
+      Grundsicherung.
+  unit: Share
+  reference_period: null
+  type: scalar
   2006-12-07:
     scalar: 0.17

--- a/src/_gettsim/parameters/kindergeld.yaml
+++ b/src/_gettsim/parameters/kindergeld.yaml
@@ -15,6 +15,7 @@ altersgrenze:
       children up to a specified age are entitled to child benefit under certain
       conditions.
   unit: Years
+  reference_period: null
   1984-01-01:
     mit_bedingungen: 27
     ohne_bedingungen: 18

--- a/src/_gettsim/parameters/kinderzuschl.yaml
+++ b/src/_gettsim/parameters/kinderzuschl.yaml
@@ -59,6 +59,8 @@ kindersofortzuschlag:
       With the introduction of the immediate supplement from July 1, 2022,
       the maximum amount in the child supplement increases by 20 Euro.
   unit: Euros
+  reference_period: Month
+  type: scalar
   2022-07-01:
     scalar: 20
   2023-01-01:
@@ -105,6 +107,8 @@ entzugsrate_eltern:
       berücksichtigt.
     en: null
   unit: Share
+  reference_period: null
+  type: scalar
   2005-01-01:
     scalar: 0.7
     reference: Art. 46 G. v. 24.12.2003 BGBl. I. S. 2954.
@@ -117,7 +121,7 @@ entzugsrate_eltern:
 entzugsrate_kind:
   name:
     de: Minderungsrate durch Einkommen des Kindes
-    en: Rate at which child income is deducted
+    en: Rate at which benefit is reduced by child income
   description:
     de: >-
       § 6a (3) BKGG. Einkommen des Kindes beinhaltet auch Unterhalt und
@@ -125,6 +129,8 @@ entzugsrate_kind:
     en: >-
       Child alimony and alimony advance payments are also attributed to the child.
   unit: Share
+  reference_period: null
+  type: scalar
   2005-01-01:
     scalar: 1
     reference: Art. 46 G. v. 24.12.2003 BGBl. I. S. 2954.

--- a/src/_gettsim/parameters/soli_st.yaml
+++ b/src/_gettsim/parameters/soli_st.yaml
@@ -8,6 +8,8 @@ soli_st:
       Ab 1995, der upper threshold im Intervall 1 ist nach der Formel
       transition_threshold in soli_st.py berechnet.
     en: null
+  reference_period: null
+  unit: null
   type: piecewise_linear
   1991-01-01:
     reference: Artikel 1 G. v. 24.06.1991 BGBl. I S. 1318.

--- a/src/_gettsim/parameters/unterhalt.yaml
+++ b/src/_gettsim/parameters/unterhalt.yaml
@@ -117,6 +117,7 @@ abzugsrate_kindergeld:
       for child alimony payments can deduct half of the child benefit when calculating
       alimony.
   unit: Share
+  reference_period: null
   2008-01-01:
     kind: 0.5
     erwachsener: 1

--- a/src/_gettsim/parameters/unterhaltsvors.yaml
+++ b/src/_gettsim/parameters/unterhaltsvors.yaml
@@ -29,6 +29,9 @@ altersgrenzen_bezug:
       § 1 Abs. 1, 1a UhVorschG
       Children under the age of 12 living with a single parent are entitled to alimony
       payments. Since July 2017, the age limits of the minimum alimony apply.
+  unit: Years
+  reference_period: null
+  type: dict
   2008-01-01:
     1:
       min_alter: 0
@@ -50,6 +53,9 @@ faktor_jüngste_altersgruppe:
       § 1612a Abs. 1 BGB
       Factor by which the sächliche Existenzminimum is multiplied to calculate
       the advance child alimony for children of the youngest age group.
+  unit: Euros
+  reference_period: null
+  type: scalar
   2009-01-01:
     scalar: 0.87
 anwendungsvorschrift:

--- a/src/_gettsim/parameters/wohngeld.yaml
+++ b/src/_gettsim/parameters/wohngeld.yaml
@@ -6,6 +6,8 @@ faktor_berechnungsformel:
   description:
     de: Anlage 2 WoGG zu §19 Abs. 2 WoGG
     en: null
+  unit: null
+  reference_period: null
   type: scalar
   1984-01-01:
     scalar: 1
@@ -25,6 +27,8 @@ koeffizienten_berechnungsformel:
       Wohngeldverordnung (WoGV).
       Die Schlüssel von 1 to 12 beziehen sich auf die Haushaltsgröße.
     en: The keys from 1 to 12 below refer to the household size.
+  unit: null
+  reference_period: null
   type: require_converter
   1984-01-01:
     note: Parameter aus Regressionsanalyse der Wohngeldtabellen
@@ -524,6 +528,8 @@ abzugsbeträge_steuern_sozialversicherung:
       Kriterien sind entrichtete Steuern / entrichtete GKV- und GPV-Beiträge /
       entrichtete GRV-Beiträge
     en: null
+  unit: Share
+  reference_period: null
   type: dict
   1984-01-01:
     0: 0.06
@@ -549,6 +555,7 @@ min_miete:
     de: WoGG - Anlage 3 (bis 2019 Anlage 2) (zu § 19 Abs. 2)
     en: null
   unit: Euros
+  reference_period: Month
   type: dict
   1984-01-01:
     1: 0
@@ -617,7 +624,7 @@ min_miete:
     10: 146
     11: 180
     12: 286
-min_eink:
+min_einkommen:
   name:
     de: Minimalwert für Parameter Y
     en: null
@@ -625,6 +632,7 @@ min_eink:
     de: WoGG - Anlage 3 (bis 2019 Anlage 2) (zu § 19 Abs. 2)
     en: null
   unit: Euros
+  reference_period: Month
   type: dict
   1984-01-01:
     1: 0
@@ -1909,6 +1917,7 @@ vermögensfreibetrag:
       2009. Vorher war hohes Vermögen laut WoGG kein Ausschlussgrund.
     en: Since 2009, wealth might be a reason not to grand housing benefit.
   unit: Euros
+  reference_period: null
   type: dict
   1970-01-01:
     grundfreibetrag: inf

--- a/src/_gettsim/wohngeld/einkommen.py
+++ b/src/_gettsim/wohngeld/einkommen.py
@@ -407,7 +407,9 @@ def einkommen(
 
     """
     eink_nach_abzug_m_hh = einkommen_vor_freibetrag - einkommen_freibetrag
-    unteres_eink = params["min_eink"][min(anzahl_personen, max(params["min_eink"]))]
+    unteres_eink = params["min_einkommen"][
+        min(anzahl_personen, max(params["min_einkommen"]))
+    ]
 
     out = max(eink_nach_abzug_m_hh, unteres_eink)
     return out

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -71,24 +71,7 @@
             },
             "reference": { "type": "string" },
             "note": { "type": "string" },
-            "deviation_from": { "type": "string" },
-            "min_alter": { "type": "number" },
-            "max_alter": { "type": "number" },
-            "betrag": { "type": "number" },
-            "lower_threshold": {
-              "oneOf": [
-                { "type": "number" },
-                { "type": "string", "enum": ["-inf"] }
-              ]
-            },
-            "upper_threshold": {
-              "oneOf": [
-                { "type": "number" },
-                { "type": "string", "enum": ["inf"] }
-              ]
-            },
-            "rate": { "type": "number" },
-            "intercept_at_lower_threshold": { "type": "number" }
+            "deviation_from": { "type": "string" }
           },
           "additionalProperties": true
         }

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -95,7 +95,14 @@
       },
       "additionalProperties": false,
       "allOf": [
-        { "required": ["name", "description", "type"] },
+        { "required": [
+          "name",
+          "description",
+          "unit",
+          "reference_period",
+          "type"
+        ]
+      },
         {
           "minProperties": 1,
           "patternProperties": {

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -82,7 +82,8 @@
           "name",
           "description",
           "unit",
-          "reference_period"
+          "reference_period",
+          "type"
         ]
       },
         {

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -51,8 +51,8 @@
           ]
         },
         "reference_period": {
-          "type": "string",
-          "enum": ["Year", "Quarter", "Month", "Week", "Day", "Hour"]
+          "type": ["string", "null"],
+          "enum": ["Year", "Quarter", "Month", "Week", "Day", "Hour", null]
         },
         "access_different_date": {
           "type": "string",

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -82,8 +82,7 @@
           "name",
           "description",
           "unit",
-          "reference_period",
-          "type"
+          "reference_period"
         ]
       },
         {

--- a/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
+++ b/tests/ttsim/mettsim/housing_benefits/eligibility/eligibility.py
@@ -37,7 +37,7 @@ def requirement_fulfilled_fam_not_considering_children(
 ) -> bool:
     return (
         housing_benefits__income__amount_m_fam
-        < subsistence_income_level["per_spouse_m"] * number_of_adults_fam
+        < subsistence_income_level["per_spouse"] * number_of_adults_fam
     )
 
 
@@ -51,7 +51,7 @@ def requirement_fulfilled_fam_considering_children(
     subsistence_income_level: dict[str, float],
 ) -> bool:
     return housing_benefits__income__amount_m_fam < (
-        subsistence_income_level["per_individual_m"]
+        subsistence_income_level["per_individual"]
         * number_of_family_members_considered_fam
     )
 

--- a/tests/ttsim/mettsim/housing_benefits/eligibility/params.yaml
+++ b/tests/ttsim/mettsim/housing_benefits/eligibility/params.yaml
@@ -6,11 +6,13 @@ subsistence_income_level:
   description:
     de: Dict, da es sich über die Jahre ändert, aber der Paramtername gleich bleibt.
     en: Dict, because it changes over time, but the parameter name remains the same.
+  unit: Euros
+  reference_period: Month
   type: dict
   1900-01-01:
-    per_spouse_m: 500.0
+    per_spouse: 500.0
   2020-01-01:
-    per_individual_m: 500.0
+    per_individual: 500.0
 max_number_of_family_members:
   name:
     de: Maximalzahl der zu berücksichtigenden Personen
@@ -18,6 +20,8 @@ max_number_of_family_members:
   description:
     de: Erst nach Reform 2020 relevant.
     en: Only relevant after 2020 reform.
+  unit: null
+  reference_period: null
   type: scalar
   2020-01-01:
     value: 4
@@ -28,6 +32,8 @@ max_age_children:
   description:
     de: In Mittelerde passiert nichts, niemals.
     en: In Middle Earth nothing happens, ever.
+  unit: Years
+  reference_period: null
   type: scalar
   1900-01-01:
     value: 18

--- a/tests/ttsim/mettsim/housing_benefits/params.yaml
+++ b/tests/ttsim/mettsim/housing_benefits/params.yaml
@@ -6,6 +6,8 @@ assistance_rate:
   description:
     de: In Mittelerde passiert immer noch nichts.
     en: Still nothing happens in Middle Earth.
+  unit: Share
+  reference_period: null
   type: scalar
   1900-01-01:
     value: 0.5

--- a/tests/ttsim/mettsim/orc_hunting_bounty/params.yaml
+++ b/tests/ttsim/mettsim/orc_hunting_bounty/params.yaml
@@ -6,6 +6,8 @@ raw_bounties_per_orc:
   description:
     de: Test für den Typ require_converter
     en: Test the require_converter type
+  unit: Euros
+  reference_period: null
   type: require_converter
   1900-01-01:
     small_orc: 100

--- a/tests/ttsim/mettsim/payroll_tax/child_tax_credit/params.yaml
+++ b/tests/ttsim/mettsim/payroll_tax/child_tax_credit/params.yaml
@@ -6,6 +6,8 @@ schedule:
   description:
     de: In Mittelerde passiert nichts.
     en: In Middle Earth nothing happens.
+  unit: null
+  reference_period: null
   type: dict
   1900-01-01:
     child_amount_y: 100.0

--- a/tests/ttsim/mettsim/payroll_tax/income/params.yaml
+++ b/tests/ttsim/mettsim/payroll_tax/income/params.yaml
@@ -6,7 +6,8 @@ lump_sum_deduction_y:
   description:
     de: Lohnsteuerpauschalabzug
     en: Lump sum deduction for payroll tax
-  type: scalar
+  unit: Euros
   reference_period: Year
+  type: scalar
   1900-01-01:
     value: 100.0

--- a/tests/ttsim/mettsim/payroll_tax/payroll_tax.yaml
+++ b/tests/ttsim/mettsim/payroll_tax/payroll_tax.yaml
@@ -6,6 +6,8 @@ wealth_threshold_for_reduced_tax_rate:
   description:
     de: Umgekehrte Bennenung schiene sinnvoll.
     en: The reverse naming would seem more sensible.
+  unit: Euros
+  reference_period: null
   type: scalar
   1900-01-01:
     value: 50000
@@ -16,6 +18,8 @@ tax_schedule_standard:
   description:
     de: Für Angehörige von Familien mit niedrigem Vermögen
     en: For member of families with low wealth
+  unit: null
+  reference_period: null
   type: piecewise_linear
   1900-01-01:
     0:
@@ -36,6 +40,8 @@ tax_schedule_reduced:
   description:
     de: Für Angehörige von Familien mit hohem Vermögen
     en: For member of families with high wealth
+  unit: null
+  reference_period: null
   type: piecewise_linear
   1900-01-01:
     0:

--- a/tests/ttsim/mettsim/payroll_tax/payroll_tax.yaml
+++ b/tests/ttsim/mettsim/payroll_tax/payroll_tax.yaml
@@ -19,7 +19,7 @@ tax_schedule_standard:
     de: Für Angehörige von Familien mit niedrigem Vermögen
     en: For member of families with low wealth
   unit: null
-  reference_period: null
+  reference_period: Year
   type: piecewise_linear
   1900-01-01:
     0:
@@ -41,7 +41,7 @@ tax_schedule_reduced:
     de: Für Angehörige von Familien mit hohem Vermögen
     en: For member of families with high wealth
   unit: null
-  reference_period: null
+  reference_period: Year
   type: piecewise_linear
   1900-01-01:
     0:

--- a/tests/ttsim/mettsim/property_tax/params.yaml
+++ b/tests/ttsim/mettsim/property_tax/params.yaml
@@ -8,6 +8,8 @@ tax_schedule:
       Vermögenssteuer auf Landbesitz. Bemisst sich an Größe des landwirtschaftlich
       nutzbaren Landes in Hektar.
     en: Wealth tax on land. Depends on size of arable land in hectares.
+  unit: Euros
+  reference_period: null
   type: piecewise_constant
   1900-01-01:
     0:


### PR DESCRIPTION
Title says it all. Better be explicit in the structure and allow for nulls than leaving things out accidentally.