### PR TITLE
Apply phase in parameters for EM Rente

### DIFF
--- a/src/_gettsim/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
@@ -65,7 +65,7 @@ altersgrenze_gestaffelt:
       annual precision.
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout
+  type: birth_year_based_phase_inout_of_age_thresholds
   2014-06-23:
     reference: RV-Leistungsverbesserungsgesetz 2014. BGBl. I S. 787 2014
     first_birthyear_to_consider: 1900

--- a/src/_gettsim/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/besonders_langjährig/altersgrenze.yaml
@@ -65,11 +65,11 @@ altersgrenze_gestaffelt:
       annual precision.
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout_of_age_thresholds
+  type: year_based_phase_inout_of_age_thresholds
   2014-06-23:
     reference: RV-Leistungsverbesserungsgesetz 2014. BGBl. I S. 787 2014
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2031
+    first_year_to_consider: 1900
+    last_year_to_consider: 2031
     1952:
       years: 63
       months: 0

--- a/src/_gettsim/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
@@ -53,7 +53,7 @@ altersgrenze_gestaffelt:
       1945.
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
@@ -497,7 +497,7 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.sozialgesetzbuch-sgb.de/sgbvi/237a.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.

--- a/src/_gettsim/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/für_frauen/altersgrenze.yaml
@@ -53,12 +53,12 @@ altersgrenze_gestaffelt:
       1945.
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1940:
       12:
         years: 60
@@ -258,8 +258,8 @@ altersgrenze_gestaffelt:
   1996-09-27:
     reference: Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461
     note: Increase of FRA accelerated with exemption (Vertrauensschutz).
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1939:
       12:
         years: 60
@@ -497,12 +497,12 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.sozialgesetzbuch-sgb.de/sgbvi/237a.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1948:
       12:
         years: 60

--- a/src/_gettsim/sozialversicherung/rente/altersrente/langjährig/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/langjährig/altersgrenze.yaml
@@ -35,12 +35,12 @@ altersgrenze_gestaffelt:
       https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/242-altersrente-fuer-langjaehrig-versicherte-altersgrenzen.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 63 to 65 for birth cohort 1938-1943.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2100
+    first_year_to_consider: 1900
+    last_year_to_consider: 2100
     1937:
       12:
         years: 63
@@ -126,8 +126,8 @@ altersgrenze_gestaffelt:
   1996-09-27:
     reference: Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461 1996
     note: FRA increase accelerated.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2100
+    first_year_to_consider: 1900
+    last_year_to_consider: 2100
     1936:
       12:
         years: 63
@@ -209,8 +209,8 @@ altersgrenze_gestaffelt:
   2007-04-20:
     reference: RV-Altersgrenzenanpassungsgesetz 2007. BGBl. I S. 554 2007
     note: Increase of FRA from 65 to 67 for birth cohort 1949-1963.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2100
+    first_year_to_consider: 1900
+    last_year_to_consider: 2100
     1948:
       12:
         years: 65
@@ -341,12 +341,12 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.sozialgesetzbuch-sgb.de/sgbvi/236.html
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout_of_age_thresholds
+  type: year_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Early retirement age decreased from 63 to 62 starting from birth cohort 1944.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2100
+    first_year_to_consider: 1900
+    last_year_to_consider: 2100
     1943:
       years: 63
       months: 0

--- a/src/_gettsim/sozialversicherung/rente/altersrente/langjährig/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/langjährig/altersgrenze.yaml
@@ -35,7 +35,7 @@ altersgrenze_gestaffelt:
       https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/242-altersrente-fuer-langjaehrig-versicherte-altersgrenzen.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 63 to 65 for birth cohort 1938-1943.
@@ -341,7 +341,7 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.sozialgesetzbuch-sgb.de/sgbvi/236.html
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout
+  type: birth_year_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Early retirement age decreased from 63 to 62 starting from birth cohort 1944.

--- a/src/_gettsim/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
@@ -44,7 +44,7 @@ altersgrenze_gestaffelt:
       is higher or lower unless special regulations apply.
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout_of_age_thresholds
+  type: year_based_phase_inout_of_age_thresholds
   2007-04-20:
     reference: RV-Altersgrenzenanpassungsgesetz 20.04.2007. BGBl. I S. 554
     note: >-
@@ -52,8 +52,8 @@ altersgrenze_gestaffelt:
       Vertrauensschutz (Art. 56) applies for birth cohorts before 1955 who were in
       Altersteilzeit before January 1st, 2007 or received "Anpassungsgeld für
       entlassene Arbeitnehmer des Bergbaus".
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2031
+    first_year_to_consider: 1900
+    last_year_to_consider: 2031
     1946:
       years: 65
       months: 0

--- a/src/_gettsim/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/regelaltersrente/altersgrenze.yaml
@@ -44,7 +44,7 @@ altersgrenze_gestaffelt:
       is higher or lower unless special regulations apply.
   unit: Years
   reference_period: null
-  type: birth_year_based_phase_inout
+  type: birth_year_based_phase_inout_of_age_thresholds
   2007-04-20:
     reference: RV-Altersgrenzenanpassungsgesetz 20.04.2007. BGBl. I S. 554
     note: >-

--- a/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
@@ -38,7 +38,7 @@ altersgrenze_gestaffelt:
       https://www.gesetze-im-internet.de/sgb_6/__237.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
