### PR TITLE
Check array length when converting to df.

### DIFF
--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -423,13 +423,13 @@ def group_variables_are_not_constant_within_groups(
 
 @interface_function()
 def non_convertible_objects_in_results_tree(
-    input_data__tree: NestedData,
+    processed_data: QNameData,
     results__tree: NestedData,
 ) -> None:
     """Fail if results should be converted to a DataFrame but contain non-convertible
     objects."""
     _numeric_types = (int, float, bool, np.integer, np.floating, np.bool_)
-    expected_object_length = len(input_data__tree["p_id"])
+    expected_object_length = len(next(iter(processed_data.values())))
 
     paths_with_incorrect_types = []
     paths_with_incorrect_length = []

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -434,7 +434,7 @@ def non_convertible_objects_in_results_tree(
     paths_with_incorrect_types = []
     paths_with_incorrect_length = []
     for path, data in dt.flatten_to_tree_paths(results__tree).items():
-        if isinstance(data, (pd.Series, np.ndarray, list)):
+        if isinstance(data, (np.ndarray, list)):
             if not all(isinstance(item, _numeric_types) for item in data):
                 paths_with_incorrect_types.append(str(path))
             if len(data) != expected_object_length:

--- a/tests/ttsim/test_failures.py
+++ b/tests/ttsim/test_failures.py
@@ -140,6 +140,11 @@ def some_x(x):
     return x
 
 
+@policy_function()
+def some_policy_func_returning_array_of_length_2() -> np.ndarray:
+    return np.array([1, 2])
+
+
 @pytest.mark.parametrize(
     ("tree", "leaf_checker", "err_substr"),
     [
@@ -759,23 +764,35 @@ def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_type(
 
 @pytest.mark.parametrize(
     (
-        "results__tree",
+        "environment",
+        "targets__tree",
         "match",
     ),
     [
         (
             {
-                "some_array_param": np.array([1, 2]),
+                "some_policy_func_returning_array_of_length_2": some_policy_func_returning_array_of_length_2,
             },
+            {"some_policy_func_returning_array_of_length_2": "res1"},
             "The data contains paths that don't have the same length",
         ),
     ],
 )
 def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_length(
-    results__tree,
-    match,
+    environment,
+    targets__tree,
     minimal_data_tree,
+    match,
 ):
+    results__tree = main(
+        inputs={
+            "input_data__tree": minimal_data_tree,
+            "policy_environment": environment,
+            "targets__tree": targets__tree,
+            "rounding": False,
+        },
+        targets=["results__tree"],
+    )["results__tree"]
     with pytest.raises(ValueError, match=match):
         non_convertible_objects_in_results_tree(
             results__tree=results__tree,

--- a/tests/ttsim/test_failures.py
+++ b/tests/ttsim/test_failures.py
@@ -714,6 +714,7 @@ def test_fail_if_input_df_mapper_has_incorrect_format(
     (
         "environment",
         "targets__tree",
+        "match",
     ),
     [
         (
@@ -721,6 +722,7 @@ def test_fail_if_input_df_mapper_has_incorrect_format(
                 "some_piecewise_polynomial_param": _SOME_PIECEWISE_POLYNOMIAL_PARAM,
             },
             {"some_piecewise_polynomial_param": "res1"},
+            "The data contains objects that cannot be cast to a pandas.DataFrame",
         ),
         (
             {
@@ -729,13 +731,15 @@ def test_fail_if_input_df_mapper_has_incorrect_format(
                 ),
             },
             {"some_consecutive_int_1d_lookup_table_param": "res1"},
+            "The data contains objects that cannot be cast to a pandas.DataFrame",
         ),
     ],
 )
-def test_fail_if_non_convertible_objects_in_results_tree(
+def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_type(
     environment,
     targets__tree,
     minimal_data_tree,
+    match,
 ):
     results__tree = main(
         inputs={
@@ -746,10 +750,37 @@ def test_fail_if_non_convertible_objects_in_results_tree(
         },
         targets=["results__tree"],
     )["results__tree"]
-    with pytest.raises(
-        TypeError, match=r"The following paths contain non-scalar\nobjects"
-    ):
-        non_convertible_objects_in_results_tree(results__tree)
+    with pytest.raises(TypeError, match=match):
+        non_convertible_objects_in_results_tree(
+            results__tree=results__tree,
+            input_data__tree=minimal_data_tree,
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        "results__tree",
+        "match",
+    ),
+    [
+        (
+            {
+                "some_array_param": np.array([1, 2]),
+            },
+            "The data contains paths that don't have the same length",
+        ),
+    ],
+)
+def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_length(
+    results__tree,
+    match,
+    minimal_data_tree,
+):
+    with pytest.raises(ValueError, match=match):
+        non_convertible_objects_in_results_tree(
+            results__tree=results__tree,
+            input_data__tree=minimal_data_tree,
+        )
 
 
 def test_fail_if_p_id_does_not_exist():

--- a/tests/ttsim/test_failures.py
+++ b/tests/ttsim/test_failures.py
@@ -746,19 +746,19 @@ def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_type(
     minimal_data_tree,
     match,
 ):
-    results__tree = main(
+    actual = main(
         inputs={
             "input_data__tree": minimal_data_tree,
             "policy_environment": environment,
             "targets__tree": targets__tree,
             "rounding": False,
         },
-        targets=["results__tree"],
-    )["results__tree"]
+        targets=["processed_data", "results__tree"],
+    )
     with pytest.raises(TypeError, match=match):
         non_convertible_objects_in_results_tree(
-            results__tree=results__tree,
-            input_data__tree=minimal_data_tree,
+            processed_data=actual["processed_data"],
+            results__tree=actual["results__tree"],
         )
 
 
@@ -784,19 +784,19 @@ def test_fail_if_non_convertible_objects_in_results_tree_because_of_object_lengt
     minimal_data_tree,
     match,
 ):
-    results__tree = main(
+    actual = main(
         inputs={
             "input_data__tree": minimal_data_tree,
             "policy_environment": environment,
             "targets__tree": targets__tree,
             "rounding": False,
         },
-        targets=["results__tree"],
-    )["results__tree"]
+        targets=["processed_data", "results__tree"],
+    )
     with pytest.raises(ValueError, match=match):
         non_convertible_objects_in_results_tree(
-            results__tree=results__tree,
-            input_data__tree=minimal_data_tree,
+            processed_data=actual["processed_data"],
+            results__tree=actual["results__tree"],
         )
 
 


### PR DESCRIPTION
### What problem do you want to solve?

Adresses this comment by @hmgaudecker when checking whether the resuls tree can be converted to DF.

```quote
    # TODO: HM doesn't think this will work as is, we'll need to check the length of
    # the data. Someone might request a policy parameter that is a 3-element array.
```
