### PR TITLE
Remove all occurances of `vectorization_strategy='loop'`

### DIFF
--- a/src/_gettsim/individual_characteristics.py
+++ b/src/_gettsim/individual_characteristics.py
@@ -2,19 +2,19 @@ from __future__ import annotations
 
 import datetime
 
-import numpy
+from ttsim.config import numpy_or_jax as np
 
 from ttsim import policy_function
 
 
-@policy_function(vectorization_strategy="loop")
+@policy_function()
 def geburtsdatum(
     geburtsjahr: int,
     geburtsmonat: int,
     geburtstag: int,
-) -> numpy.datetime64:
+) -> np.datetime64:
     """Create date of birth datetime variable."""
-    return numpy.datetime64(
+    return np.datetime64(
         datetime.datetime(
             geburtsjahr,
             geburtsmonat,


### PR DESCRIPTION
### What problem do you want to solve?

Some GETTSIM Functions still use numpy vectorization, indicated by `vectorization_strategy='loop'`. These should be modified to be either vectorized by default or use GETSSIM's vectorization functionality. 

### Todo

- [ ]  Remove `vectorization_strategy='loop'`

  - [ ] `miete.py`
  - [ ] `regelbedarf.py`
  - [ ] `alter.py`
  - [ ] `behinderung.py`
  - [ ] `erziehungsgeld.py`
  - [ ] `kindergeld.py`
  - [ ] `einkommen.py`
  - [ ] `lohnsteuer.py`
  - [ ] `midijob.py`
  - [ ] `solidaritätszuschlag.py`
  - [ ] `arbeitslosengeld.py`
  - [ ] `beitrag.py`
  - [ ] `altersgrenzen.py`
  - [ ] `grundrente.py`
  - [ ] `unterhaltsvorschuss.py`
  - [ ] `einkommen.py`
  - [ ] `wohngeld.py`