@@ -650,7 +650,7 @@ altersgrenze_gestaffelt_vertrauensschutz:
       the age threshold.
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1996-07-29:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: >-
@@ -758,7 +758,7 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.buzer.de/Anlage_19_SGB_VI.htm
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout
+  type: birth_month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.

--- a/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/altersrente/wegen_arbeitslosigkeit/altersgrenze.yaml
@@ -38,12 +38,12 @@ altersgrenze_gestaffelt:
       https://www.gesetze-im-internet.de/sgb_6/__237.html
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of full retirement age from 60 to 65 for birth cohort 1941-1952.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1940:
       12:
         years: 60
@@ -240,8 +240,8 @@ altersgrenze_gestaffelt:
   1996-07-29:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: Increase of full retirement age from 60 to 65 for birth cohort 1937-1952.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1936:
       12:
         years: 60
@@ -440,8 +440,8 @@ altersgrenze_gestaffelt:
   1996-09-27:
     reference: Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461 1996
     note: Increase of full retirement age from 60 to 65 for birth cohort 1937-1941.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1936:
       12:
         years: 60
@@ -650,7 +650,7 @@ altersgrenze_gestaffelt_vertrauensschutz:
       the age threshold.
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1996-07-29:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: >-
@@ -658,8 +658,8 @@ altersgrenze_gestaffelt_vertrauensschutz:
       covered under Vertrauensschutz. The Vertrauensschutzregel was not revoked under
       the subsequent Wachstums- und Beschäftigungsförderungsgesetz 1996. BGBl. I S. 1461
       1996.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1940:
       12:
         years: 60
@@ -758,12 +758,12 @@ altersgrenze_vorzeitig_gestaffelt:
       https://www.buzer.de/Anlage_19_SGB_VI.htm
   unit: Years
   reference_period: null
-  type: birth_month_based_phase_inout_of_age_thresholds
+  type: month_based_phase_inout_of_age_thresholds
   1989-12-18:
     reference: Rentenreformgesetz 1992. BGBl. I S. 2261 1989 § 41
     note: Increase of early retirement age from 60 to 62 for birth cohort 1949-1952.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1948:
       12:
         years: 60
@@ -847,8 +847,8 @@ altersgrenze_vorzeitig_gestaffelt:
   1996-07-29:
     reference: Ruhestandsförderungsgesetz 1996. BGBl. I S. 1078 1996.
     note: Increase of early retirement age as before. (§ 237 SGB VI  Abs.5).
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 2029
+    first_year_to_consider: 1900
+    last_year_to_consider: 2029
     1948:
       12:
         years: 60
@@ -935,8 +935,8 @@ altersgrenze_vorzeitig_gestaffelt:
   2004-07-26:
     reference: RV-Nachhaltigkeitsgesetz 2004. BGBl. I S. 1791 2004
     note: Increase of the early retirement age from 60 to 63 for birth cohort 1946-1948.
-    first_birthyear_to_consider: 1900
-    last_birthyear_to_consider: 1951
+    first_year_to_consider: 1900
+    last_year_to_consider: 1951
     1945:
       12:
         years: 60

--- a/src/_gettsim/sozialversicherung/rente/erwerbsminderung/altersgrenze.yaml
+++ b/src/_gettsim/sozialversicherung/rente/erwerbsminderung/altersgrenze.yaml
@@ -1,5 +1,5 @@
 ---
-altersgrenze_allgemein:
+altersgrenze:
   name:
     de: Altersgrenze für Erwerbsminderungsrente
     en: Statutory retirement age for disability pension
@@ -7,55 +7,110 @@ altersgrenze_allgemein:
     de: >-
       § 77 SGB VI
       Altersgrenze bis zu der man die Erwerbsminderungsrente ohne Abzüge in
-      Anspruch nehmen kann. Bis 2012 lag die Altersgrenze bei 63. Ab dann
-      schrittweise Anhebung bis 65.
-      https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/295-erwerbsminderungsrente-und-rentenabschlaege.html
+      Anspruch nehmen kann.
     en: >-
       § 77 SGB VI
       Age limit up to which one can claim the public disability insurance without
-      deductions. Up to 2012, the standard retirement age was 63.
-      From then on gradual increase until 65.
+      deductions.
   unit: Years
   reference_period: null
   type: scalar
   2001-01-01:
     value: 63
+altersgrenze_gestaffelt:
+  name:
+    de: Altersgrenze für Erwerbsminderungsrente
+    en: Statutory retirement age for disability pension
+  description:
+    de: >-
+      § 77 SGB VI / § 264d SGB VI
+      Altersgrenze bis zu der man die Erwerbsminderungsrente ohne Abzüge in
+      Anspruch nehmen kann. Bis 2012 lag die Altersgrenze bei 63. Ab dann
+      schrittweise Anhebung bis 65.
+      https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/295-erwerbsminderungsrente-und-rentenabschlaege.html
+    en: >-
+      § 77 SGB VI / § 264d SGB VI
+      Age limit up to which one can claim the public disability insurance without
+      deductions. Up to 2012, the standard retirement age was 63.
+      From then on gradual increase until 65.
+  unit: Years
+  reference_period: null
+  type: month_based_phase_inout_of_age_thresholds
   2012-01-01:
