### PR TITLE
Allow params as targets

### DIFF
--- a/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
@@ -1,5 +1,5 @@
 ---
-delete_this_prefix_later_altersgrenze:
+altersgrenze:
   name:
     de: Einheitliche Altersgrenze für Altersrente wegen Arbeitslosigkeit (abschlagsfrei)
     en: Uniform age threshold for pension for unemployed (without deductions)

--- a/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/wegen_arbeitslosigkeit.py
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/wegen_arbeitslosigkeit.py
@@ -7,23 +7,6 @@ from ttsim import policy_function
 
 
 @policy_function(
-    end_date="1989-12-17",
-    leaf_name="altersgrenze",
-    vectorization_strategy="not_required",
-)
-def altersgrenze_ohne_staffelung(ges_rente_params: dict) -> float:
-    """Full retirement age for unemployed.
-
-    Before the WFG (Gesetz für Wachstum und Beschäftigung) was implemented in 1997 the
-    full retirement age was the same for every birth cohort.
-
-    Does not check for eligibility for this pathway into retirement.
-    """
-
-    return ges_rente_params["altersgrenze_rente_wegen_arbeitslosigkeit_abschlagsfrei"]
-
-
-@policy_function(
     start_date="1989-12-18",
     end_date="1996-07-28",
     leaf_name="altersgrenze",

--- a/src/_gettsim_tests/test_groupings.py
+++ b/src/_gettsim_tests/test_groupings.py
@@ -26,10 +26,8 @@ def test_groupings(test: PolicyTest):
     flat_result = dt.flatten_to_qual_names(result)
     flat_expected_output_tree = dt.flatten_to_qual_names(test.expected_output_tree)
 
-    for result, expected in zip(
-        flat_result.values(), flat_expected_output_tree.values()
-    ):
-        assert_array_almost_equal(result, expected, decimal=2)
+    for col, actual in flat_result.items():
+        assert_array_almost_equal(actual, flat_expected_output_tree[col], decimal=2)
 
 
 def test_fail_to_compute_sn_id_if_married_but_gemeinsam_veranlagt_differs():

--- a/src/_gettsim_tests/test_household_links.py
+++ b/src/_gettsim_tests/test_household_links.py
@@ -25,7 +25,5 @@ def test_aggregate_by_p_id(test: PolicyTest):
     flat_result = dt.flatten_to_qual_names(result)
     flat_expected_output_tree = dt.flatten_to_qual_names(test.expected_output_tree)
 
-    for result, expected in zip(
-        flat_result.values(), flat_expected_output_tree.values()
-    ):
-        assert_array_almost_equal(result, expected, decimal=2)
+    for col, actual in flat_result.items():
+        assert_array_almost_equal(actual, flat_expected_output_tree[col], decimal=2)

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -115,6 +115,7 @@ def compute_taxes_and_transfers(
             k: v for k, v in ttsim_objects.items() if isinstance(v, ParamsFunction)
         },
     )
+
     # Flatten nested objects to qualified names
     all_targets = set(dt.qual_names(targets_tree))
     params_targets = {t for t in all_targets if t in processed_params_tree}

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -333,7 +333,7 @@ def combine_policy_functions_and_derived_functions(
     )
     out = {**aggregate_by_group_functions, **out}
 
