### PR TITLE
Active periods for params

### DIFF
--- a/src/_gettsim/sozialversicherung/geringfügige_einkommen.yaml
+++ b/src/_gettsim/sozialversicherung/geringfügige_einkommen.yaml
@@ -133,7 +133,7 @@ arbeitgeberpauschale_lohnsteuer:
   unit: Share
   reference_period: null
   type: scalar
-  access_different_date: jahresanfang
+  add_jahresanfang: true
   1984-01-01:
     value: 0
   1999-01-01:

--- a/src/_gettsim/sozialversicherung/rente/altersrente/entgeltpunkte.py
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/entgeltpunkte.py
@@ -44,7 +44,7 @@ def neue_entgeltpunkte(
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
     wohnort_ost: bool,
     sozialversicherung__rente__beitrag__beitragsbemessungsgrenze_m: float,
-    beitragspflichtiges_durchschnittsentgelt_m: float,
+    beitragspflichtiges_durchschnittsentgelt_y: float,
     umrechnung_entgeltpunkte_beitrittsgebiet: float,
 ) -> float:
     """Return earning points for the wages earned in the last year."""
@@ -71,7 +71,7 @@ def neue_entgeltpunkte(
     else:
         bruttolohn_scaled_rentenv = bruttolohn_scaled_east
 
-    return bruttolohn_scaled_rentenv / beitragspflichtiges_durchschnittsentgelt_m
+    return bruttolohn_scaled_rentenv / beitragspflichtiges_durchschnittsentgelt_y / 12
 
 
 @policy_function()

--- a/src/_gettsim/sozialversicherung/rente/altersrente/entgeltpunkte.py
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/entgeltpunkte.py
@@ -71,7 +71,7 @@ def neue_entgeltpunkte(
     else:
         bruttolohn_scaled_rentenv = bruttolohn_scaled_east
 
-    return bruttolohn_scaled_rentenv / beitragspflichtiges_durchschnittsentgelt_y / 12
+    return bruttolohn_scaled_rentenv / (beitragspflichtiges_durchschnittsentgelt_y / 12)
 
 
 @policy_function()

--- a/src/_gettsim/sozialversicherung/rente/altersrente/rentenformel.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/rentenformel.yaml
@@ -18,7 +18,7 @@ zugangsfaktor_veränderung_pro_jahr:
   2001-01-01:
     vorzeitiger_renteneintritt: 0.036
     späterer_renteneintritt: 0.06
-parameter_beitragspflichtiges_durchschnittsentgelt:
+beitragspflichtiges_durchschnittsentgelt_y:
   name:
     de: Beitragspflichtiges Durchschnittsentgelt aller Versicherten
     en: Mean relevant wage of all insured individuals

--- a/src/_gettsim/sozialversicherung/rente/beitrag/arbeitgeberpauschale.yaml
+++ b/src/_gettsim/sozialversicherung/rente/beitrag/arbeitgeberpauschale.yaml
@@ -16,7 +16,7 @@ arbeitgeberpauschale_bei_geringfügiger_beschäftigung:
   unit: Share
   reference_period: null
   type: scalar
-  access_different_date: jahresanfang
+  add_jahresanfang: true
   1999-01-01:
     value: 0.12
   2003-04-01:

--- a/src/_gettsim/sozialversicherung/rente/beitrag/beitrag.py
+++ b/src/_gettsim/sozialversicherung/rente/beitrag/beitrag.py
@@ -47,19 +47,46 @@ def betrag_versicherter_m_mit_midijob(
     return out
 
 
-@policy_function(end_date="2003-03-31", leaf_name="betrag_arbeitgeber_m")
-def betrag_arbeitgeber_m_ohne_midijob(
+@policy_function(
+    end_date="1998-12-31",
+    leaf_name="betrag_arbeitgeber_m",
+)
+def betrag_arbeitgeber_m_ohne_arbeitgeberpauschale(
     sozialversicherung__geringfügig_beschäftigt: bool,
     einkommen_m: float,
     parameter_beitragssatz: float,
-    arbeitgeberpauschale_bei_geringfügiger_beschäftigung: float,
-    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
 ) -> float:
     """Employer's public pension insurance contribution.
 
     Before Midijob introduction in April 2003.
     """
-    ges_rentenv_beitr_regular_job_m = einkommen_m * parameter_beitragssatz
+    betrag_regulär_beschäftigt_m = einkommen_m * parameter_beitragssatz
+
+    if sozialversicherung__geringfügig_beschäftigt:
+        out = 0.0
+    else:
+        out = betrag_regulär_beschäftigt_m
+
+    return out
+
+
+@policy_function(
+    start_date="1999-01-01",
+    end_date="2003-03-31",
+    leaf_name="betrag_arbeitgeber_m",
+)
+def betrag_arbeitgeber_m_mit_arbeitgeberpauschale(
+    sozialversicherung__geringfügig_beschäftigt: bool,
+    einkommen_m: float,
+    parameter_beitragssatz: float,
+    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
+    arbeitgeberpauschale_bei_geringfügiger_beschäftigung: float,
+) -> float:
+    """Employer's public pension insurance contribution.
+
+    Before Midijob introduction in April 2003.
+    """
+    betrag_regulär_beschäftigt_m = einkommen_m * parameter_beitragssatz
 
     if sozialversicherung__geringfügig_beschäftigt:
         out = (
@@ -67,7 +94,7 @@ def betrag_arbeitgeber_m_ohne_midijob(
             * arbeitgeberpauschale_bei_geringfügiger_beschäftigung
         )
     else:
-        out = ges_rentenv_beitr_regular_job_m
+        out = betrag_regulär_beschäftigt_m
 
     return out
 

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/geringfügig_beschäftigt_nur_west.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/geringfügig_beschäftigt_nur_west.yaml
@@ -1,6 +1,5 @@
 ---
 info:
-  note: Skipping because parameter starts only in 1999. Check for correctness.
   precision_atol: 1
   source: Regression test. Unclear whether numbers are correct by external standards.
 inputs:

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/skip_geringfügig_beschäftigt_nur_west.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/skip_geringfügig_beschäftigt_nur_west.yaml
@@ -1,6 +1,6 @@
 ---
 info:
-  note: ''
+  note: Skipping because parameter starts only in 1999. Check for correctness.
   precision_atol: 1
   source: Regression test. Unclear whether numbers are correct by external standards.
 inputs:

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import datetime
 import itertools
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import dags.tree as dt
@@ -208,7 +209,7 @@ def set_up_policy_environment(
     _orig_ttsim_objects_tree = orig_ttsim_objects_tree(root)
     _orig_params_tree = orig_params_tree(root)
     # Will move this line out eventually. Just include in tests, do not run every time.
-    fail_because_of_clashes(
+    fail_because_active_periods_overlap(
         orig_ttsim_objects_tree=_orig_ttsim_objects_tree,
         orig_params_tree=_orig_params_tree,
     )
@@ -264,26 +265,21 @@ def set_up_policy_environment(
     )
 
 
-def fail_because_of_clashes(
+def fail_because_active_periods_overlap(
     orig_ttsim_objects_tree: FlatTTSIMObjectDict,
     orig_params_tree: FlatOrigParamSpecDict,
 ) -> None:
-    """Fail because of clashes of names.
+    """Fail because active periods of TTSIM objects / parameters overlap.
 
-    Two scenarios are checked:
-    - Within TTSIMObjects, active periods of a path + leaf name could overlap
-    - There may be name clashes involving parameters (parameters from multiple files
-      that end up having the same path or parameters named in the same way as a path +
-      leaf name).
+    Checks that objects or parameters with the same path are not active at the same
+    time.
 
     Raises
     ------
     ConflictingActivePeriodsError
-        If multiple objects with the same leaf name are active at the same time.
-    ConflictingNamesError
-        If there are name clashes involving parameters.
+        If multiple objects and/or parameters with the same leaf name are active at the
+        same time.
     """
-
     # Create mapping from leaf names to TTSIM objects.
     overlap_checker: dict[tuple[str, ...], list[TTSIMObject]] = {}
     for orig_path, obj in orig_ttsim_objects_tree.items():
@@ -292,6 +288,19 @@ def fail_because_of_clashes(
             overlap_checker[path].append(obj)
         else:
             overlap_checker[path] = [obj]
+
+    for orig_path, obj in orig_params_tree.items():
+        path = (*orig_path[:-2], orig_path[-1])
+        if path in overlap_checker:
+            overlap_checker[path].extend(
+                _ttsim_param_with_active_periods(
+                    param_spec=obj, leaf_name=orig_path[-1]
+                )
+            )
+        else:
+            overlap_checker[path] = _ttsim_param_with_active_periods(
+                param_spec=obj, leaf_name=orig_path[-1]
+            )
 
     # Check for overlapping start and end dates for time-dependent functions.
     for path, objects in overlap_checker.items():
@@ -305,24 +314,65 @@ def fail_because_of_clashes(
                     overlap_end=min(end1, end2),
                 )
 
-    # Start with a single element each.
-    name_checker: dict[tuple[str, ...], list[TTSIMObject | OrigParamSpec]] = {}
-    for path, objects in overlap_checker.items():
-        name_checker[path] = [objects[0]]
-    # Now add the yaml objects.
-    for orig_path, obj in orig_params_tree.items():
-        path = (*orig_path[:-2], orig_path[-1])
-        if path in name_checker:
-            name_checker[path].append(obj)
-        else:
-            name_checker[path] = [obj]
 
-    for path, objects in name_checker.items():
-        if len(objects) > 1:
-            raise ConflictingNamesError(
-                affected_objects=objects,
-                path=path,
+@dataclass(frozen=True)
+class _TTSIMParamWithActivePeriod(TTSIMObject):
+    """A TTSIMParam object which mimics a TTSIMObject regarding active periods.
+
+    Only used here for checking overlap.
+    """
+
+    original_function_name: str
+
+
+def _ttsim_param_with_active_periods(
+    param_spec: OrigParamSpec,
+    leaf_name: str,
+) -> list[_TTSIMParamWithActivePeriod]:
+    """Return parameter with active periods."""
+
+    def _remove_note_and_reference(entry: dict[str | int, Any]) -> dict[str | int, Any]:
+        """Remove note and reference from a parameter specification."""
+        entry.pop("note", None)
+        entry.pop("reference", None)
+        return entry
+
+    relevant = sorted(
+        [key for key in param_spec if isinstance(key, datetime.date)],
+        reverse=True,
+    )
+    if not relevant:
+        raise ValueError(f"No relevant dates found for {param_spec}")
+
+    out = []
+    start_date: datetime.date | None = None
+    end_date = DEFAULT_END_DATE
+    for date in relevant:
+        if _remove_note_and_reference(param_spec[date]):
+            start_date = date
+        else:
+            if start_date:
+                out.append(
+                    _TTSIMParamWithActivePeriod(
+                        leaf_name=leaf_name,
+                        original_function_name=leaf_name,
+                        start_date=start_date,
+                        end_date=end_date,
+                    )
+                )
+            start_date = None
+            end_date = date - datetime.timedelta(days=1)
+    if start_date:
+        out.append(
+            _TTSIMParamWithActivePeriod(
+                leaf_name=leaf_name,
+                original_function_name=leaf_name,
+                start_date=start_date,
+                end_date=end_date,
             )
+        )
+
+    return out
 
 
 class ConflictingActivePeriodsError(Exception):
@@ -357,37 +407,6 @@ class ConflictingActivePeriodsError(Exception):
         }
 
         Overlap from {self.overlap_start} to {self.overlap_end}."""
-
-
-class ConflictingNamesError(Exception):
-    def __init__(
-        self,
-        affected_objects: list[TTSIMObject | OrigParamSpec],
-        path: tuple[str, ...],
-    ) -> None:
-        self.affected_objects = affected_objects
-        self.path = path
-
-    def __str__(self) -> str:
-        objects = []
-        for obj in self.affected_objects:
-            if isinstance(obj, TTSIMObject):
-                objects.append(obj.__getattribute__("original_function_name"))
-            else:
-                objects.append(str(obj))
-        return f"""
-        Objects with path
-
-          {self.path}
-
-        clash. The following objects are affected:
-
-          {
-            '''
-          '''.join(objects)
-        }
-
-        """
 
 
 def active_ttsim_objects_tree(

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -271,8 +271,8 @@ def fail_because_active_periods_overlap(
 ) -> None:
     """Fail because active periods of TTSIM objects / parameters overlap.
 
-    Checks that objects or parameters with the same path are not active at the same
-    time.
+    Checks that objects or parameters with the same tree path / qualified name are not
+    active at the same time.
 
     Raises
     ------

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -504,7 +504,7 @@ def test_fail_because_of_conflicting_active_periods(
 @pytest.mark.parametrize(
     "orig_ttsim_objects_tree, orig_params_tree",
     [
-        # Same global module, no overlapping periods, name clashes leaf name / yaml.
+        # Same global module, no overlap in functions, name clashes leaf name / yaml.
         (
             {
                 ("c", "a"): policy_function(
@@ -520,7 +520,7 @@ def test_fail_because_of_conflicting_active_periods(
             },
             {("c", "f"): {datetime.date(2023, 1, 1): {"value": 1}}},
         ),
-        # Same paths, no overlapping periods, name clashes leaf name / yaml.
+        # Same paths, no overlap in functions, name clashes leaf name / yaml.
         (
             {
                 ("x", "a", "b"): policy_function(
@@ -555,6 +555,52 @@ def test_fail_because_of_conflicting_names(
             orig_ttsim_objects_tree=orig_ttsim_objects_tree,
             orig_params_tree=orig_params_tree,
         )
+
+
+@pytest.mark.parametrize(
+    "orig_ttsim_objects_tree, orig_params_tree",
+    [
+        # Same leaf names across functions / parameters, but no overlapping periods.
+        (
+            {
+                ("c", "a"): policy_function(
+                    start_date="2012-01-01",
+                    end_date="2015-12-31",
+                    leaf_name="f",
+                )(identity),
+                ("c", "b"): policy_function(
+                    start_date="2023-02-01",
+                    end_date="2023-02-28",
+                    leaf_name="f",
+                )(identity),
+            },
+            {
+                ("c", "f"): {
+                    "name": {"de": "foo", "en": "foo"},
+                    "description": {"de": "foo", "en": "foo"},
+                    "unit": None,
+                    "reference_period": None,
+                    "type": "scalar",
+                    datetime.date(1984, 1, 1): {"value": 1},
+                    datetime.date(1985, 1, 1): {"value": 3},
+                    datetime.date(1995, 1, 1): {"value": 5},
+                    datetime.date(2012, 1, 1): {"note": "more complex, see function"},
+                    datetime.date(2016, 1, 1): {"value": 10},
+                    datetime.date(2023, 2, 1): {"note": "more complex, see function"},
+                    datetime.date(2023, 3, 1): {"value": 13},
+                }
+            },
+        ),
+    ],
+)
+def test_pass_because_no_overlap_functions_params(
+    orig_ttsim_objects_tree: FlatTTSIMObjectDict,
+    orig_params_tree: FlatOrigParamSpecDict,
+):
+    fail_because_of_clashes(
+        orig_ttsim_objects_tree=orig_ttsim_objects_tree,
+        orig_params_tree=orig_params_tree,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -23,20 +23,23 @@ from ttsim import (
 from ttsim.loader import orig_params_tree, orig_ttsim_objects_tree
 from ttsim.policy_environment import (
     ConflictingActivePeriodsError,
-    ConflictingNamesError,
     _fail_if_name_of_last_branch_element_not_leaf_name_of_function,
     _get_params_contents,
     _parse_raw_parameter_group,
+    _ttsim_param_with_active_periods,
+    _TTSIMParamWithActivePeriod,
     active_ttsim_objects_tree,
     active_ttsim_params_tree,
-    fail_because_of_clashes,
+    fail_because_active_periods_overlap,
 )
+from ttsim.ttsim_objects import DEFAULT_END_DATE
 
 if TYPE_CHECKING:
     from ttsim.typing import (
         FlatOrigParamSpecDict,
         FlatTTSIMObjectDict,
         NestedTTSIMObjectDict,
+        OrigParamSpec,
     )
 
 
@@ -417,7 +420,7 @@ def test_fail_because_of_clashes_no_conflicts(
     orig_ttsim_objects_tree: FlatTTSIMObjectDict,
     orig_params_tree: FlatOrigParamSpecDict,
 ):
-    fail_because_of_clashes(
+    fail_because_active_periods_overlap(
         orig_ttsim_objects_tree=orig_ttsim_objects_tree,
         orig_params_tree=orig_params_tree,
     )
@@ -495,7 +498,7 @@ def test_fail_because_of_conflicting_active_periods(
     orig_ttsim_objects_tree: FlatTTSIMObjectDict,
 ):
     with pytest.raises(ConflictingActivePeriodsError):
-        fail_because_of_clashes(
+        fail_because_active_periods_overlap(
             orig_ttsim_objects_tree=orig_ttsim_objects_tree,
             orig_params_tree={},
         )
@@ -550,8 +553,8 @@ def test_fail_because_of_conflicting_names(
     orig_ttsim_objects_tree: FlatTTSIMObjectDict,
     orig_params_tree: FlatOrigParamSpecDict,
 ):
-    with pytest.raises(ConflictingNamesError):
-        fail_because_of_clashes(
+    with pytest.raises(ConflictingActivePeriodsError):
+        fail_because_active_periods_overlap(
             orig_ttsim_objects_tree=orig_ttsim_objects_tree,
             orig_params_tree=orig_params_tree,
         )
@@ -597,16 +600,160 @@ def test_fail_because_of_conflicting_names(
                 }
             },
         ),
+        # Different periods specified in different files.
+        (
+            {},
+            {
+                ("c", "f"): {
+                    "name": {"de": "foo", "en": "foo"},
+                    "description": {"de": "foo", "en": "foo"},
+                    "unit": None,
+                    "reference_period": None,
+                    "type": "scalar",
+                    datetime.date(1984, 1, 1): {"value": 1},
+                    datetime.date(1985, 1, 1): {"value": 3},
+                    datetime.date(1995, 1, 1): {"value": 5},
+                    datetime.date(2012, 1, 1): {"note": "more complex, see function"},
+                },
+                ("d", "f"): {
+                    "name": {"de": "foo", "en": "foo"},
+                    "description": {"de": "foo", "en": "foo"},
+                    "unit": None,
+                    "reference_period": None,
+                    "type": "scalar",
+                    datetime.date(2016, 1, 1): {"value": 10},
+                    datetime.date(2023, 2, 1): {
+                        "note": "more complex, see function",
+                        "reference": "https://example.com/foo",
+                    },
+                    datetime.date(2023, 3, 1): {
+                        "value": 13,
+                        "note": "Complex didn't last long.",
+                    },
+                },
+            },
+        ),
     ],
 )
 def test_pass_because_no_overlap_functions_params(
     orig_ttsim_objects_tree: FlatTTSIMObjectDict,
     orig_params_tree: FlatOrigParamSpecDict,
 ):
-    fail_because_of_clashes(
+    fail_because_active_periods_overlap(
         orig_ttsim_objects_tree=orig_ttsim_objects_tree,
         orig_params_tree=orig_params_tree,
     )
+
+
+@pytest.mark.parametrize(
+    "param_spec, leaf_name, expected",
+    (
+        (
+            {
+                "name": {"de": "spam", "en": "spam"},
+                "description": {"de": "spam", "en": "spam"},
+                "unit": None,
+                "reference_period": None,
+                "type": "scalar",
+                datetime.date(1984, 1, 1): {"note": "completely empty"},
+            },
+            "spam",
+            [],
+        ),
+        (
+            {
+                "name": {"de": "foo", "en": "foo"},
+                "description": {"de": "foo", "en": "foo"},
+                "unit": None,
+                "reference_period": None,
+                "type": "scalar",
+                datetime.date(1984, 1, 1): {"value": 1},
+            },
+            "foo",
+            [
+                _TTSIMParamWithActivePeriod(
+                    leaf_name="foo",
+                    original_function_name="foo",
+                    start_date=datetime.date(1984, 1, 1),
+                    end_date=DEFAULT_END_DATE,
+                )
+            ],
+        ),
+        (
+            {
+                "name": {"de": "foo", "en": "foo"},
+                "description": {"de": "foo", "en": "foo"},
+                "unit": None,
+                "reference_period": None,
+                "type": "scalar",
+                datetime.date(1984, 1, 1): {"value": 1},
+                datetime.date(1985, 1, 1): {"note": "stop"},
+            },
+            "foo",
+            [
+                _TTSIMParamWithActivePeriod(
+                    leaf_name="foo",
+                    original_function_name="foo",
+                    start_date=datetime.date(1984, 1, 1),
+                    end_date=datetime.date(1984, 12, 31),
+                )
+            ],
+        ),
+        (
+            {
+                "name": {"de": "bar", "en": "bar"},
+                "description": {"de": "bar", "en": "bar"},
+                "unit": None,
+                "reference_period": None,
+                "type": "scalar",
+                datetime.date(1984, 1, 1): {"value": 1},
+                datetime.date(1985, 1, 1): {"value": 3},
+                datetime.date(1995, 1, 1): {"value": 5},
+                datetime.date(2012, 1, 1): {"note": "more complex, see function"},
+                datetime.date(2016, 1, 1): {"value": 10},
+                datetime.date(2023, 2, 1): {
+                    "note": "more complex, see function",
+                    "reference": "https://example.com/bar",
+                },
+                datetime.date(2023, 3, 1): {
+                    "value": 13,
+                    "note": "Complex didn't last long.",
+                },
+            },
+            "bar",
+            [
+                _TTSIMParamWithActivePeriod(
+                    leaf_name="bar",
+                    original_function_name="bar",
+                    start_date=datetime.date(2023, 3, 1),
+                    end_date=DEFAULT_END_DATE,
+                ),
+                _TTSIMParamWithActivePeriod(
+                    leaf_name="bar",
+                    original_function_name="bar",
+                    start_date=datetime.date(2016, 1, 1),
+                    end_date=datetime.date(2023, 1, 31),
+                ),
+                _TTSIMParamWithActivePeriod(
+                    leaf_name="bar",
+                    original_function_name="bar",
+                    start_date=datetime.date(1984, 1, 1),
+                    end_date=datetime.date(2011, 12, 31),
+                ),
+            ],
+        ),
+    ),
+)
+def test_ttsim_param_with_active_periods(
+    param_spec: OrigParamSpec,
+    leaf_name: str,
+    expected: list[_TTSIMParamWithActivePeriod],
+):
+    actual = _ttsim_param_with_active_periods(
+        param_spec=param_spec,
+        leaf_name=leaf_name,
+    )
+    assert actual == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/ttsim/test_policy_environment.py
+++ b/tests/ttsim/test_policy_environment.py
@@ -586,8 +586,14 @@ def test_fail_because_of_conflicting_names(
                     datetime.date(1995, 1, 1): {"value": 5},
                     datetime.date(2012, 1, 1): {"note": "more complex, see function"},
                     datetime.date(2016, 1, 1): {"value": 10},
-                    datetime.date(2023, 2, 1): {"note": "more complex, see function"},
-                    datetime.date(2023, 3, 1): {"value": 13},
+                    datetime.date(2023, 2, 1): {
+                        "note": "more complex, see function",
+                        "reference": "https://example.com/foo",
+                    },
+                    datetime.date(2023, 3, 1): {
+                        "value": 13,
+                        "note": "Complex didn't last long.",
+                    },
                 }
             },
         ),


### PR DESCRIPTION
As realised in #914, we want to be able to interchangeably use parameters and functions with the same leaf name. Use case there:
```
('sozialversicherung', 'rente', 'beitrag', 'beitragsbemessungsgrenze_m')
```
sometimes depends on the data (different values east/west), sometimes it is a common scalar.

Before this PR, this will fail because we check existence of the above path in the `orig_params_tree` against the same path in the `orig_ttsim_objects_tree` without checking for active periods. In this PR, we will adjust the check.