-    value: 63.083333
-  2012-02-01:
-    value: 63.166666
-  2012-03-01:
-    value: 63.25
-  2012-04-01:
-    value: 63.333333
-  2012-05-01:
-    value: 63.416666
-  2012-06-01:
-    value: 63.5
-  2013-01-01:
-    value: 63.583333
-  2014-01-01:
-    value: 63.666666
-  2015-01-01:
-    value: 63.75
-  2016-01-01:
-    value: 63.833333
-  2017-01-01:
-    value: 63.916666
-  2018-01-01:
-    value: 64
-  2019-01-01:
-    value: 64.166666
-  2020-01-01:
-    value: 64.333333
-  2021-01-01:
-    value: 64.5
-  2022-01-01:
-    value: 64.666666
-  2023-01-01:
-    value: 64.833333
-  2024-01-01:
-    value: 65
+    reference: Art. 4 G. v. 05.12.2012 BGBl. I S. 2474
+    first_year_to_consider: 1990
+    last_year_to_consider: 2030
+    2011:
+      12:
+        years: 63
+        months: 0
+    2012:
+      1:
+        years: 63
+        months: 1
+      2:
+        years: 63
+        months: 2
+      3:
+        years: 63
+        months: 3
+      4:
+        years: 63
+        months: 4
+      5:
+        years: 63
+        months: 5
+      6:
+        years: 63
+        months: 6
+    2013:
+      1:
+        years: 63
+        months: 7
+    2014:
+      1:
+        years: 63
+        months: 8
+    2015:
+      1:
+        years: 63
+        months: 9
+    2016:
+      1:
+        years: 63
+        months: 10
+    2017:
+      1:
+        years: 63
+        months: 11
+    2018:
+      1:
+        years: 64
+        months: 0
+    2019:
+      1:
+        years: 64
+        months: 2
+    2020:
+      1:
+        years: 64
+        months: 4
+    2021:
+      1:
+        years: 64
+        months: 6
+    2022:
+      1:
+        years: 64
+        months: 8
+    2023:
+      1:
+        years: 64
+        months: 10
+    2024:
+      1:
+        years: 65
+        months: 0
 altersgrenze_langjährig_versichert:
   # TODO(@MImmesberger): Probably delete this.
   # https://github.com/iza-institute-of-labor-economics/gettsim/issues/838

--- a/src/_gettsim/sozialversicherung/rente/erwerbsminderung/erwerbsminderung.py
+++ b/src/_gettsim/sozialversicherung/rente/erwerbsminderung/erwerbsminderung.py
@@ -144,8 +144,41 @@ def entgeltpunkte_ost(
     )
 
 
