### PR TITLE
Make GETTSIM functions jittable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -42,3 +42,10 @@ def skipif_jax(request, backend):
     """Automatically skip tests marked with skipif_jax when backend is jax."""
     if request.node.get_closest_marker("skipif_jax") and backend == "jax":
         pytest.skip("Cannot run this test with Jax")
+
+
+@pytest.fixture(autouse=True)
+def skipif_numpy(request, backend):
+    """Automatically skip tests marked with skipif_numpy when backend is numpy."""
+    if request.node.get_closest_marker("skipif_numpy") and backend == "numpy":
+        pytest.skip("Cannot run this test with Numpy")

--- a/pixi.lock
+++ b/pixi.lock
@@ -273,7 +273,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -511,7 +511,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -749,7 +749,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -995,7 +995,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   mypy:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1274,7 +1274,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -1517,7 +1517,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -1760,7 +1760,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -2011,7 +2011,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -2285,7 +2285,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -2523,7 +2523,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -2761,7 +2761,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -3007,7 +3007,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -3281,7 +3281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -3519,7 +3519,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -3757,7 +3757,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -4003,7 +4003,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   py312-jax:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -4289,7 +4289,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -4539,7 +4539,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.0-unix_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -4789,7 +4789,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/86/2f/1f0144b14553ad32a8d0afa38b832c4b117694484c32aef2d939dc96f20a/pdbp-1.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
@@ -5041,7 +5041,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e6/eb/3bf6ea8ab7f1503dca3a10df2e4b9c3f6b3316df07f6c0ded94b281c7101/scipy-1.15.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/65/44/bb509c3d2c0b5a87e7a5af1d5917a402a32ff026f777a6d7cb6990746cbb/tabcompleter-1.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/9a/937038f3efc70871fb26b0ee6148efcfcfb96643c517c2aaddd7ed07ad76/wadler_lindig-0.1.6-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -6620,10 +6620,10 @@ packages:
   purls: []
   size: 21903
   timestamp: 1694400856979
-- pypi: .
+- pypi: ./
   name: gettsim
