### PR TITLE
Convert `minijobgrenze_abgeleitet_von_mindestlohn` to params functions.

### DIFF
--- a/src/_gettsim/arbeitslosengeld_2/einkommen.py
+++ b/src/_gettsim/arbeitslosengeld_2/einkommen.py
@@ -14,7 +14,7 @@ from ttsim import (
 from ttsim.shared import upsert_tree
 
 if TYPE_CHECKING:
-    from ttsim.typing import RawParam
+    from ttsim import RawParam
 
 
 @policy_function(start_date="2005-01-01")

--- a/src/_gettsim/arbeitslosengeld_2/regelbedarf.py
+++ b/src/_gettsim/arbeitslosengeld_2/regelbedarf.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from ttsim import param_function, policy_function
 
 if TYPE_CHECKING:
-    from ttsim.typing import RawParam
+    from ttsim import RawParam
 
 
 @policy_function(start_date="2005-01-01")

--- a/src/_gettsim/einkommensteuer/einkommensteuer.py
+++ b/src/_gettsim/einkommensteuer/einkommensteuer.py
@@ -22,8 +22,7 @@ from ttsim.piecewise_polynomial import (
 )
 
 if TYPE_CHECKING:
-    from ttsim import ConsecutiveInt1dLookupTableParamValue
-    from ttsim.typing import RawParam
+    from ttsim import ConsecutiveInt1dLookupTableParamValue, RawParam
 
 
 @agg_by_group_function(agg_type=AggType.COUNT)

--- a/src/_gettsim/lohnsteuer/einkommen.py
+++ b/src/_gettsim/lohnsteuer/einkommen.py
@@ -228,4 +228,4 @@ def vorsorgepauschale_y_ab_2023(
     leaf_name="vorsorgepauschale_y",
 )
 def vorsorgepauschale_y_ab_2005_bis_2009() -> float:
-    return 0.0
+    raise NotImplementedError("Vorsorgepauschale not implemented before 2010.")

--- a/src/_gettsim/sozialversicherung/minijob.py
+++ b/src/_gettsim/sozialversicherung/minijob.py
@@ -53,8 +53,7 @@ def minijobgrenze_abgeleitet_von_mindestlohn(
     mindestlohn: float,
     faktoren_minijobformel: dict[str, float],
 ) -> float:
-    """Minijob income threshold since 10/2022. Since then, it is calculated endogenously
-    from the statutory minimum wage.
+    """Minijob income threshold, derived from the statutory minimum wage.
 
     Rounding according to § 8 Abs. 1a Satz 2 SGB IV.
     """

--- a/src/_gettsim/sozialversicherung/minijob.py
+++ b/src/_gettsim/sozialversicherung/minijob.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ttsim import RoundingSpec, policy_function
+from ttsim import RoundingSpec, param_function, policy_function
+from ttsim.config import numpy_or_jax as np
 
 
 @policy_function()
@@ -44,12 +45,9 @@ def minijobgrenze_unterscheidung_ost_west(
     )
 
 
-@policy_function(
+@param_function(
     start_date="2022-10-01",
     leaf_name="minijobgrenze",
-    rounding_spec=RoundingSpec(
-        base=1, direction="up", reference="§ 8 Abs. 1a Satz 2 SGB IV"
-    ),
 )
 def minijobgrenze_abgeleitet_von_mindestlohn(
     mindestlohn: float,
@@ -57,8 +55,10 @@ def minijobgrenze_abgeleitet_von_mindestlohn(
 ) -> float:
     """Minijob income threshold since 10/2022. Since then, it is calculated endogenously
     from the statutory minimum wage.
+
+    Rounding according to § 8 Abs. 1a Satz 2 SGB IV.
     """
-    return (
+    return np.ceil(
         mindestlohn
         * faktoren_minijobformel["zähler"]
         / faktoren_minijobformel["nenner"]

--- a/tests/ttsim/mettsim/orc_hunting_bounty/orc_hunting_bounty.py
+++ b/tests/ttsim/mettsim/orc_hunting_bounty/orc_hunting_bounty.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 from ttsim import param_function, policy_function
 
 if TYPE_CHECKING:
-    from ttsim.typing import RawParam
+    from ttsim import RawParam
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### What problem do you want to solve?

I looked through the whole codebase to find `policy_function`s that should be `param_function`s but found only this one. Also I fixed some import statements and added a `NotImplementedError` for `vorsorgepauschale_y` for Lohnsteuer before 2010.