-@policy_function(start_date="2001-01-01")
-def zurechnungszeit(
+@policy_function(
+    start_date="2000-12-23", end_date="2014-06-30", leaf_name="zurechnungszeit"
+)
+def zurechnungszeit_mit_gestaffelter_altersgrenze_bis_06_2014(
+    mean_entgeltpunkte_pro_bewertungsmonat: float,
+    sozialversicherung__rente__alter_bei_renteneintritt: float,
+    sozialversicherung__rente__jahr_renteneintritt: int,
+    sozialversicherung__rente__monat_renteneintritt: int,
+    zurechnungszeitgrenze_gestaffelt: ConsecutiveInt1dLookupTableParamValue,
+) -> float:
+    """Additional Entgeltpunkte accumulated through "Zurechnungszeit".
+
+    Provides the Entgeltpunkt-basis for calculation of the Erwerbsminderungsrente.
+
+    In the case of the public disability insurance, pensioners are credited with
+    additional earning points. They receive their average earned income points for each
+    year between their age of retirement and the "zurechnungszeitgrenze".
+    """
+    claiming_month_since_ad = (
+        sozialversicherung__rente__jahr_renteneintritt * 12
+        + sozialversicherung__rente__monat_renteneintritt
+    )
+    altersgrenze_zurechnungszeit = zurechnungszeitgrenze_gestaffelt.values_to_look_up[
+        claiming_month_since_ad - zurechnungszeitgrenze_gestaffelt.base_to_subtract
+    ]
+    return (
+        altersgrenze_zurechnungszeit
+        - (sozialversicherung__rente__alter_bei_renteneintritt)
+    ) * mean_entgeltpunkte_pro_bewertungsmonat
+
+
+@policy_function(
+    start_date="2014-07-01", end_date="2017-07-16", leaf_name="zurechnungszeit"
+)
+def zurechnungszeit_mit_einheitlicher_altersgrenze(
     mean_entgeltpunkte_pro_bewertungsmonat: float,
     sozialversicherung__rente__alter_bei_renteneintritt: float,
     zurechnungszeitgrenze: float,
@@ -160,6 +193,35 @@ def zurechnungszeit(
     """
     return (
         zurechnungszeitgrenze - (sozialversicherung__rente__alter_bei_renteneintritt)
+    ) * mean_entgeltpunkte_pro_bewertungsmonat
+
+
+@policy_function(start_date="2017-07-17", leaf_name="zurechnungszeit")
+def zurechnungszeit_mit_gestaffelter_altersgrenze_ab_07_2017(
+    mean_entgeltpunkte_pro_bewertungsmonat: float,
+    sozialversicherung__rente__alter_bei_renteneintritt: float,
+    sozialversicherung__rente__jahr_renteneintritt: int,
+    sozialversicherung__rente__monat_renteneintritt: int,
+    zurechnungszeitgrenze_gestaffelt: ConsecutiveInt1dLookupTableParamValue,
+) -> float:
+    """Additional Entgeltpunkte accumulated through "Zurechnungszeit".
+
+    Provides the Entgeltpunkt-basis for calculation of the Erwerbsminderungsrente.
+
+    In the case of the public disability insurance, pensioners are credited with
+    additional earning points. They receive their average earned income points for each
+    year between their age of retirement and the "zurechnungszeitgrenze".
+    """
+    claiming_month_since_ad = (
+        sozialversicherung__rente__jahr_renteneintritt * 12
+        + sozialversicherung__rente__monat_renteneintritt
+    )
+    altersgrenze_zurechnungszeit = zurechnungszeitgrenze_gestaffelt.values_to_look_up[
+        claiming_month_since_ad - zurechnungszeitgrenze_gestaffelt.base_to_subtract
+    ]
+    return (
+        altersgrenze_zurechnungszeit
+        - (sozialversicherung__rente__alter_bei_renteneintritt)
     ) * mean_entgeltpunkte_pro_bewertungsmonat
 
 

--- a/src/_gettsim/sozialversicherung/rente/erwerbsminderung/formel.yaml
+++ b/src/_gettsim/sozialversicherung/rente/erwerbsminderung/formel.yaml
@@ -1,127 +1,255 @@
 ---
 zurechnungszeitgrenze:
   name:
-    de: Zurechnungszeitgrenze
-    en: Supplementary time limit
+    de: Alter bis zu dem Zurechnungszeiten angerechnet werden
+    en: Age limit for the supplementary period of the public disability insurance
   description:
     de: >-
-      § 59 SGB VI
-      Altersgrenze für die Zurechnungszeit der Erwerbsminderungsrente.
-      Anhebung von 2020 bis 2027 um 1 Monat pro Kalendarjahr und ab 2028
-      jeweils 2 Monate bis 67 erreicht ist.
-      https://sozialversicherung-kompetent.de/rentenversicherung/leistungsrecht/295-erwerbsminderungsrente-und-rentenabschlaege.html
-      For 2014 reform see: Artikel 1 Nr. 4 des RV-Leistungsverbesserungsgesetz vom
-      23. Juni 2014, BGBl. I, Seite 787
-      For the time before 2004 see (Anlage 23, p.1837):
-      https://www.bgbl.de/xaver/bgbl/text.xav?SID=&tf=xaver.component.Text_0&tocf=&qmf=&hlf=xaver.component.Hitlist_0&bk=bgbl&start=%2F%2F*%5B%40node_id%3D%27955873%27%5D&skin=pdf&tlevel=-2&nohist=1&sinst=23CF02AC
+      § 59 SGB VI (after July 2014)
+      Zurechnungszeiten werden bis zu dieser Altersgrenze gewährt.
     en: >-
-      § 59 SGB VI
-      Age limit for the supplementary period of the public disability insurance.
-      Increase from 2020 to 2027 by 1 month per year, and from 2028
-      by 2 months each year until 67 is reached.
+      § 59 SGB VI (after July 2014)
+      Supplementary periods are granted up to this age limit.
   unit: Years
   reference_period: null
   type: scalar
-  2001-01-01:
-    value: 62.916666
-  2001-02-01:
-    value: 62.833333
-  2001-03-01:
-    value: 62.75
-  2001-04-01:
-    value: 62.666666
-  2001-05-01:
-    value: 62.583333
-  2001-06-01:
-    value: 62.5
-  2001-07-01:
-    value: 62.416666
-  2001-08-01:
-    value: 62.333333
-  2001-09-01:
-    value: 62.25
-  2001-10-01:
-    value: 62.166666
-  2001-11-01:
-    value: 62.083333
-  2001-12-01:
-    value: 62
-  2002-01-01:
-    value: 61.916666
-  2002-02-01:
-    value: 61.833333
-  2002-03-01:
-    value: 61.75
-  2002-04-01:
-    value: 61.666666
-  2002-05-01:
-    value: 61.583333
-  2002-06-01:
-    value: 61.5
-  2002-07-01:
-    value: 61.416666
-  2002-08-01:
-    value: 61.333333
-  2002-09-01:
-    value: 61.25
-  2002-10-01:
-    value: 61.166666
-  2002-11-01:
-    value: 61.083333
-  2002-12-01:
-    value: 61
-  2003-01-01:
-    value: 60.916666
-  2003-02-01:
-    value: 60.833333
-  2003-03-01:
-    value: 60.75
-  2003-04-01:
-    value: 60.666666
-  2003-05-01:
-    value: 60.583333
-  2003-06-01:
-    value: 60.5
-  2003-07-01:
-    value: 60.416666
-  2003-08-01:
-    value: 60.333333
-  2003-09-01:
-    value: 60.25
-  2003-10-01:
-    value: 60.166666
-  2003-11-01:
-    value: 60.083333
-  2003-12-01:
-    value: 60
   2014-07-01:
     value: 62
-  2019-01-01:
-    value: 65.666666
-  2020-01-01:
-    value: 65.75
-  2021-01-01:
-    value: 65.833333
-  2022-01-01:
-    value: 65.916666
-  2023-01-01:
-    value: 66
-  2024-01-01:
-    value: 66.083333
-  2025-01-01:
-    value: 66.166666
-  2026-01-01:
-    value: 66.25
-  2027-01-01:
-    value: 66.333333
-  2028-01-01:
-    value: 66.5
-  2029-01-01:
-    value: 66.666666
-  2030-01-01:
-    value: 66.833333
-  2031-01-01:
-    value: 67
+  2017-07-17:
+    note: Claiming year and month based limit. See `zurechnungszeitgrenze`.
+    reference: G. v. 17.07.2017 BGBl. I S. 2509
+zurechnungszeitgrenze_gestaffelt:
+  name:
+    de: Alter bis zu dem Zurechnungszeiten angerechnet werden
+    en: Age limit for the supplementary period of the public disability insurance
+  description:
+    de: >-
+      § 253a (Anlage 23 bis 2014)
+      Zurechnungszeiten werden bis zu dieser Altersgrenze gewährt.
+    en: >-
+      § 253a (Anlage 23 until 2014)
+      Supplementary periods are granted up to this age limit.
+  unit: Years
+  reference_period: null
+  type: month_based_phase_inout_of_age_thresholds
+  2000-12-23:
+    reference: Anlage 23, G. v. 20.12.2000 BGBl. I S. 1827
+    first_year_to_consider: 1990
+    last_year_to_consider: 2030
+    2000:
+      12:
+        years: 63
+        months: 0
+    2001:
+      1:
+        years: 62
+        months: 11
+      2:
+        years: 62
+        months: 10
+      3:
+        years: 62
+        months: 9
+      4:
+        years: 62
+        months: 8
+      5:
+        years: 62
+        months: 7
+      6:
+        years: 62
+        months: 6
+      7:
+        years: 62
+        months: 5
+      8:
+        years: 62
+        months: 4
+      9:
+        years: 62
+        months: 3
+      10:
+        years: 62
+        months: 2
+      11:
+        years: 62
+        months: 1
+      12:
+        years: 62
+        months: 0
+    2002:
+      1:
+        years: 61
+        months: 11
+      2:
+        years: 61
+        months: 10
+      3:
+        years: 61
+        months: 9
+      4:
+        years: 61
+        months: 8
+      5:
+        years: 61
+        months: 7
+      6:
+        years: 61
+        months: 6
+      7:
+        years: 61
+        months: 5
+      8:
+        years: 61
+        months: 4
+      9:
+        years: 61
+        months: 3
+      10:
+        years: 61
+        months: 2
+      11:
+        years: 61
+        months: 1
+      12:
+        years: 61
+        months: 0
+    2003:
+      1:
+        years: 60
+        months: 11
+      2:
+        years: 60
+        months: 10
+      3:
+        years: 60
+        months: 9
+      4:
+        years: 60
+        months: 8
+      5:
+        years: 60
+        months: 7
+      6:
+        years: 60
+        months: 6
+      7:
+        years: 60
+        months: 5
+      8:
+        years: 60
+        months: 4
+      9:
+        years: 60
+        months: 3
+      10:
+        years: 60
+        months: 2
+      11:
+        years: 60
+        months: 1
+      12:
+        years: 60
+        months: 0
+  2014-07-01:
+    reference: Art. 1 Nr. 4 G. v. 23.06.2014 BGBl. I S. 787
+    note: Uniform age threshold of 62 years. See `zurechnungszeitgrenze`.
+  2017-07-17:
+    reference: G. v. 17.07.2017 BGBl. I S. 2509
+    first_year_to_consider: 1990
+    last_year_to_consider: 2030
+    2017:
+      12:
+        years: 62
+        months: 0
+    2018:
+      1:
+        years: 62
+        months: 3
+    2019:
+      1:
+        years: 62
+        months: 6
+    2020:
+      1:
+        years: 63
+        months: 0
+    2021:
+      1:
+        years: 63
+        months: 6
+    2022:
+      1:
+        years: 64
+        months: 0
+    2023:
+      1:
+        years: 64
+        months: 6
+    2024:
+      1:
+        years: 65
+        months: 0
+  2018-11-28:
+    reference: Art. 1 G. v. 28.11.2018 BGBl. I S. 2016
+    first_year_to_consider: 1990
+    last_year_to_consider: 2040
+    2018:
+      12:
+        years: 62
+        months: 3
+    2019:
+      1:
+        years: 65
+        months: 8
+    2020:
+      1:
+        years: 65
+        months: 9
+    2021:
+      1:
+        years: 65
+        months: 10
+    2022:
+      1:
+        years: 65
+        months: 11
+    2023:
+      1:
+        years: 66
+        months: 0
+    2024:
+      1:
+        years: 66
+        months: 1
+    2025:
+      1:
+        years: 66
+        months: 2
+    2026:
+      1:
+        years: 66
+        months: 3
+    2027:
+      1:
+        years: 66
+        months: 4
+    2028:
+      1:
+        years: 66
+        months: 6
+    2029:
+      1:
+        years: 66
+        months: 8
+    2030:
+      1:
+        years: 66
+        months: 10
+    2031:
+      1:
+        years: 67
+        months: 0
 min_zugangsfaktor:
   name:
     de: Kleinster möglicher Zugangsfaktor bei der Erwerbsminderungsrente

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/teilw_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/teilw_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 44.15686275
+    - 44.0
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1940_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1940_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 15.43875686
+    - 15.164534
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1941_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1941_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 19.08474576
+    - 18.813559
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1970_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1970_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 44.03351955
+    - 43.56424581005586
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2001-01-01/voll_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 30.70909091
+    - 30.490909
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2012-01-01/voll_erwerbsgemindert_birthyear_1990_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2012-01-01/voll_erwerbsgemindert_birthyear_1990_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/teilw_erwerbsgemindert_birthyear_1995_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/teilw_erwerbsgemindert_birthyear_1995_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -30,7 +30,7 @@ inputs:
     sozialversicherung__rente__jahr_renteneintritt:
       - 2018
     sozialversicherung__rente__monat_renteneintritt:
-      - 2
+      - 1
     sozialversicherung__rente__pflichtbeitragsmonate:
       - 60.0
     wohnort_ost:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 29.44
+    - 30.0
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1960_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1960_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 16.2035225
+    - 16.291585
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1970_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1970_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 25.6744186
+    - 25.813953
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1980_preliminary_products.yaml
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 29.38403042
+    - 29.543726
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1990_preliminary_products.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/erwerbsminderung/2018-01-01/voll_erwerbsgemindert_birthyear_1990_preliminary_products.yaml
@@ -2,7 +2,7 @@
 info:
   note: ''
   precision_atol: 0.01
-  source: Own calculations
+  source: Regression test.
 inputs:
   assumed:
     geburtsjahr:
@@ -40,7 +40,7 @@ outputs:
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_ost:
     - 0.0
   sozialversicherung__rente__erwerbsminderung__entgeltpunkte_west:
-    - 11.91366906
+    - 11.978417
   sozialversicherung__rente__erwerbsminderung__grundsätzlich_anspruchsberechtigt:
     - true
   sozialversicherung__rente__erwerbsminderung__rentenartfaktor:

--- a/src/ttsim/__init__.py
+++ b/src/ttsim/__init__.py
@@ -40,8 +40,8 @@ from ttsim.piecewise_polynomial import (
 from ttsim.plot_dag import plot_dag
 from ttsim.policy_environment import (
     PolicyEnvironment,
-    get_birth_month_based_phase_inout_param_value,
-    get_birth_year_based_phase_inout_param_value,
+    get_birth_month_based_phase_inout_of_age_thresholds_param_value,
+    get_birth_year_based_phase_inout_of_age_thresholds_param_value,
     get_consecutive_int_1d_lookup_table_param_value,
     get_consecutive_int_2d_lookup_table_param_value,
     set_up_policy_environment,
@@ -84,8 +84,8 @@ __all__ = [
     "compute_taxes_and_transfers",
     "create_data_tree_from_df",
     "create_time_conversion_functions",
-    "get_birth_month_based_phase_inout_param_value",
-    "get_birth_year_based_phase_inout_param_value",
+    "get_birth_month_based_phase_inout_of_age_thresholds_param_value",
+    "get_birth_year_based_phase_inout_of_age_thresholds_param_value",
     "get_consecutive_int_1d_lookup_table_param_value",
     "get_consecutive_int_2d_lookup_table_param_value",
     "get_piecewise_parameters",

--- a/src/ttsim/__init__.py
+++ b/src/ttsim/__init__.py
@@ -40,10 +40,10 @@ from ttsim.piecewise_polynomial import (
 from ttsim.plot_dag import plot_dag
 from ttsim.policy_environment import (
     PolicyEnvironment,
-    get_birth_month_based_phase_inout_of_age_thresholds_param_value,
-    get_birth_year_based_phase_inout_of_age_thresholds_param_value,
     get_consecutive_int_1d_lookup_table_param_value,
     get_consecutive_int_2d_lookup_table_param_value,
+    get_month_based_phase_inout_of_age_thresholds_param_value,
+    get_year_based_phase_inout_of_age_thresholds_param_value,
     set_up_policy_environment,
 )
 from ttsim.prepare_data import create_data_tree_from_df
@@ -84,11 +84,11 @@ __all__ = [
     "compute_taxes_and_transfers",
     "create_data_tree_from_df",
     "create_time_conversion_functions",
-    "get_birth_month_based_phase_inout_of_age_thresholds_param_value",
-    "get_birth_year_based_phase_inout_of_age_thresholds_param_value",
     "get_consecutive_int_1d_lookup_table_param_value",
     "get_consecutive_int_2d_lookup_table_param_value",
+    "get_month_based_phase_inout_of_age_thresholds_param_value",
     "get_piecewise_parameters",
+    "get_year_based_phase_inout_of_age_thresholds_param_value",
     "group_creation_function",
     "insert_path_and_value",
     "join",

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -49,8 +49,8 @@
             "piecewise_cubic",
             "consecutive_int_1d_lookup_table",
             "consecutive_int_2d_lookup_table",
-            "birth_month_based_phase_inout",
-            "birth_year_based_phase_inout",
+            "birth_month_based_phase_inout_of_age_thresholds",
+            "birth_year_based_phase_inout_of_age_thresholds",
             "require_converter"
           ]
         },

--- a/src/ttsim/params-schema.json
+++ b/src/ttsim/params-schema.json
@@ -49,8 +49,8 @@
             "piecewise_cubic",
             "consecutive_int_1d_lookup_table",
             "consecutive_int_2d_lookup_table",
-            "birth_month_based_phase_inout_of_age_thresholds",
-            "birth_year_based_phase_inout_of_age_thresholds",
+            "month_based_phase_inout_of_age_thresholds",
+            "year_based_phase_inout_of_age_thresholds",
             "require_converter"
           ]
         },

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -517,14 +517,18 @@ def get_one_param(  # noqa: PLR0911
             cleaned_spec["value"]
         )
         return ConsecutiveInt1dLookupTableParam(**cleaned_spec)
-    elif spec["type"] == "birth_month_based_phase_inout":
-        cleaned_spec["value"] = get_birth_month_based_phase_inout_param_value(
-            cleaned_spec["value"]
+    elif spec["type"] == "birth_month_based_phase_inout_of_age_thresholds":
+        cleaned_spec["value"] = (
+            get_birth_month_based_phase_inout_of_age_thresholds_param_value(
+                cleaned_spec["value"]
+            )
         )
         return ConsecutiveInt1dLookupTableParam(**cleaned_spec)
-    elif spec["type"] == "birth_year_based_phase_inout":
-        cleaned_spec["value"] = get_birth_year_based_phase_inout_param_value(
-            cleaned_spec["value"]
+    elif spec["type"] == "birth_year_based_phase_inout_of_age_thresholds":
+        cleaned_spec["value"] = (
+            get_birth_year_based_phase_inout_of_age_thresholds_param_value(
+                cleaned_spec["value"]
+            )
         )
         return ConsecutiveInt1dLookupTableParam(**cleaned_spec)
     elif spec["type"] == "require_converter":
@@ -646,10 +650,10 @@ def _year_fraction(r: dict[Literal["years", "months"], int]) -> float:
     return r["years"] + r["months"] / 12
 
 
-def get_birth_month_based_phase_inout_param_value(
+def get_birth_month_based_phase_inout_of_age_thresholds_param_value(
     raw: dict[str | int, Any],
 ) -> dict[int, float]:
-    """Get the parameters for birth month-based phase-in.
+    """Get the parameters for birth month-based phase-in/phase-out of age thresholds.
 
     Fills up months for which no parameters are given with the last given value.
     """
@@ -714,10 +718,10 @@ def get_birth_month_based_phase_inout_param_value(
     )
 
 
-def get_birth_year_based_phase_inout_param_value(
+def get_birth_year_based_phase_inout_of_age_thresholds_param_value(
     raw: dict[str | int, Any],
 ) -> dict[int, float]:
-    """Get the parameters for birth year-based phase-in.
+    """Get the parameters for birth year-based phase-in/phase-out of age thresholds.
 
     Requires all birth years to be given.
     """

--- a/src/ttsim/policy_environment.py
+++ b/src/ttsim/policy_environment.py
@@ -517,16 +517,16 @@ def get_one_param(  # noqa: PLR0911
             cleaned_spec["value"]
         )
         return ConsecutiveInt1dLookupTableParam(**cleaned_spec)
-    elif spec["type"] == "birth_month_based_phase_inout_of_age_thresholds":
+    elif spec["type"] == "month_based_phase_inout_of_age_thresholds":
         cleaned_spec["value"] = (
-            get_birth_month_based_phase_inout_of_age_thresholds_param_value(
+            get_month_based_phase_inout_of_age_thresholds_param_value(
                 cleaned_spec["value"]
             )
         )
         return ConsecutiveInt1dLookupTableParam(**cleaned_spec)
-    elif spec["type"] == "birth_year_based_phase_inout_of_age_thresholds":
+    elif spec["type"] == "year_based_phase_inout_of_age_thresholds":
         cleaned_spec["value"] = (
-            get_birth_year_based_phase_inout_of_age_thresholds_param_value(
+            get_year_based_phase_inout_of_age_thresholds_param_value(
                 cleaned_spec["value"]
             )
         )
@@ -650,10 +650,10 @@ def _year_fraction(r: dict[Literal["years", "months"], int]) -> float:
     return r["years"] + r["months"] / 12
 
 
-def get_birth_month_based_phase_inout_of_age_thresholds_param_value(
+def get_month_based_phase_inout_of_age_thresholds_param_value(
     raw: dict[str | int, Any],
 ) -> dict[int, float]:
-    """Get the parameters for birth month-based phase-in/phase-out of age thresholds.
+    """Get the parameters for month-based phase-in/phase-out of age thresholds.
 
     Fills up months for which no parameters are given with the last given value.
     """
@@ -675,29 +675,23 @@ def get_birth_month_based_phase_inout_of_age_thresholds_param_value(
                 lookup_table[m] = lookup_table[m - 1]
         return lookup_table
 
-    first_m_since_ad_to_consider = _m_since_ad(
-        y=raw.pop("first_birthyear_to_consider"), m=1
-    )
-    last_m_since_ad_to_consider = _m_since_ad(
-        y=raw.pop("last_birthyear_to_consider"), m=12
-    )
+    first_m_since_ad_to_consider = _m_since_ad(y=raw.pop("first_year_to_consider"), m=1)
+    last_m_since_ad_to_consider = _m_since_ad(y=raw.pop("last_year_to_consider"), m=12)
     assert all(isinstance(k, int) for k in raw)
-    first_birthyear_phase_inout: int = min(raw.keys())  # type: ignore[assignment]
-    first_birthmonth_phase_inout: int = min(raw[first_birthyear_phase_inout].keys())
+    first_year_phase_inout: int = min(raw.keys())  # type: ignore[assignment]
+    first_month_phase_inout: int = min(raw[first_year_phase_inout].keys())
     first_m_since_ad_phase_inout = _m_since_ad(
-        y=first_birthyear_phase_inout, m=first_birthmonth_phase_inout
+        y=first_year_phase_inout, m=first_month_phase_inout
     )
-    last_birthyear_phase_inout: int = max(raw.keys())  # type: ignore[assignment]
-    last_birthmonth_phase_inout: int = max(raw[last_birthyear_phase_inout].keys())
+    last_year_phase_inout: int = max(raw.keys())  # type: ignore[assignment]
+    last_month_phase_inout: int = max(raw[last_year_phase_inout].keys())
     last_m_since_ad_phase_inout = _m_since_ad(
-        y=last_birthyear_phase_inout, m=last_birthmonth_phase_inout
+        y=last_year_phase_inout, m=last_month_phase_inout
     )
     assert first_m_since_ad_to_consider <= first_m_since_ad_phase_inout
     assert last_m_since_ad_to_consider >= last_m_since_ad_phase_inout
     before_phase_inout: dict[int, float] = {
-        b_m: _year_fraction(
-            raw[first_birthyear_phase_inout][first_birthmonth_phase_inout]
-        )
+        b_m: _year_fraction(raw[first_year_phase_inout][first_month_phase_inout])
         for b_m in range(first_m_since_ad_to_consider, first_m_since_ad_phase_inout)
     }
     during_phase_inout: dict[int, float] = _fill_phase_inout(
@@ -706,9 +700,7 @@ def get_birth_month_based_phase_inout_of_age_thresholds_param_value(
         last_m_since_ad_phase_inout=last_m_since_ad_phase_inout,
     )
     after_phase_inout: dict[int, float] = {
-        b_m: _year_fraction(
-            raw[last_birthyear_phase_inout][last_birthmonth_phase_inout]
-        )
+        b_m: _year_fraction(raw[last_year_phase_inout][last_month_phase_inout])
         for b_m in range(
             last_m_since_ad_phase_inout + 1, last_m_since_ad_to_consider + 1
         )
@@ -718,32 +710,32 @@ def get_birth_month_based_phase_inout_of_age_thresholds_param_value(
     )
 
 
-def get_birth_year_based_phase_inout_of_age_thresholds_param_value(
+def get_year_based_phase_inout_of_age_thresholds_param_value(
     raw: dict[str | int, Any],
 ) -> dict[int, float]:
-    """Get the parameters for birth year-based phase-in/phase-out of age thresholds.
+    """Get the parameters for year-based phase-in/phase-out of age thresholds.
 
-    Requires all birth years to be given.
+    Requires all years to be given.
     """
 
-    first_birthyear_to_consider = raw.pop("first_birthyear_to_consider")
-    last_birthyear_to_consider = raw.pop("last_birthyear_to_consider")
+    first_year_to_consider = raw.pop("first_year_to_consider")
+    last_year_to_consider = raw.pop("last_year_to_consider")
     assert all(isinstance(k, int) for k in raw)
-    first_birthyear_phase_inout: int = min(raw.keys())  # type: ignore[assignment]
-    last_birthyear_phase_inout: int = max(raw.keys())  # type: ignore[assignment]
-    assert first_birthyear_to_consider <= first_birthyear_phase_inout
-    assert last_birthyear_to_consider >= last_birthyear_phase_inout
+    first_year_phase_inout: int = min(raw.keys())  # type: ignore[assignment]
+    last_year_phase_inout: int = max(raw.keys())  # type: ignore[assignment]
+    assert first_year_to_consider <= first_year_phase_inout
+    assert last_year_to_consider >= last_year_phase_inout
     before_phase_inout: dict[int, float] = {
-        b_y: _year_fraction(raw[first_birthyear_phase_inout])
-        for b_y in range(first_birthyear_to_consider, first_birthyear_phase_inout)
+        b_y: _year_fraction(raw[first_year_phase_inout])
+        for b_y in range(first_year_to_consider, first_year_phase_inout)
     }
     during_phase_inout: dict[int, float] = {
         b_y: _year_fraction(raw[b_y])  # type: ignore[misc]
         for b_y in raw
     }
     after_phase_inout: dict[int, float] = {
-        b_y: _year_fraction(raw[last_birthyear_phase_inout])
-        for b_y in range(last_birthyear_phase_inout + 1, last_birthyear_to_consider + 1)
+        b_y: _year_fraction(raw[last_year_phase_inout])
+        for b_y in range(last_year_phase_inout + 1, last_year_to_consider + 1)
     }
     return get_consecutive_int_1d_lookup_table_param_value(
         {**before_phase_inout, **during_phase_inout, **after_phase_inout}


### PR DESCRIPTION
### What problem do you want to solve?

Partly fixes #938 

- Apply phase in parameters for EM Rente
- Update the EM Rente parameters for 2000 until 2031
- Add proper references
- Update regression tests: 
    - Affects regression tests from 2001 and between 01/2017 and 11/2018 
    - 2001: Base Zugangsfaktor calculation on `jahr/monat_renteneintritt` rather than `date_policy_environment`.
    - 2017/18: Update policy environment with parameters that were not implemented before (mainly because they never came into effect due to the 11/2018 reform, but we want to include them anyhow).
