### PR TITLE
Rename `ist_selbstständig` to `ist_hauptberuflich_selbstständig`

### DIFF
--- a/src/_gettsim/einkommensteuer/einkünfte/inputs.py
+++ b/src/_gettsim/einkommensteuer/einkünfte/inputs.py
@@ -6,5 +6,5 @@ from ttsim.tt_dag_elements import policy_input
 
 
 @policy_input()
-def ist_selbstständig() -> bool:
+def ist_hauptberuflich_selbstständig() -> bool:
     """Self-employed (main profession)."""

--- a/src/_gettsim/einkommensteuer/einkünfte/inputs.py
+++ b/src/_gettsim/einkommensteuer/einkünfte/inputs.py
@@ -10,6 +10,5 @@ def ist_hauptberuflich_selbstständig() -> bool:
     """Self-employed (main occupation).
 
     A person is self-employed as a main occupation if the self-employed activity clearly
-    exceeds the other gainful activities in terms of economic significance and time
-    expenditure.
+    exceeds the other gainful activities in terms of economic significance and time use.
     """

--- a/src/_gettsim/einkommensteuer/einkünfte/inputs.py
+++ b/src/_gettsim/einkommensteuer/einkünfte/inputs.py
@@ -7,4 +7,9 @@ from ttsim.tt_dag_elements import policy_input
 
 @policy_input()
 def ist_hauptberuflich_selbstständig() -> bool:
-    """Self-employed (main profession)."""
+    """Self-employed (main occupation).
+
+    A person is self-employed as a main occupation if the self-employed activity clearly
+    exceeds the other gainful activities in terms of economic significance and time
+    expenditure.
+    """

--- a/src/_gettsim/sozialversicherung/kranken/beitrag/beitrag.py
+++ b/src/_gettsim/sozialversicherung/kranken/beitrag/beitrag.py
@@ -11,13 +11,13 @@ def betrag_versicherter_m_ohne_midijob(
     betrag_rentner_m: float,
     betrag_selbstständig_m: float,
     betrag_versicherter_regulär_beschäftigt_m: float,
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
 ) -> float:
     """Public health insurance contributions paid by the insured person.
 
     Before Midijob introduction in April 2003.
     """
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = betrag_selbstständig_m
     elif sozialversicherung__geringfügig_beschäftigt:
         out = 0.0
@@ -36,13 +36,13 @@ def betrag_versicherter_m_mit_midijob(
     sozialversicherung__in_gleitzone: bool,
     betrag_versicherter_in_gleitzone_m: float,
     betrag_versicherter_regulär_beschäftigt_m: float,
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
 ) -> float:
     """Public health insurance contributions paid by the insured person.
 
     After Midijob introduction in April 2003.
     """
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = betrag_selbstständig_m
     elif sozialversicherung__geringfügig_beschäftigt:
         out = 0.0
@@ -60,7 +60,7 @@ def betrag_arbeitgeber_m_ohne_midijob(
     sozialversicherung__geringfügig_beschäftigt: bool,
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
     einkommen_m: float,
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     minijob_arbeitgeberpauschale: float,
     beitragssatz_arbeitgeber: float,
 ) -> float:
@@ -68,7 +68,7 @@ def betrag_arbeitgeber_m_ohne_midijob(
 
     Before Midijob introduction in April 2003.
     """
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = 0.0
     elif sozialversicherung__geringfügig_beschäftigt:
         out = (
@@ -88,7 +88,7 @@ def betrag_arbeitgeber_m_mit_midijob(
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
     betrag_arbeitgeber_in_gleitzone_m: float,
     einkommen_m: float,
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     minijob_arbeitgeberpauschale: float,
     beitragssatz_arbeitgeber: float,
 ) -> float:
@@ -96,7 +96,7 @@ def betrag_arbeitgeber_m_mit_midijob(
 
     After Midijob introduction in April 2003.
     """
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = 0.0
     elif sozialversicherung__geringfügig_beschäftigt:
         out = (

--- a/src/_gettsim/sozialversicherung/kranken/beitrag/einkommen.py
+++ b/src/_gettsim/sozialversicherung/kranken/beitrag/einkommen.py
@@ -42,7 +42,7 @@ def einkommen_bis_beitragsbemessungsgrenze_m(
 def bemessungsgrundlage_selbstständig_m(
     einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_m: float,
     bezugsgröße_selbstständige_m: float,
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     privat_versichert: bool,
     beitragsbemessungsgrenze_m: float,
     mindestanteil_bezugsgröße_selbstständige: float,
@@ -55,7 +55,10 @@ def bemessungsgrundlage_selbstständig_m(
     Reference: §240 SGB V Abs. 4
     """
     # Calculate if self employed insures via public health insurance.
-    if einkommensteuer__einkünfte__ist_selbstständig and not privat_versichert:
+    if (
+        einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig
+        and not privat_versichert
+    ):
         out = min(
             beitragsbemessungsgrenze_m,
             max(

--- a/src/_gettsim/sozialversicherung/pflege/beitrag/beitrag.py
+++ b/src/_gettsim/sozialversicherung/pflege/beitrag/beitrag.py
@@ -11,14 +11,14 @@ from ttsim.tt_dag_elements import policy_function
     leaf_name="betrag_versicherter_m",
 )
 def betrag_versicherter_m_ohne_midijob(
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     betrag_selbstständig_m: float,
     sozialversicherung__geringfügig_beschäftigt: bool,
     betrag_versicherter_regulär_beschäftigt_m: float,
     betrag_rentner_m: float,
 ) -> float:
     """Long-term care insurance contributions paid by the insured person."""
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = betrag_selbstständig_m
     elif sozialversicherung__geringfügig_beschäftigt:
         out = 0.0
@@ -34,7 +34,7 @@ def betrag_versicherter_m_ohne_midijob(
     leaf_name="betrag_versicherter_m",
 )
 def betrag_versicherter_m_mit_midijob(
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     betrag_selbstständig_m: float,
     sozialversicherung__geringfügig_beschäftigt: bool,
     sozialversicherung__in_gleitzone: bool,
@@ -43,7 +43,7 @@ def betrag_versicherter_m_mit_midijob(
     betrag_rentner_m: float,
 ) -> float:
     """Long-term care insurance contributions paid by the insured person."""
-    if einkommensteuer__einkünfte__ist_selbstständig:
+    if einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
         out = betrag_selbstständig_m
     elif sozialversicherung__geringfügig_beschäftigt:
         out = 0.0
@@ -62,7 +62,7 @@ def betrag_versicherter_m_mit_midijob(
     leaf_name="betrag_arbeitgeber_m",
 )
 def betrag_arbeitgeber_m_ohne_midijob(
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     sozialversicherung__geringfügig_beschäftigt: bool,
     betrag_arbeitgeber_regulär_beschäftigt_m: float,
 ) -> float:
@@ -71,7 +71,7 @@ def betrag_arbeitgeber_m_ohne_midijob(
     Before Midijob introduction in April 2003.
     """
     if (
-        einkommensteuer__einkünfte__ist_selbstständig
+        einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig
         or sozialversicherung__geringfügig_beschäftigt
     ):
         out = 0.0
@@ -86,7 +86,7 @@ def betrag_arbeitgeber_m_ohne_midijob(
     leaf_name="betrag_arbeitgeber_m",
 )
 def betrag_arbeitgeber_m_mit_midijob(
-    einkommensteuer__einkünfte__ist_selbstständig: bool,
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig: bool,
     sozialversicherung__geringfügig_beschäftigt: bool,
     sozialversicherung__in_gleitzone: bool,
     betrag_arbeitgeber_in_gleitzone_m: float,
@@ -97,7 +97,7 @@ def betrag_arbeitgeber_m_mit_midijob(
     After Midijob introduction in April 2003.
     """
     if (
-        einkommensteuer__einkünfte__ist_selbstständig
+        einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig
         or sozialversicherung__geringfügig_beschäftigt
     ):
         out = 0.0

--- a/src/_gettsim_tests/test_data/arbeitslosengeld_2/2024-01-01/single_no_income.yaml
+++ b/src/_gettsim_tests/test_data/arbeitslosengeld_2/2024-01-01/single_no_income.yaml
@@ -35,7 +35,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/arbeitslosengeld_2/2024-01-01/skip_single_no_children.yaml
+++ b/src/_gettsim_tests/test_data/arbeitslosengeld_2/2024-01-01/skip_single_no_children.yaml
@@ -28,7 +28,7 @@ inputs:
       - 0.0
     einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_m:
       - 0.0
-    einkommensteuer__einkünfte__ist_selbstständig:
+    einkommensteuer__einkünfte__ist_hauptberuflich_selbstständig:
       - false
     einkommensteuer__einkünfte__sonstige__alle_weiteren_m:
       - 0.0

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_1.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_2.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_3.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_4.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2010-01-01/hh_id_5.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2015-01-01/hh_id_16.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2015-01-01/hh_id_16.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2015-01-01/hh_id_17.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2015-01-01/hh_id_17.yaml
@@ -54,7 +54,7 @@ inputs:
           betrag_m:
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
         sonstige:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2017-01-01/hh_id_18.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2017-01-01/hh_id_18.yaml
@@ -54,7 +54,7 @@ inputs:
           betrag_m:
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
         sonstige:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_10.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_10.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_11.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_11.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_12.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_12.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_7.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_8.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_9.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2018-01-01/hh_id_9.yaml
@@ -41,7 +41,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2019-01-01/hh_id_13.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2019-01-01/hh_id_13.yaml
@@ -54,7 +54,7 @@ inputs:
           betrag_m:
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
         sonstige:

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_14.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_14.yaml
@@ -80,7 +80,7 @@ inputs:
             - 0.0
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_19.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_19.yaml
@@ -80,7 +80,7 @@ inputs:
             - 0.0
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_20.yaml
+++ b/src/_gettsim_tests/test_data/einkommensteuer/zu_versteuerndes_einkommen/2020-01-01/hh_id_20.yaml
@@ -80,7 +80,7 @@ inputs:
             - 0.0
             - 0.0
             - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_1.yaml
@@ -96,7 +96,7 @@ inputs:
             - 1.0
             - 2.0
             - 3.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_2.yaml
@@ -96,7 +96,7 @@ inputs:
             - 5.0
             - 6.0
             - 7.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_3.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 8.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_4.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 9.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_5.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 10.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_6.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 11.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_7.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 12.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_8.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 13.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2023-07-01/ohne_unterschied_entgeltpunkte_ost_west.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2023-07-01/ohne_unterschied_entgeltpunkte_ost_west.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 13.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2025-01-01/wohnort_ost_irrelevant.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2025-01-01/wohnort_ost_irrelevant.yaml
@@ -48,7 +48,7 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_m:
             - 13.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
         sonstige:
           alle_weiteren_m:

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/geringfügig_beschäftigt_nur_west.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/1998-01-01/geringfügig_beschäftigt_nur_west.yaml
@@ -29,7 +29,7 @@ inputs:
             geförderte_private_vorsorge_m:
               - 0.0
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
     hh_id:

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/geringfügig_beschäftigt.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/geringfügig_beschäftigt.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 0

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/regulär_beschäftigt.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/regulär_beschäftigt.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 13

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/selbständig_viel_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/selbständig_viel_einkommen.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
     hh_id:
       - 13

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/selbständig_wenig_einkommen.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2002-01-01/selbständig_wenig_einkommen.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
     hh_id:
       - 13

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2004-04-01/rentner.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2004-04-01/rentner.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 13

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_10.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_10.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 10

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_11.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_11.yaml
@@ -30,7 +30,7 @@ inputs:
             geförderte_private_vorsorge_m:
               - 0.0
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
     hh_id:

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_12.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_12.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 12

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_7.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 7

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_8.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 8

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_9.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2010-01-01/hh_id_9.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 9

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_1.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 1

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_2.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 2

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_3.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 3

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_4.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 4

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_5.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 5

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2018-01-01/hh_id_6.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 6

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2019-01-01/hh_id_23.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2019-01-01/hh_id_23.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
     hh_id:
       - 23

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2019-01-01/hh_id_24.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2019-01-01/hh_id_24.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
     hh_id:
       - 24

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2020-01-01/hh_id_15.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2020-01-01/hh_id_15.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 15

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2020-01-01/hh_id_25.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2020-01-01/hh_id_25.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - true
     hh_id:
       - 25

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-01-01/hh_id_16.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-01-01/hh_id_16.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 16

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-01-01/hh_id_17.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-01-01/hh_id_17.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 17

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_18.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_18.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 18

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_19.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_19.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 19

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_20.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_20.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 20

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_21.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_21.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 21

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_22.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2022-10-01/hh_id_22.yaml
@@ -26,7 +26,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 22

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_23.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_23.yaml
@@ -27,7 +27,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 23

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_24.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_24.yaml
@@ -27,7 +27,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 24

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_25.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_25.yaml
@@ -27,7 +27,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 25

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_26.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_26.yaml
@@ -27,7 +27,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 26

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_27.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2023-07-01/hh_id_27.yaml
@@ -27,7 +27,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 27

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/above_new_beitragsbemessungsgrenze.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/above_new_beitragsbemessungsgrenze.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 0

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/above_old_beitragsbemessungsgrenze.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/above_old_beitragsbemessungsgrenze.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 0

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/below_beitragsbemessungsgrenze.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/below_beitragsbemessungsgrenze.yaml
@@ -24,7 +24,7 @@ inputs:
               - 0.0
             geförderte_private_vorsorge_m:
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
     hh_id:
       - 0

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/einkommen_in_gleitzone.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2024-01-01/einkommen_in_gleitzone.yaml
@@ -36,7 +36,7 @@ inputs:
               - 0.0
               - 0.0
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false

--- a/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2025-01-01/einkommen_in_gleitzone.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/beiträge/2025-01-01/einkommen_in_gleitzone.yaml
@@ -36,7 +36,7 @@ inputs:
               - 0.0
               - 0.0
               - 0.0
-        ist_selbstständig:
+        ist_hauptberuflich_selbstständig:
           - false
           - false
           - false


### PR DESCRIPTION
### What problem do you want to solve?

Clarifies the meaning of `ist_selbstständig` by renaming to `ist_hauptberuflich_selbstständig` as discussed in #892.
