### PR TITLE
Apply `ConsecutiveInt`-type to EstG Abzüge and Kindergeld

### DIFF
--- a/src/_gettsim/einkommensteuer/abzüge/alter.py
+++ b/src/_gettsim/einkommensteuer/abzüge/alter.py
@@ -48,11 +48,7 @@ def altersfreibetrag_y_bis_2004(
     return out
 
 
-@policy_function(
-    start_date="2005-01-01",
-    leaf_name="altersfreibetrag_y",
-    vectorization_strategy="loop",
-)
+@policy_function(start_date="2005-01-01", leaf_name="altersfreibetrag_y")
 def altersfreibetrag_y_ab_2005(
     alter: int,
     geburtsjahr: int,

--- a/src/_gettsim/einkommensteuer/abzüge/alter.py
+++ b/src/_gettsim/einkommensteuer/abzüge/alter.py
@@ -22,8 +22,8 @@ def altersfreibetrag_y_bis_2004(
     einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_y: float,
     einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_y: float,
     altersentlastungsbetrag_altersgrenze: int,
-    maximaler_altersentlastungsbetrag_einheitlich: float,
-    altersentlastungsquote_einheitlich: float,
+    maximaler_altersentlastungsbetrag: float,
+    altersentlastungsquote: float,
 ) -> float:
     """Calculate tax deduction allowance for elderly until 2004."""
     altersgrenze = altersentlastungsbetrag_altersgrenze
@@ -35,12 +35,12 @@ def altersfreibetrag_y_bis_2004(
     )
     if alter > altersgrenze:
         out = min(
-            altersentlastungsquote_einheitlich
+            altersentlastungsquote
             * (
                 einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y
                 + weiteres_einkommen
             ),
-            maximaler_altersentlastungsbetrag_einheitlich,
+            maximaler_altersentlastungsbetrag,
         )
     else:
         out = 0.0
@@ -62,9 +62,11 @@ def altersfreibetrag_y_ab_2005(
     altersentlastungsquote_gestaffelt: ConsecutiveInt1dLookupTableParamValue,
 ) -> float:
     """Calculate tax deduction allowance for elderly since 2005."""
-    betrag_max = maximaler_altersentlastungsbetrag_gestaffelt.values_to_look_up[
-        geburtsjahr - maximaler_altersentlastungsbetrag_gestaffelt.base_to_subtract
-    ]
+    maximaler_altersentlastungsbetrag = (
+        maximaler_altersentlastungsbetrag_gestaffelt.values_to_look_up[
+            geburtsjahr - maximaler_altersentlastungsbetrag_gestaffelt.base_to_subtract
+        ]
+    )
 
     einkommen_lohn = (
         0
@@ -82,7 +84,7 @@ def altersfreibetrag_y_ab_2005(
     ] * (einkommen_lohn + weiteres_einkommen)
 
     if alter > altersentlastungsbetrag_altersgrenze:
-        out = min(betrag, betrag_max)
+        out = min(betrag, maximaler_altersentlastungsbetrag)
     else:
         out = 0.0
 

--- a/src/_gettsim/einkommensteuer/abzüge/alter.py
+++ b/src/_gettsim/einkommensteuer/abzüge/alter.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
-from ttsim import policy_function
-from ttsim.config import numpy_or_jax as np
+from typing import TYPE_CHECKING
+
+from ttsim import (
+    get_consecutive_int_1d_lookup_table_param_value,
+    param_function,
+    policy_function,
+)
+
+if TYPE_CHECKING:
+    from ttsim import ConsecutiveInt1dLookupTableParamValue
 
 
 @policy_function(end_date="2004-12-31", leaf_name="altersfreibetrag_y")
@@ -54,19 +62,13 @@ def altersfreibetrag_y_ab_2005(
     einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_y: float,
     einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_y: float,
     altersentlastungsbetrag_altersgrenze: int,
-    maximaler_altersentlastungsbetrag_gestaffelt: dict[int, float],
-    altersentlastungsquote_gestaffelt: dict[int, float],
+    maximaler_altersentlastungsbetrag_gestaffelt: ConsecutiveInt1dLookupTableParamValue,
+    altersentlastungsquote_gestaffelt: ConsecutiveInt1dLookupTableParamValue,
 ) -> float:
     """Calculate tax deduction allowance for elderly since 2005."""
-    bins = sorted(maximaler_altersentlastungsbetrag_gestaffelt.keys())
-    if geburtsjahr <= 1939:
-        selected_bin = 1940
-    else:
-        selected_bin = bins[
-            np.searchsorted(np.asarray([*bins, np.inf]), geburtsjahr, side="right") - 1
-        ]
-
-    out_max = maximaler_altersentlastungsbetrag_gestaffelt[selected_bin]
+    betrag_max = maximaler_altersentlastungsbetrag_gestaffelt.values_to_look_up[
+        geburtsjahr - maximaler_altersentlastungsbetrag_gestaffelt.base_to_subtract
+    ]
 
     einkommen_lohn = (
         0
@@ -79,13 +81,74 @@ def altersfreibetrag_y_ab_2005(
         + einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_y,
         0.0,
     )
-    out_quote = altersentlastungsquote_gestaffelt[selected_bin] * (
-        einkommen_lohn + weiteres_einkommen
-    )
+    betrag = altersentlastungsquote_gestaffelt.values_to_look_up[
+        geburtsjahr - altersentlastungsquote_gestaffelt.base_to_subtract
+    ] * (einkommen_lohn + weiteres_einkommen)
 
     if alter > altersentlastungsbetrag_altersgrenze:
-        out = min(out_quote, out_max)
+        out = min(betrag, betrag_max)
     else:
         out = 0.0
 
     return out
+
+
+@param_function(start_date="2005-01-01")
+def altersentlastungsquote_gestaffelt(
+    raw_altersentlastungsquote_gestaffelt: dict[str | int, int | float],
+) -> ConsecutiveInt1dLookupTableParamValue:
+    """Convert the raw parameters for the age-based tax deduction allowance to a dict."""
+    spec = raw_altersentlastungsquote_gestaffelt.copy()
+    first_birthyear_to_consider: int = int(spec.pop("first_birthyear_to_consider"))
+    last_birthyear_to_consider: int = int(spec.pop("last_birthyear_to_consider"))
+    spec_int_float: dict[int, float] = {int(k): float(v) for k, v in spec.items()}
+    return get_consecutive_int_1d_lookup_table_with_filled_up_tails(
+        raw=spec_int_float,
+        left_tail_key=first_birthyear_to_consider,
+        right_tail_key=last_birthyear_to_consider,
+    )
+
+
+@param_function(start_date="2005-01-01")
+def maximaler_altersentlastungsbetrag_gestaffelt(
+    raw_maximaler_altersentlastungsbetrag_gestaffelt: dict[str | int, int | float],
+) -> ConsecutiveInt1dLookupTableParamValue:
+    """Convert the raw parameters for the age-based tax deduction allowance to a dict."""
+    spec = raw_maximaler_altersentlastungsbetrag_gestaffelt.copy()
+    first_birthyear_to_consider: int = int(spec.pop("first_birthyear_to_consider"))
+    last_birthyear_to_consider: int = int(spec.pop("last_birthyear_to_consider"))
+    spec_int_float: dict[int, float] = {int(k): float(v) for k, v in spec.items()}
+    return get_consecutive_int_1d_lookup_table_with_filled_up_tails(
+        raw=spec_int_float,
+        left_tail_key=first_birthyear_to_consider,
+        right_tail_key=last_birthyear_to_consider,
+    )
+
+
+def get_consecutive_int_1d_lookup_table_with_filled_up_tails(
+    raw: dict[int, float],
+    left_tail_key: int,
+    right_tail_key: int,
+) -> ConsecutiveInt1dLookupTableParamValue:
+    """Create a consecutive integer lookup table with filled tails.
+
+    This function takes a dictionary of consecutive integer keys and their corresponding
+    values, and extends it to include all integers between left_tail_key and
+    right_tail_key by filling the gaps with the minimum and maximum values from the
+    original dictionary.
+    """
+    min_key_in_spec = min(raw.keys())
+    max_key_in_spec = max(raw.keys())
+    assert all(isinstance(k, int) for k in raw)
+    assert len(list(raw.keys())) == max_key_in_spec - min_key_in_spec + 1, (
+        "Dictionary keys must be consecutive integers."
+    )
+    consecutive_dict_start = dict.fromkeys(
+        range(left_tail_key, min_key_in_spec), raw[min_key_in_spec]
+    )
+    consecutive_dict_end = dict.fromkeys(
+        range(max_key_in_spec + 1, right_tail_key + 1), raw[max_key_in_spec]
+    )
+    return get_consecutive_int_1d_lookup_table_param_value(
+        {**consecutive_dict_start, **raw, **consecutive_dict_end}
+    )

--- a/src/_gettsim/einkommensteuer/abzüge/alter.yaml
+++ b/src/_gettsim/einkommensteuer/abzüge/alter.yaml
@@ -18,7 +18,7 @@ altersentlastungsbetrag_altersgrenze:
   type: scalar
   1984-01-01:
     value: 64
-maximaler_altersentlastungsbetrag_einheitlich:
+maximaler_altersentlastungsbetrag:
   name:
     de: Höchstbetrag des Altersentlastungsbetrags
     en: Maximum Amount of Tax Credit for older employees.
@@ -90,7 +90,7 @@ raw_maximaler_altersentlastungsbetrag_gestaffelt:
     1973: 76
     1974: 38
     1975: 0
-altersentlastungsquote_einheitlich:
+altersentlastungsquote:
   name:
     de: Anteil des Altersentlastungsbetrags
     en: Income share deducted for older employees.

--- a/src/_gettsim/einkommensteuer/abzüge/alter.yaml
+++ b/src/_gettsim/einkommensteuer/abzüge/alter.yaml
@@ -39,8 +39,8 @@ maximaler_altersentlastungsbetrag_einheitlich:
   2002-01-01:
     value: 1908
   2005-01-01:
-    note: Ausschleichung per maximaler_altersentlastungsbetrag_gestaffelt
-maximaler_altersentlastungsbetrag_gestaffelt:
+    note: Ausschleichung per `raw_maximaler_altersentlastungsbetrag_gestaffelt`
+raw_maximaler_altersentlastungsbetrag_gestaffelt:
   name:
     de: Höchstbetrag des Altersentlastungsbetrags
     en: Maximum Amount of Tax Credit for older employees.
@@ -49,9 +49,11 @@ maximaler_altersentlastungsbetrag_gestaffelt:
     en: null
   unit: Euros
   reference_period: Year
-  type: dict
+  type: require_converter
   2005-01-01:
     reference: Artikel 1 G. v. 05.07.2004 BGBl. I S. 1427.
+    first_birthyear_to_consider: 1900
+    last_birthyear_to_consider: 2100
     1940: 1900
     1941: 1824
     1942: 1748
@@ -107,8 +109,8 @@ altersentlastungsquote_einheitlich:
   1984-01-01:
     value: 0.4
   2005-01-01:
-    note: Ausschleichung per altersentlastungsquote_gestaffelt
-altersentlastungsquote_gestaffelt:
+    note: Ausschleichung per `raw_altersentlastungsquote_gestaffelt`
+raw_altersentlastungsquote_gestaffelt:
   name:
     de: Anteil des Altersentlastungsbetrags
     en: Income share deducted for older employees.
@@ -123,9 +125,11 @@ altersentlastungsquote_gestaffelt:
       deducted. Since 2005, this share additionally depends on the birth year.
   unit: Share
   reference_period: null
-  type: dict
+  type: require_converter
   2005-01-01:
     reference: Artikel 1 G. v. 05.07.2004 BGBl. I S. 1427.
+    first_birthyear_to_consider: 1900
+    last_birthyear_to_consider: 2100
     1940: 0.4
     1941: 0.384
     1942: 0.368

--- a/src/_gettsim/einkommensteuer/einkommensteuer.py
+++ b/src/_gettsim/einkommensteuer/einkommensteuer.py
@@ -22,6 +22,7 @@ from ttsim.piecewise_polynomial import (
 )
 
 if TYPE_CHECKING:
+    from ttsim import ConsecutiveInt1dLookupTableParamValue
     from ttsim.typing import RawParam
 
 
@@ -171,10 +172,13 @@ def betrag_ohne_kinderfreibetrag_y_sn(
 def relevantes_kindergeld_mit_staffelung_m(
     anzahl_kindergeld_ansprüche_1: int,
     anzahl_kindergeld_ansprüche_2: int,
-    kindergeld__satz_gestaffelt: dict[int, float],
+    kindergeld__satz_nach_anzahl_kinder: ConsecutiveInt1dLookupTableParamValue,
 ) -> float:
     """Kindergeld relevant for income tax. For each parent, half of the actual
     Kindergeld claim is considered.
+
+    Note: It doesn't matter which parent actually receives the Kindergeld. For income
+    tax purposes, only the eligibility to claim Kindergeld is relevant.
 
     Source: § 31 Satz 4 EStG: "Bei nicht zusammenveranlagten Eltern wird der
     Kindergeldanspruch im Umfang des Kinderfreibetrags angesetzt."
@@ -185,10 +189,9 @@ def relevantes_kindergeld_mit_staffelung_m(
     if kindergeld_ansprüche == 0:
         relevantes_kindergeld = 0.0
     else:
-        relevantes_kindergeld = sum(
-            kindergeld__satz_gestaffelt[(min(i, max(kindergeld__satz_gestaffelt)))]
-            for i in range(1, kindergeld_ansprüche + 1)
-        )
+        relevantes_kindergeld = kindergeld__satz_nach_anzahl_kinder.values_to_look_up[
+            kindergeld_ansprüche - kindergeld__satz_nach_anzahl_kinder.base_to_subtract
+        ]
 
     return relevantes_kindergeld / 2
 
@@ -204,6 +207,9 @@ def relevantes_kindergeld_ohne_staffelung_m(
 ) -> float:
     """Kindergeld relevant for income tax. For each parent, half of the actual
     Kindergeld claim is considered.
+
+    Note: It doesn't matter which parent actually receives the Kindergeld. For income
+    tax purposes, only the eligibility to claim Kindergeld is relevant.
 
     Source: § 31 Satz 4 EStG: "Bei nicht zusammenveranlagten Eltern wird der
     Kindergeldanspruch im Umfang des Kinderfreibetrags angesetzt."

--- a/src/_gettsim/einkommensteuer/einkommensteuer.py
+++ b/src/_gettsim/einkommensteuer/einkommensteuer.py
@@ -164,11 +164,7 @@ def betrag_ohne_kinderfreibetrag_y_sn(
     )
 
 
-@policy_function(
-    end_date="2022-12-31",
-    leaf_name="relevantes_kindergeld_m",
-    vectorization_strategy="loop",
-)
+@policy_function(end_date="2022-12-31", leaf_name="relevantes_kindergeld_m")
 def relevantes_kindergeld_mit_staffelung_m(
     anzahl_kindergeld_ansprüche_1: int,
     anzahl_kindergeld_ansprüche_2: int,

--- a/src/_gettsim/einkommensteuer/einkommensteuer.py
+++ b/src/_gettsim/einkommensteuer/einkommensteuer.py
@@ -182,14 +182,12 @@ def relevantes_kindergeld_mit_staffelung_m(
     """
     kindergeld_ansprüche = anzahl_kindergeld_ansprüche_1 + anzahl_kindergeld_ansprüche_2
 
-    if kindergeld_ansprüche == 0:
-        relevantes_kindergeld = 0.0
-    else:
-        relevantes_kindergeld = kindergeld__satz_nach_anzahl_kinder.values_to_look_up[
+    return (
+        kindergeld__satz_nach_anzahl_kinder.values_to_look_up[
             kindergeld_ansprüche - kindergeld__satz_nach_anzahl_kinder.base_to_subtract
         ]
-
-    return relevantes_kindergeld / 2
+        / 2
+    )
 
 
 @policy_function(

--- a/src/_gettsim/kindergeld/kindergeld.py
+++ b/src/_gettsim/kindergeld/kindergeld.py
@@ -40,9 +40,7 @@ def betrag_ohne_staffelung_m(
     return satz * anzahl_ansprüche
 
 
-@policy_function(
-    end_date="2022-12-31", leaf_name="betrag_m", vectorization_strategy="loop"
-)
+@policy_function(end_date="2022-12-31", leaf_name="betrag_m")
 def betrag_gestaffelt_m(
     anzahl_ansprüche: int,
     satz_nach_anzahl_kinder: ConsecutiveInt1dLookupTableParamValue,

--- a/src/_gettsim/kindergeld/kindergeld.py
+++ b/src/_gettsim/kindergeld/kindergeld.py
@@ -51,15 +51,9 @@ def betrag_gestaffelt_m(
     being claimed for.
 
     """
-
-    if anzahl_ansprüche == 0:
-        sum_kindergeld = 0.0
-    else:
-        sum_kindergeld = satz_nach_anzahl_kinder.values_to_look_up[
-            anzahl_ansprüche - satz_nach_anzahl_kinder.base_to_subtract
-        ]
-
-    return sum_kindergeld
+    return satz_nach_anzahl_kinder.values_to_look_up[
+        anzahl_ansprüche - satz_nach_anzahl_kinder.base_to_subtract
+    ]
 
 
 @policy_function(
@@ -159,5 +153,5 @@ def satz_nach_anzahl_kinder(
         for k in range(max_num_children_in_spec + 1, max_num_children)
     }
     return get_consecutive_int_1d_lookup_table_param_value(
-        {**base_spec, **extended_spec}
+        {0: 0.0, **base_spec, **extended_spec}
     )

--- a/src/_gettsim/kindergeld/kindergeld.yaml
+++ b/src/_gettsim/kindergeld/kindergeld.yaml
@@ -36,7 +36,7 @@ satz_gestaffelt:
     en: null
   unit: Euros
   reference_period: Month
-  type: dict
+  type: require_converter
   1975-01-01:
     1: 26
     2: 36

--- a/src/_gettsim/kinderzuschlag/kinderzuschlag.py
+++ b/src/_gettsim/kinderzuschlag/kinderzuschlag.py
@@ -10,12 +10,13 @@ if TYPE_CHECKING:
     from _gettsim.param_types import (
         ExistenzminimumNachAufwendungenMitBildungUndTeilhabe,
     )
+    from ttsim import ConsecutiveInt1dLookupTableParamValue
 
 
 @param_function(start_date="2021-01-01", end_date="2022-12-31", leaf_name="satz")
 def satz_mit_gestaffeltem_kindergeld(
     existenzminimum: ExistenzminimumNachAufwendungenMitBildungUndTeilhabe,
-    kindergeld__satz_gestaffelt: dict[int, float],
+    kindergeld__satz_nach_anzahl_kinder: ConsecutiveInt1dLookupTableParamValue,
     satz_vorjahr_ohne_kindersofortzuschlag: float,
 ) -> float:
     """Prior to 2021, the maximum amount of the Kinderzuschlag was specified directly in
@@ -34,7 +35,9 @@ def satz_mit_gestaffeltem_kindergeld(
             + existenzminimum.heizkosten.kind
         )
         / 12
-        - kindergeld__satz_gestaffelt[1],
+        - kindergeld__satz_nach_anzahl_kinder.values_to_look_up[
+            1 - kindergeld__satz_nach_anzahl_kinder.base_to_subtract
+        ],
         satz_vorjahr_ohne_kindersofortzuschlag,
     )
 

--- a/src/_gettsim/unterhaltsvorschuss/unterhaltsvorschuss.py
+++ b/src/_gettsim/unterhaltsvorschuss/unterhaltsvorschuss.py
@@ -15,7 +15,7 @@ from ttsim import (
 )
 
 if TYPE_CHECKING:
-    from ttsim import RawParam
+    from ttsim import ConsecutiveInt1dLookupTableParamValue, RawParam
     from ttsim.typing import TTSIMArray
 
 
@@ -105,10 +105,12 @@ def kindergeld_erstes_kind_ohne_staffelung_m(
 
 @param_function(end_date="2022-12-31", leaf_name="kindergeld_erstes_kind_m")
 def kindergeld_erstes_kind_gestaffelt_m(
-    kindergeld__satz_gestaffelt: dict[int, float],
+    kindergeld__satz_nach_anzahl_kinder: ConsecutiveInt1dLookupTableParamValue,
 ) -> float:
     """Kindergeld for first child when Kindergeld depends on number of children."""
-    return kindergeld__satz_gestaffelt[1]
+    return kindergeld__satz_nach_anzahl_kinder.values_to_look_up[
+        1 - kindergeld__satz_nach_anzahl_kinder.base_to_subtract
+    ]
 
 
 @policy_function(


### PR DESCRIPTION
### What problem do you want to solve?

Partly closes the `ConsecutiveInt`-type section of #938 (everything except for `raw_max_miete_m_nach_baujahr`).

To be discussed: Do we want to find a general solution for my provisional implementation of `get_consecutive_int_1d_lookup_table_with_filled_up_tails`? I don't think we need it somewhere else (as of now) so I think dealing with it right there is fine?
