### PR TITLE
Use PolicyInput annotation instead of generic Union type in template

### DIFF
--- a/src/_gettsim_tests/test_templates.py
+++ b/src/_gettsim_tests/test_templates.py
@@ -23,6 +23,23 @@ def test_template_all_outputs_no_inputs(backend):
         },
         output_names=["labels__grouping_levels", "templates__input_data_dtypes"],
     )
+
+    paths_with_unspecified_dtypes = []
+    flat_res = dt.flatten_to_tree_paths(res["templates__input_data_dtypes"])
+    for p, dtype in flat_res.items():
+        if "|" in dtype:
+            paths_with_unspecified_dtypes.append(p)
+    if paths_with_unspecified_dtypes:
+        formatted = "\n".join([str(p) for p in paths_with_unspecified_dtypes])
+        msg = (
+            "The following paths have a generic union type (indicated by '|' in dtype):"
+            f"\n{formatted}"
+            "\n\n"
+            "To fix this, make sure you specified all input variables as PolicyInput "
+            "with the correct type hints."
+        )
+        raise AssertionError(msg)
+
     pattern_all = get_re_pattern_for_all_time_units_and_groupings(
         time_units=list(TIME_UNIT_LABELS),
         grouping_levels=res["labels__grouping_levels"],

--- a/src/ttsim/interface_dag_elements/labels.py
+++ b/src/ttsim/interface_dag_elements/labels.py
@@ -21,19 +21,19 @@ if TYPE_CHECKING:
         NestedPolicyEnvironment,
         OrderedQNames,
         QNameData,
-        QNamePolicyEnvironment,
+        QNameSpecializedEnvironment0,
         UnorderedQNames,
     )
 
 
 @interface_function()
 def grouping_levels(
-    policy_environment: QNamePolicyEnvironment,
+    policy_environment: NestedPolicyEnvironment,
 ) -> OrderedQNames:
     """The grouping levels of the policy environment."""
     return tuple(
         name.rsplit("_", 1)[0]
-        for name in policy_environment
+        for name in dt.flatten_to_qnames(policy_environment)
         if name.endswith("_id") and name != "p_id"
     )
 
@@ -183,7 +183,7 @@ def column_targets(
 
 @interface_function()
 def param_targets(
-    specialized_environment__without_tree_logic_and_with_derived_functions: QNamePolicyEnvironment,  # noqa: E501
+    specialized_environment__without_tree_logic_and_with_derived_functions: QNameSpecializedEnvironment0,  # noqa: E501
     targets__qname: OrderedQNames,
     column_targets: OrderedQNames,
 ) -> OrderedQNames:

--- a/src/ttsim/interface_dag_elements/labels.py
+++ b/src/ttsim/interface_dag_elements/labels.py
@@ -33,7 +33,7 @@ def grouping_levels(
     """The grouping levels of the policy environment."""
     return tuple(
         name.rsplit("_", 1)[0]
-        for name in dt.flatten_to_qnames(policy_environment)
+        for name in policy_environment
         if name.endswith("_id") and name != "p_id"
     )
 

--- a/src/ttsim/interface_dag_elements/templates.py
+++ b/src/ttsim/interface_dag_elements/templates.py
@@ -5,10 +5,13 @@ from typing import TYPE_CHECKING
 import dags.tree as dt
 
 from ttsim.interface_dag_elements.interface_node_objects import interface_function
+from ttsim.tt_dag_elements.column_objects_param_function import PolicyInput
+from ttsim.tt_dag_elements.vectorization import scalar_type_to_array_type
 
 if TYPE_CHECKING:
     from ttsim.interface_dag_elements.typing import (
         NestedInputStructureDict,
+        NestedPolicyEnvironment,
         OrderedQNames,
         QNameSpecializedEnvironment0,
         UnorderedQNames,
@@ -18,13 +21,28 @@ if TYPE_CHECKING:
 @interface_function()
 def input_data_dtypes(
     specialized_environment__with_partialled_params_and_scalars: QNameSpecializedEnvironment0,  # noqa: E501
+    policy_environment: NestedPolicyEnvironment,
     targets__qname: OrderedQNames,
     labels__top_level_namespace: UnorderedQNames,
 ) -> NestedInputStructureDict:
-    return dt.create_tree_with_input_types(
+    base_dtype_tree = dt.create_tree_with_input_types(
         functions=dt.unflatten_from_qnames(
             specialized_environment__with_partialled_params_and_scalars,
         ),
         targets=targets__qname,
         top_level_inputs=labels__top_level_namespace,
     )
+
+    # Replace dtypes of PolicyInputs that have the generic type 'FloatColumn | IntColumn
+    # | BoolColumn' with the actual dtype of the policy environment.
+    flat_policy_env = dt.flatten_to_tree_paths(policy_environment)
+    flat_dtype_tree = dt.flatten_to_tree_paths(base_dtype_tree)
+    out = {}
+    for p, derived_dtype_in_base in flat_dtype_tree.items():
+        policy_env_element = flat_policy_env[p]
+        if isinstance(policy_env_element, PolicyInput) and "|" in derived_dtype_in_base:
+            out[p] = scalar_type_to_array_type(policy_env_element.data_type)
+        else:
+            out[p] = derived_dtype_in_base
+
+    return dt.unflatten_from_tree_paths(out)

--- a/src/ttsim/tt_dag_elements/vectorization.py
+++ b/src/ttsim/tt_dag_elements/vectorization.py
@@ -492,11 +492,11 @@ def _create_vectorized_signature(func: Callable[..., Any]) -> inspect.Signature:
             name=param.name,
             kind=param.kind,
             default=param.default,
-            annotation=_scalar_type_to_array_type(param.annotation),
+            annotation=scalar_type_to_array_type(param.annotation),
         )
         for param in inspect.signature(func).parameters.values()
     ]
-    return_annotation = _scalar_type_to_array_type(
+    return_annotation = scalar_type_to_array_type(
         inspect.signature(func).return_annotation
     )
     return inspect.Signature(parameters=parameters, return_annotation=return_annotation)
@@ -507,7 +507,7 @@ def _create_vectorized_annotations(func: Callable[..., Any]) -> dict[str, Any]:
     parameters_and_return = ["return", *inspect.signature(func).parameters]
     annotations = inspect.get_annotations(func)
     return {
-        name: _scalar_type_to_array_type(
+        name: scalar_type_to_array_type(
             # If no annotation is available, we assume it is a numerical scalar type,
             # which is converted to an array type.
             annotations.get(name, "IntColumn | FloatColumn | BoolColumn"),
@@ -516,7 +516,7 @@ def _create_vectorized_annotations(func: Callable[..., Any]) -> dict[str, Any]:
     }
 
 
-def _scalar_type_to_array_type(orig_type: Literal["int", "float", "bool"]) -> str:
+def scalar_type_to_array_type(orig_type: Literal["int", "float", "bool"]) -> str:
     """Convert a scalar type to the corresponding array type."""
     registry = {
         "int": "IntColumn",


### PR DESCRIPTION
### What problem do you want to solve?

Replaces the generic union types that were part of the input dtype template with the correct dtypes derived from `PolicyInput` annotations.