-    _fail_if_targets_not_in_functions(
+    _fail_if_function_targets_not_in_functions(
         functions=out,
         targets=targets,
     )
@@ -341,7 +341,7 @@ def combine_policy_functions_and_derived_functions(
     return out
 
 
-def _fail_if_targets_not_in_functions(
+def _fail_if_function_targets_not_in_functions(
     functions: QualNameTTSIMFunctionDict,
     targets: QualNameTargetList,
 ) -> None:

--- a/src/ttsim/compute_taxes_and_transfers.py
+++ b/src/ttsim/compute_taxes_and_transfers.py
@@ -139,7 +139,7 @@ def compute_taxes_and_transfers(
     )
     functions_with_partialled_parameters = _partial_parameters_to_functions(
         functions=functions_with_rounding_specs,
-        params=environment.params,
+        processed_params=environment.params,
     )
     functions_with_partialled_parameters = _partial_params_to_functions(
         functions=functions_with_partialled_parameters,
@@ -288,7 +288,7 @@ def combine_policy_functions_and_derived_functions(
 
     Parameters
     ----------
-    functions
+    ttsim_objects
         Dict with qualified function names as keys and functions with qualified
         arguments as values.
     targets
@@ -322,13 +322,17 @@ def combine_policy_functions_and_derived_functions(
     )
     out = {**aggregate_by_group_functions, **out}
 
-    _fail_if_targets_not_in_functions(functions=out, targets=targets)
+    _fail_if_targets_not_in_functions(
+        functions=out,
+        targets=targets,
+    )
 
     return out
 
 
 def _fail_if_targets_not_in_functions(
-    functions: QualNameTTSIMFunctionDict, targets: QualNameTargetList
+    functions: QualNameTTSIMFunctionDict,
+    targets: QualNameTargetList,
 ) -> None:
     """Fail if some target is not among functions.
 
@@ -441,7 +445,7 @@ def _process_params_tree(
 
 def _partial_parameters_to_functions(
     functions: QualNameTTSIMFunctionDict,
-    params: QualNameProcessedParamDict,
+    processed_params: QualNameProcessedParamDict,
 ) -> QualNameTTSIMFunctionDict:
     """Round and partial parameters into functions.
 
@@ -465,9 +469,9 @@ def _partial_parameters_to_functions(
     for name, function in functions.items():
         arguments = get_names_of_required_arguments(function)
         partial_params = {
-            arg: params[key]
+            arg: processed_params[key]
             for arg in arguments
-            for key in params
+            for key in processed_params
             if arg.endswith(f"{key}_params")
         }
         if partial_params:

--- a/src/ttsim/plot_dag.py
+++ b/src/ttsim/plot_dag.py
@@ -105,7 +105,7 @@ def plot_dag(
         functions=partition_tree_by_reference_tree(
             tree_to_partition=functions_not_overridden, reference_tree=dag.nodes
         )[0],
-        params=environment.params,
+        processed_params=environment.params,
     )
 
     input_structure = dt.create_input_structure_tree(

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -413,11 +413,12 @@ def test_create_agg_by_group_functions(
         ({"foo__baz": some_x}, {"foo__bar": None}, "('foo', 'bar')"),
     ],
 )
-def test_fail_if_targets_are_not_among_functions(
-    functions, targets, expected_error_match
-):
+def test__fail_if_targets_not_in_functions(functions, targets, expected_error_match):
     with pytest.raises(ValueError) as e:
-        _fail_if_targets_not_in_functions(functions, targets)
+        _fail_if_targets_not_in_functions(
+            functions=functions,
+            targets=targets,
+        )
     assert expected_error_match in str(e.value)
 
 
@@ -469,7 +470,7 @@ def test_derived_aggregation_functions_are_in_correct_namespace(
     assert expected in result
 
 
-def test_output_as_tree(minimal_input_data):
+def test_output_is_tree(minimal_input_data):
     environment = PolicyEnvironment(
         {
             "p_id": p_id,
@@ -487,6 +488,40 @@ def test_output_as_tree(minimal_input_data):
     assert isinstance(out, dict)
     assert "some_func" in out["module"]
     assert isinstance(out["module"]["some_func"], TTSIMArray)
+
+
+def test_params_target_is_allowed(minimal_input_data):
+    environment = PolicyEnvironment(
+        raw_objects_tree={
+            "p_id": p_id,
+            "module": {"some_func": some_func},
+        },
+        params_tree={
+            "some_param": ScalarTTSIMParam(
+                value=1,
+                leaf_name="some_param",
+                start_date="2025-01-01",
+                end_date="2025-12-31",
+                unit="Euros",
+                reference_period="Year",
+                name={"de": "Ein Parameter", "en": "Some parameter"},
+                description={"de": "Ein Parameter", "en": "Some parameter"},
+                note=None,
+                reference=None,
+            ),
+        },
+    )
+
+    out = compute_taxes_and_transfers(
+        data_tree=minimal_input_data,
+        environment=environment,
+        targets_tree={"some_param": None, "module": {"some_func": None}},
+        jit=jit,
+    )
+
+    assert isinstance(out, dict)
+    assert "some_param" in out
+    assert out["some_param"] == 1
 
 
 def test_warn_if_functions_and_columns_overlap():

--- a/tests/ttsim/test_compute_taxes_and_transfers.py
+++ b/tests/ttsim/test_compute_taxes_and_transfers.py
@@ -32,9 +32,9 @@ from ttsim import (
 )
 from ttsim.compute_taxes_and_transfers import (
     _fail_if_foreign_keys_are_invalid_in_data,
+    _fail_if_function_targets_not_in_functions,
     _fail_if_group_variables_not_constant_within_groups,
     _fail_if_p_id_is_non_unique,
-    _fail_if_targets_not_in_functions,
     _get_top_level_namespace,
     _partial_params_to_functions,
     _process_params_tree,
@@ -413,9 +413,11 @@ def test_create_agg_by_group_functions(
         ({"foo__baz": some_x}, {"foo__bar": None}, "('foo', 'bar')"),
     ],
 )
-def test__fail_if_targets_not_in_functions(functions, targets, expected_error_match):
+def test__fail_if_function_targets_not_in_functions(
+    functions, targets, expected_error_match
+):
     with pytest.raises(ValueError) as e:
-        _fail_if_targets_not_in_functions(
+        _fail_if_function_targets_not_in_functions(
             functions=functions,
             targets=targets,
         )

--- a/tests/ttsim/test_import_version.py
+++ b/tests/ttsim/test_import_version.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import sys
 
+import pytest
+
 import ttsim
 
 
+@pytest.mark.xfail(reason="Requires own package.")
 def test_import():
     assert hasattr(ttsim, "__version__")
 


### PR DESCRIPTION
We allow params and columns to be largely interchangeable now. However, when parameters are asked for as targets, we cannot pass them into dags because dags will not look for targets among function inputs.

Solution: In `compute_taxes_and_transfers`, separate `functions_targets` and `params_targets`. Then merge "results" before returning.