-  version: 0.7.1.dev137+gb255f8af0
-  sha256: ef42085575c8d56d2dae9c7fae1deabef1e96d5806b5760f6f72bc560791ea6a
+  version: 0.7.1.dev133+gedf184a0.d20250627
+  sha256: 7727445cb26b482027a1e49c7b6a08217a76ce89b01f95d03aa4a820af312f30
   requires_dist:
   - ipywidgets
   - networkx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,7 +311,8 @@ markers = [
     "unit: Flag for unit tests which target mainly a single function.",
     "integration: Flag for integration tests which may comprise of multiple unit tests.",
     "end_to_end: Flag for tests that cover the whole program.",
-    "skipif_jax: skip test if backend is jax"
+    "skipif_jax: skip test if backend is jax",
+    "skipif_numpy: skip test if backend is numpy"
 ]
 norecursedirs = ["docs"]
 testpaths = [

--- a/src/_gettsim_tests/test_jittability.py
+++ b/src/_gettsim_tests/test_jittability.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import datetime
+import inspect
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import dags.tree as dt
+import pytest
+from dags import get_free_arguments
+
+from ttsim import main, output
+from ttsim.tt_dag_elements.column_objects_param_function import ColumnFunction
+
+if TYPE_CHECKING:
+    from ttsim.interface_dag_elements.typing import (
+        FlatColumnObjectsParamFunctions,
+        FlatOrigParamSpecs,
+        QNameSpecializedEnvironment2,
+    )
+
+GETTSIM_ROOT = Path(__file__).parent.parent / "_gettsim"
+
+
+def get_orig_gettsim_objects() -> dict[
+    str, FlatColumnObjectsParamFunctions | FlatOrigParamSpecs
+]:
+    out = main(
+        orig_policy_objects={"root": GETTSIM_ROOT},
+        output=output.Names(
+            [
+                "orig_policy_objects__column_objects_and_param_functions",
+                "orig_policy_objects__param_specs",
+            ]
+        ),
+    )
+    return {k.replace("orig_policy_objects__", ""): v for k, v in out.items()}
+
+
+def get_orig_gettsim_column_functions() -> list[ColumnFunction]:
+    orig = get_orig_gettsim_objects()["column_objects_and_param_functions"]
+    return [(tp, cf) for tp, cf in orig.items() if isinstance(cf, ColumnFunction)]
+
+
+@lru_cache(maxsize=100)
+def cached_specialized_environment(
+    date: datetime.date,
+    root: Path,
+    backend: Literal["numpy", "jax"],
+) -> QNameSpecializedEnvironment2:
+    return main(
+        date=date,
+        orig_policy_objects={"root": root},
+        backend=backend,
+        fail_and_warn=False,
+        output=output.Name(
+            ("specialized_environment", "with_partialled_params_and_scalars")
+        ),
+    )
+
+
+@pytest.mark.skipif_numpy
+@pytest.mark.parametrize(
+    "tree_path, fun",
+    get_orig_gettsim_column_functions(),
+    ids=[str(x[0]) for x in get_orig_gettsim_column_functions()],
+)
+def test_jittable(tree_path, fun, backend, xnp):
+    today = datetime.date.today()  # noqa: DTZ011
+    date = min(fun.end_date, today)
+    qname = dt.qname_from_tree_path(tree_path[:-2] + (fun.leaf_name,))
+    env = {qname: cached_specialized_environment(date, GETTSIM_ROOT, backend)[qname]}
+
+    processed_data = {}
+    for arg_name in get_free_arguments(env[qname]):
+        arg = inspect.signature(env[qname]).parameters[arg_name]
+        if "FloatColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=float)
+        elif "IntColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=int)
+        elif "BoolColumn" in arg.annotation:
+            processed_data[arg_name] = xnp.zeros(1, dtype=bool)
+        else:
+            raise ValueError(f"Unknown column type: {arg.annotation}")
+
+    main(
+        date=date,
+        specialized_environment={"with_partialled_params_and_scalars": env},
+        processed_data=processed_data,
+        targets={"qname": [qname]},
+        backend=backend,
+        output=output.Name(("raw_results", "columns")),
+        fail_and_warn=False,
+    )

--- a/src/ttsim/interface_dag.py
+++ b/src/ttsim/interface_dag.py
@@ -98,8 +98,15 @@ def main(
             functions=functions,
             output_qnames=flat_output["names"],
         )
+
+    # Not strictly necessary, but helps with debugging.
+    dag = dags.create_dag(
+        functions=functions,
+        targets=flat_output["names"],
+    )
     if flat_output["name"] is None:
         f = dags.concatenate_functions(
+            dag=dag,
             functions=functions,
             targets=flat_output["names"],
             return_type="dict",
@@ -108,6 +115,7 @@ def main(
         )
     else:
         f = dags.concatenate_functions(
+            dag=dag,
             functions=functions,
             targets=flat_output["name"],
             enforce_signature=False,

--- a/src/ttsim/interface_dag_elements/specialized_environment.py
+++ b/src/ttsim/interface_dag_elements/specialized_environment.py
@@ -191,7 +191,8 @@ def with_processed_params_and_scalars(
     if processed_data:
         all_nodes["num_segments"] = len(next(iter(processed_data.values())))
     else:
-        all_nodes["num_segments"] = 0
+        # Leave at a recognisable value; just used in jittability tests.
+        all_nodes["num_segments"] = 11111
 
     params = {k: v for k, v in all_nodes.items() if isinstance(v, ParamObject)}
     scalars = {

--- a/src/ttsim/tt_dag_elements/param_objects.py
+++ b/src/ttsim/tt_dag_elements/param_objects.py
@@ -183,7 +183,7 @@ def get_consecutive_int_2d_lookup_table_param_value(
 ) -> ConsecutiveInt2dLookupTableParamValue:
     """Get the parameters for a 2-dimensional lookup table."""
     lookup_keys_rows = xnp.asarray(sorted(raw.keys()))
-    lookup_keys_cols = xnp.asarray(sorted(raw[lookup_keys_rows[0]].keys()))
+    lookup_keys_cols = xnp.asarray(sorted(raw[lookup_keys_rows[0].item()].keys()))
     for col_value in raw.values():
         lookup_keys_this_col = xnp.asarray(sorted(col_value.keys()))
         assert (lookup_keys_cols == lookup_keys_this_col).all(), (
@@ -199,7 +199,7 @@ def get_consecutive_int_2d_lookup_table_param_value(
         base_to_subtract_cols=min(lookup_keys_cols),
         values_to_look_up=xnp.array(
             [
-                raw[row][col]
+                raw[row.item()][col.item()]
                 for row, col in itertools.product(lookup_keys_rows, lookup_keys_cols)
             ],
         ).reshape(len(lookup_keys_rows), len(lookup_keys_cols)),


### PR DESCRIPTION
### What problem do you want to solve?

Make sure the GETTSIM functions can be jitted

- [ ] Add an automatic set of tests

Make tests pass:

- [ ] 'arbeitslosengeld_2', 'einkommen.py', 'anrechnungsfreies_einkommen_m_basierend_auf_nettoquote'
- [ ] 'arbeitslosengeld_2', 'einkommen.py', 'nettoquote'
- [ ] 'arbeitslosengeld_2', 'kindergeldübertrag.py', 'in_anderer_bg_als_kindergeldempfänger'
- [ ] 'einkommensteuer', 'einkommensteuer.py', 'betrag_mit_kinderfreibetrag_y_sn_bis_2001'
- [ ] 'einkommensteuer', 'einkünfte', 'aus_kapitalvermögen', 'aus_kapitalvermögen.py', 'betrag_y_mit_sparerfreibetrag_und_werbungskostenpauschbetrag'
- [ ] 'einkommensteuer', 'einkünfte', 'einkünfte.py', 'gesamtbetrag_der_einkünfte_y_mit_kapiteleinkünften'
- [ ] 'elterngeld', 'elterngeld.py', 'elterngeld_not_implemented'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', '_kind_grundsätzlich_anspruchsberechtigt_nach_abschaffung'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'abzug_durch_einkommen_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'anspruchshöhe_kind_mit_budgetsatz_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'anspruchshöhe_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'anzurechnendes_einkommen_y'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'basisbetrag_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'betrag_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'einkommensgrenze_ohne_geschwisterbonus_kind_älter_als_reduzierungsgrenze'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'einkommensgrenze_ohne_geschwisterbonus_kind_jünger_als_reduzierungsgrenze'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'einkommensgrenze_ohne_geschwisterbonus'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'einkommensgrenze_y'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'erziehungsgeld_kind_ohne_budgetsatz_m'
- [ ] 'erziehungsgeld', 'erziehungsgeld.py', 'grundsätzlich_anspruchsberechtigt'
- [ ] 'individual_characteristics.py', 'geburtsdatum' (we may want to postpone this until we have converged on handling of dates)
- [ ] 'lohnsteuer', 'einkommen.py', 'vorsorgepauschale_y_ab_2005_bis_2009'
- [ ] 'solidaritätszuschlag', 'solidaritätszuschlag.py', 'betrag_y_sn_ohne_abgelt_st'
- [ ] 'sozialversicherung', 'arbeitslosen', 'arbeitslosengeld.py', 'betrag_m_not_implemented'
- [ ] 'sozialversicherung', 'arbeitslosen', 'arbeitslosengeld.py', 'monate_verbleibender_anspruchsdauer'
- [ ] 'sozialversicherung', 'kranken', 'beitrag', 'beitrag.py', 'betrag_selbstständig_m_ohne_ermäßigtem_beitragssatz'
- [ ] 'sozialversicherung', 'rente', 'altersrente', 'altersgrenzen.py', 'referenzalter_abschlag_mit_arbeitslosigkeit_frauen'
- [ ] 'sozialversicherung', 'rente', 'altersrente', 'altersrente.py', 'bruttorente_basisbetrag_m'
- [ ] 'sozialversicherung', 'rente', 'erwerbsminderung', 'erwerbsminderung.py', 'anteil_entgeltpunkte_ost'
- [ ] 'sozialversicherung', 'rente', 'erwerbsminderung', 'erwerbsminderung.py', 'betrag_m_einheitlich'
- [ ] 'sozialversicherung', 'rente', 'grundrente', 'grundrente.py', 'anzurechnendes_einkommen_m'
- [ ] 'sozialversicherung', 'rente', 'grundrente', 'grundrente.py', 'basisbetrag_m'
- [ ] 'unterhaltsvorschuss', 'unterhaltsvorschuss.py', 'not_implemented_m'  (@MImmesberger, please decide what to do with this)
- [ ] 'wohngeld', 'miete.py', 'miete_m_hh_mit_baujahr'
- [ ] 'wohngeld', 'voraussetzungen.py', 'grundsätzlich_anspruchsberechtigt_bg_ohne_vermögensprüfung'
- [ ] 'wohngeld', 'voraussetzungen.py', 'grundsätzlich_anspruchsberechtigt_wthh_ohne_vermögensprüfung'


Tests can be run via:
```
pixi run tests-jax src/_gettsim_tests/test_jittability.py -v
```
(restriction is important because essentially all other GETTSIM tests fail).