### PR TITLE
Enable annotations for interface / tax-transfer functions

### DIFF
--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -172,7 +172,7 @@ def abzug_durch_einkommen_m(
     leaf_name="ist_leistungsbegründendes_kind",
 )
 def _leistungsbegründendes_kind_vor_abschaffung(
-    p_id_empfänger: bool,
+    p_id_empfänger: int,
     alter_monate: int,
     budgetsatz: bool,
     maximales_kindsalter_budgetsatz: float,

--- a/src/_gettsim/familie/inputs.py
+++ b/src/_gettsim/familie/inputs.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from ttsim.tt_dag_elements import FKType, policy_input
+from ttsim.tt_dag_elements import AggType, FKType, agg_by_group_function, policy_input
 
 
 @policy_input()
 def alleinerziehend() -> bool:
     """Single parent."""
+
+
+@agg_by_group_function(agg_type=AggType.ANY)
+def alleinerziehend_fg(alleinerziehend: bool, fg_id: int) -> bool:
+    pass
 
 
 @policy_input(foreign_key_type=FKType.MUST_NOT_POINT_TO_SELF)

--- a/src/ttsim/interface_dag.py
+++ b/src/ttsim/interface_dag.py
@@ -133,7 +133,7 @@ def main(
             functions=functions,
             targets=main_target,
             enforce_signature=False,
-            set_annotations=False,
+            set_annotations=True,
             lexsort_key=lexsort_key,
         )
     else:
@@ -143,7 +143,7 @@ def main(
             targets=main_targets,
             return_type="dict",
             enforce_signature=False,
-            set_annotations=False,
+            set_annotations=True,
             lexsort_key=lexsort_key,
         )
     return f(**input_qnames)

--- a/src/ttsim/interface_dag_elements/fail_if.py
+++ b/src/ttsim/interface_dag_elements/fail_if.py
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
         OrigParamSpec,
         PolicyEnvironment,
         QNameData,
-        QNameDataColumns,
         SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
         SpecEnvWithPartialledParamsAndScalars,
         UnorderedQNames,
@@ -227,7 +226,7 @@ def active_periods_overlap(
 def any_paths_are_invalid(
     policy_environment: PolicyEnvironment,
     input_data__tree: NestedData,
-    tt_targets__tree: NestedTargetDict,
+    tt_targets__tree: NestedTargetDict | NestedStrings,
     labels__top_level_namespace: UnorderedQNames,
 ) -> None:
     """Thin wrapper around `dt.fail_if_paths_are_invalid`."""
@@ -690,7 +689,7 @@ def root_nodes_are_missing(
 @fail_or_warn_function()
 def targets_are_not_in_specialized_environment_or_data(
     specialized_environment__without_tree_logic_and_with_derived_functions: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
-    labels__processed_data_columns: QNameDataColumns,
+    labels__processed_data_columns: UnorderedQNames,
     tt_targets__qname: OrderedQNames,
 ) -> None:
     """Fail if some target is not among functions.
@@ -725,7 +724,7 @@ def targets_are_not_in_specialized_environment_or_data(
 
 
 @fail_or_warn_function()
-def targets_tree_is_invalid(tt_targets__tree: NestedTargetDict) -> None:
+def targets_tree_is_invalid(tt_targets__tree: NestedTargetDict | NestedStrings) -> None:
     """
     Validate that the targets tree is a dictionary with string keys and None leaves.
     """

--- a/src/ttsim/interface_dag_elements/labels.py
+++ b/src/ttsim/interface_dag_elements/labels.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         PolicyEnvironment,
         QNameData,
         SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+        SpecEnvWithPartialledParamsAndScalars,
         UnorderedQNames,
     )
 
@@ -181,7 +182,7 @@ def fail_if_multiple_time_units_for_same_base_name_and_group(
 
 @interface_function()
 def column_targets(
-    specialized_environment__with_partialled_params_and_scalars: UnorderedQNames,
+    specialized_environment__with_partialled_params_and_scalars: SpecEnvWithPartialledParamsAndScalars,  # noqa: E501
     tt_targets__qname: OrderedQNames,
 ) -> OrderedQNames:
     """All targets that are column functions."""

--- a/src/ttsim/interface_dag_elements/policy_environment.py
+++ b/src/ttsim/interface_dag_elements/policy_environment.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 @interface_function(in_top_level_namespace=True)
 def policy_environment(
-    orig_policy_objects__column_objects_and_param_functions: NestedColumnObjectsParamFunctions,  # noqa: E501
+    orig_policy_objects__column_objects_and_param_functions: FlatColumnObjectsParamFunctions,  # noqa: E501
     orig_policy_objects__param_specs: FlatOrigParamSpecs,
     policy_date: datetime.date,
     xnp: ModuleType,

--- a/src/ttsim/interface_dag_elements/specialized_environment.py
+++ b/src/ttsim/interface_dag_elements/specialized_environment.py
@@ -351,7 +351,7 @@ def tax_transfer_function(
         return_type="dict",
         aggregator=None,
         enforce_signature=True,
-        set_annotations=False,
+        set_annotations=True,
     )
 
     if backend == "jax":

--- a/src/ttsim/interface_dag_elements/templates.py
+++ b/src/ttsim/interface_dag_elements/templates.py
@@ -13,14 +13,14 @@ if TYPE_CHECKING:
         NestedInputStructureDict,
         OrderedQNames,
         PolicyEnvironment,
-        SpecEnvWithoutTreeLogicAndWithDerivedFunctions,
+        SpecEnvWithPartialledParamsAndScalars,
         UnorderedQNames,
     )
 
 
 @interface_function()
 def input_data_dtypes(
-    specialized_environment__with_partialled_params_and_scalars: SpecEnvWithoutTreeLogicAndWithDerivedFunctions,  # noqa: E501
+    specialized_environment__with_partialled_params_and_scalars: SpecEnvWithPartialledParamsAndScalars,  # noqa: E501
     policy_environment: PolicyEnvironment,
     tt_targets__qname: OrderedQNames,
     labels__top_level_namespace: UnorderedQNames,

--- a/src/ttsim/interface_dag_elements/tt_targets.py
+++ b/src/ttsim/interface_dag_elements/tt_targets.py
@@ -11,6 +11,7 @@ from ttsim.tt_dag_elements.column_objects_param_function import ColumnFunction
 
 if TYPE_CHECKING:
     from ttsim.interface_dag_elements.typing import (
+        NestedStrings,
         NestedTargetDict,
         OrderedQNames,
         PolicyEnvironment,
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 
 
 @interface_function()
-def tree(policy_environment: PolicyEnvironment) -> NestedTargetDict:
+def tree(policy_environment: PolicyEnvironment) -> NestedTargetDict | NestedStrings:
     """Targets as a tree. Will typically be provided by the user.
 
     If requesting `df_with_mapper` as a main target, the leaves must be the desired
@@ -37,6 +38,6 @@ def tree(policy_environment: PolicyEnvironment) -> NestedTargetDict:
 
 
 @interface_function()
-def qname(tree: NestedTargetDict) -> OrderedQNames:
+def qname(tree: NestedTargetDict | NestedStrings) -> OrderedQNames:
     """Targets in their qualified name-representation."""
     return dt.flatten_to_qnames(tree)

--- a/src/ttsim/interface_dag_elements/warn_if.py
+++ b/src/ttsim/interface_dag_elements/warn_if.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ttsim.interface_dag_elements.typing import (
         OrderedQNames,
         PolicyEnvironment,
-        QNameDataColumns,
+        UnorderedQNames,
     )
 
 
@@ -67,7 +67,7 @@ class FunctionsAndDataColumnsOverlapWarning(UserWarning):
 @fail_or_warn_function()
 def functions_and_data_columns_overlap(
     policy_environment: PolicyEnvironment,
-    labels__processed_data_columns: QNameDataColumns,
+    labels__processed_data_columns: UnorderedQNames,
 ) -> None:
     """Warn if functions are overridden by data."""
     overridden_elements = sorted(

--- a/tests/ttsim/interface_dag_elements/test_specialized_environment.py
+++ b/tests/ttsim/interface_dag_elements/test_specialized_environment.py
@@ -30,7 +30,11 @@ from ttsim.tt_dag_elements import (
 )
 
 if TYPE_CHECKING:
-    from ttsim.interface_dag_elements.typing import IntColumn, PolicyEnvironment
+    from ttsim.interface_dag_elements.typing import (
+        FloatColumn,
+        IntColumn,
+        PolicyEnvironment,
+    )
 
 
 @policy_input()
@@ -267,7 +271,7 @@ def function_with_float_return(x: int) -> float:
     return x
 
 
-def some_x(x):
+def some_x(x: int) -> int:
     return x
 
 
@@ -575,11 +579,11 @@ def test_user_provided_aggregation(backend):
     expected = pd.Series([400, 400, 200], index=pd.Index(data["p_id"], name="p_id"))
 
     @policy_function(vectorization_strategy="vectorize")
-    def betrag_m_double(betrag_m):
+    def betrag_m_double(betrag_m: float) -> float:
         return 2 * betrag_m
 
     @agg_by_group_function(agg_type=AggType.MAX)
-    def betrag_m_double_fam(betrag_m_double, fam_id) -> float:
+    def betrag_m_double_fam(betrag_m_double: float, fam_id: int) -> float:
         pass
 
     policy_environment = {
@@ -625,11 +629,11 @@ def test_user_provided_aggregation_with_time_conversion(backend):
     )
 
     @policy_function(vectorization_strategy="vectorize")
-    def betrag_double_m(betrag_m):
+    def betrag_double_m(betrag_m: float) -> float:
         return 2 * betrag_m
 
     @agg_by_group_function(agg_type=AggType.MAX)
-    def max_betrag_double_m_fam(betrag_double_m, fam_id) -> float:
+    def max_betrag_double_m_fam(betrag_double_m: float, fam_id: int) -> float:
         pass
 
     policy_environment = {
@@ -716,7 +720,7 @@ def test_user_provided_aggregate_by_p_id_specs(
     xnp,
 ):
     @policy_function(leaf_name=leaf_name, vectorization_strategy="not_required")
-    def source() -> int:
+    def source() -> FloatColumn:
         return xnp.array([100, 200, 300])
 
     policy_environment = merge_trees(

--- a/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
+++ b/tests/ttsim/mettsim/payroll_tax/child_tax_credit/child_tax_credit.py
@@ -2,15 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from types import ModuleType
-
 from ttsim.tt_dag_elements import (
     AggType,
     agg_by_p_id_function,
     join,
     policy_function,
 )
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    from ttsim.interface_dag_elements.typing import BoolColumn, IntColumn
 
 
 @agg_by_p_id_function(agg_type=AggType.SUM)
@@ -22,7 +24,7 @@ def amount_y(
     """The amount of child tax credit at the recipient level."""
 
 
-@policy_function(vectorization_strategy="vectorize")
+@policy_function()
 def claim_of_child_y(
     child_eligible: bool,
     schedule: dict[str, float],
@@ -33,7 +35,7 @@ def claim_of_child_y(
         return 0
 
 
-@policy_function(vectorization_strategy="vectorize")
+@policy_function()
 def child_eligible(
     age: int,
     schedule: dict[str, float],
@@ -44,11 +46,11 @@ def child_eligible(
 
 @policy_function(vectorization_strategy="not_required")
 def in_same_household_as_recipient(
-    p_id: int,
-    kin_id: int,
-    p_id_recipient: int,
+    p_id: IntColumn,
+    kin_id: IntColumn,
+    p_id_recipient: IntColumn,
     xnp: ModuleType,
-) -> bool:
+) -> BoolColumn:
     return (
         join(
             foreign_key=p_id_recipient,

--- a/tests/ttsim/tt_dag_elements/test_rounding.py
+++ b/tests/ttsim/tt_dag_elements/test_rounding.py
@@ -132,7 +132,7 @@ def test_rounding_with_time_conversion(backend, xnp):
 
     # Define function that should be rounded
     @policy_function(rounding_spec=RoundingSpec(base=1, direction="down"))
-    def test_func_m(x):
+    def test_func_m(x: float) -> float:
         return x
 
     data = {


### PR DESCRIPTION
- [x] Set `set_annotations=True` for interface function. Fix errors that cropped up due to inconsistent annotations.
- [x] Set `set_annotations=True` for taxes & transfers function. 
- [x] Fix GETTSIM 
- [x] Fix METTSIM / ttsim tests