### PR TITLE
Vorjahr input names and their namespaces

### DIFF
--- a/outdated_docs/how-to-guides/calculating_elterngeld.ipynb
+++ b/outdated_docs/how-to-guides/calculating_elterngeld.ipynb
@@ -14,10 +14,10 @@
     "\n",
     "In principle, one can compute Elterngeld in three steps:\n",
     "1. Compute the average monthly gross income before birth in the data.\n",
-    "2. Call GETTSIM with the target `elterngeld__nettoeinkommen_approximation_m` using the policy\n",
+    "2. Call GETTSIM with the target `elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m` using the policy\n",
     "   environment of the year **before** the child was born.\n",
     "3. Call GETTSIM with the target `elterngeld__betrag_m` using the outcome of step 2 as the input\n",
-    "   for `elterngeld__nettoeinkommen_vorjahr_m` and the policy environment of the year the\n",
+    "   for `elterngeld__mean_nettoeinkommen_in_12_monaten_vor_geburt_m` and the policy environment of the year the\n",
     "   child was born.\n",
     "\n",
     "In the following, we will explain some more details."
@@ -114,8 +114,8 @@
     "### Step 2: Approximate net wage before birth\n",
     "\n",
     "GETTSIM provides an easy way to compute the relevant net wage\n",
-    "`elterngeld__nettoeinkommen_vorjahr_m` based on step 1 using the target\n",
-    "`elterngeld__nettoeinkommen_approximation_m`.\n",
+    "`elterngeld__mean_nettoeinkommen_in_12_monaten_vor_geburt_m` based on step 1 using the target\n",
+    "`elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m`.\n",
     "\n",
     "We use the policy environment of January 1st of the year before the child was born (§2e\n",
     "Abs. 1 S. 2 BEEG). Note that this is correct regardless of the point in time when the\n",
@@ -135,7 +135,7 @@
     "net_wage_approximation = compute_taxes_and_transfers(\n",
     "    data=data_before_birth,\n",
     "    environment=environment_2023,\n",
-    "    targets=[\"elterngeld__nettoeinkommen_approximation_m\"],\n",
+    "    targets=[\"elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m\"],\n",
     ")\n",
     "\n",
     "net_wage_approximation"
@@ -184,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then, we add `elterngeld__nettoeinkommen_vorjahr_m` to the data based on step 2."
+    "Then, we add `elterngeld__mean_nettoeinkommen_in_12_monaten_vor_geburt_m` to the data based on step 2."
    ]
   },
   {
@@ -194,9 +194,11 @@
    "outputs": [],
    "source": [
     "# Add net wage approximation\n",
-    "data_after_birth[\"elterngeld__nettoeinkommen_vorjahr_m\"] = net_wage_approximation[\n",
-    "    \"elterngeld__nettoeinkommen_approximation_m\"\n",
-    "]"
+    "data_after_birth[\"elterngeld__mean_nettoeinkommen_in_12_monaten_vor_geburt_m\"] = (\n",
+    "    net_wage_approximation[\n",
+    "        \"elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m\"\n",
+    "    ]\n",
+    ")"
    ]
   },
   {

--- a/src/_gettsim/arbeitslosengeld_2/inputs.py
+++ b/src/_gettsim/arbeitslosengeld_2/inputs.py
@@ -7,7 +7,8 @@ from ttsim.tt_dag_elements import FKType, policy_input
 
 @policy_input(start_date="2023-01-01")
 def bezug_im_vorjahr() -> bool:
-    """Whether the person received Arbeitslosengeld 2 / Bürgergeld in the previous year."""
+    """Whether the person received Arbeitslosengeld 2 / Bürgergeld in the previous
+    calendar year."""
 
 
 # TODO(@MImmesberger): Remove input variable eigenbedarf_gedeckt once

--- a/src/_gettsim/arbeitslosengeld_2/inputs.py
+++ b/src/_gettsim/arbeitslosengeld_2/inputs.py
@@ -7,8 +7,7 @@ from ttsim.tt_dag_elements import FKType, policy_input
 
 @policy_input(start_date="2023-01-01")
 def bezug_im_vorjahr() -> bool:
-    """Whether the person received Arbeitslosengeld 2 / Bürgergeld in the previous
-    calendar year."""
+    """Person received Arbeitslosengeld 2 / Bürgergeld in the last 12 months."""
 
 
 # TODO(@MImmesberger): Remove input variable eigenbedarf_gedeckt once

--- a/src/_gettsim/einkommensteuer/einkünfte/aus_nichtselbstständiger_arbeit/inputs.py
+++ b/src/_gettsim/einkommensteuer/einkünfte/aus_nichtselbstständiger_arbeit/inputs.py
@@ -8,8 +8,3 @@ from ttsim.tt_dag_elements import policy_input
 @policy_input()
 def bruttolohn_m() -> float:
     """Monthly wage."""
-
-
-@policy_input()
-def bruttolohn_vorjahr_m() -> float:
-    """Monthly wage of previous year."""

--- a/src/_gettsim/einkommensteuer/einkünfte/sonstige/rente/inputs.py
+++ b/src/_gettsim/einkommensteuer/einkünfte/sonstige/rente/inputs.py
@@ -14,15 +14,6 @@ def alle_weiteren_m() -> float:
     """
 
 
-@policy_input(start_date="2021-01-01")
-def gesamtbetrag_vorjahr_m() -> float:
-    """Income from private and public pensions in the previous year.
-
-    GETTSIM can calculate this input based on the data of the previous year using the
-    target `("einkommensteuer", "einkünfte", "sonstige", "betrag_m")`.
-    """
-
-
 @policy_input()
 def sonstige_private_vorsorge_m() -> float:
     """Monthly payout from private pensions without tax-favored contributions.

--- a/src/_gettsim/elterngeld/einkommen.py
+++ b/src/_gettsim/elterngeld/einkommen.py
@@ -27,13 +27,13 @@ def anzurechnendes_nettoeinkommen_m(
     rounding_spec=RoundingSpec(base=2, direction="down", reference="§ 2 (2) BEEG"),
 )
 def lohnersatzanteil_einkommen_untere_grenze(
-    nettoeinkommen_vorjahr_m: float,
+    mean_nettoeinkommen_in_12_monaten_vor_geburt_m: float,
     nettoeinkommensstufen_für_lohnersatzrate: dict[str, float],
 ) -> float:
     """Lower threshold for replacement rate adjustment minus net income."""
     return (
         nettoeinkommensstufen_für_lohnersatzrate["lower_threshold"]
-        - nettoeinkommen_vorjahr_m
+        - mean_nettoeinkommen_in_12_monaten_vor_geburt_m
     )
 
 
@@ -42,12 +42,12 @@ def lohnersatzanteil_einkommen_untere_grenze(
     rounding_spec=RoundingSpec(base=2, direction="down", reference="§ 2 (2) BEEG"),
 )
 def lohnersatzanteil_einkommen_obere_grenze(
-    nettoeinkommen_vorjahr_m: float,
+    mean_nettoeinkommen_in_12_monaten_vor_geburt_m: float,
     nettoeinkommensstufen_für_lohnersatzrate: dict[str, float],
 ) -> float:
     """Net income minus upper threshold for replacement rate adjustment."""
     return (
-        nettoeinkommen_vorjahr_m
+        mean_nettoeinkommen_in_12_monaten_vor_geburt_m
         - nettoeinkommensstufen_für_lohnersatzrate["upper_threshold"]
     )
 
@@ -102,7 +102,7 @@ def einkommen_vorjahr_unter_bezugsgrenze_ohne_unterscheidung_single_paar(
     start_date="2012-09-18",
     rounding_spec=RoundingSpec(base=0.01, direction="down"),
 )
-def nettoeinkommen_approximation_m(
+def mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m(
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_m: float,
     lohnsteuer__betrag_m: float,
     lohnsteuer__betrag_soli_m: float,

--- a/src/_gettsim/elterngeld/elterngeld.py
+++ b/src/_gettsim/elterngeld/elterngeld.py
@@ -85,7 +85,7 @@ def betrag_m(
 
 @policy_function(start_date="2007-01-01")
 def basisbetrag_m(
-    nettoeinkommen_vorjahr_m: float,
+    mean_nettoeinkommen_in_12_monaten_vor_geburt_m: float,
     lohnersatzanteil: float,
     anzurechnendes_nettoeinkommen_m: float,
     max_zu_berücksichtigendes_einkommen: float,
@@ -96,7 +96,7 @@ def basisbetrag_m(
 
     """
     berücksichtigtes_einkommen = min(
-        nettoeinkommen_vorjahr_m,
+        mean_nettoeinkommen_in_12_monaten_vor_geburt_m,
         max_zu_berücksichtigendes_einkommen,
     )
     return (
@@ -212,7 +212,7 @@ def bezugsmonate_unter_grenze_fg(
 
 @policy_function(start_date="2011-01-01")
 def lohnersatzanteil(
-    nettoeinkommen_vorjahr_m: float,
+    mean_nettoeinkommen_in_12_monaten_vor_geburt_m: float,
     lohnersatzanteil_einkommen_untere_grenze: float,
     lohnersatzanteil_einkommen_obere_grenze: float,
     einkommensschritte_korrektur: float,
@@ -229,9 +229,9 @@ def lohnersatzanteil(
     """
     # Higher replacement rate if considered income is below a threshold
     if (
-        nettoeinkommen_vorjahr_m
+        mean_nettoeinkommen_in_12_monaten_vor_geburt_m
         < nettoeinkommensstufen_für_lohnersatzrate["lower_threshold"]
-        and nettoeinkommen_vorjahr_m > 0
+        and mean_nettoeinkommen_in_12_monaten_vor_geburt_m > 0
     ):
         out = satz + (
             lohnersatzanteil_einkommen_untere_grenze
@@ -240,7 +240,7 @@ def lohnersatzanteil(
         )
     # Lower replacement rate if considered income is above a threshold
     elif (
-        nettoeinkommen_vorjahr_m
+        mean_nettoeinkommen_in_12_monaten_vor_geburt_m
         > nettoeinkommensstufen_für_lohnersatzrate["upper_threshold"]
     ):
         # Replacement rate is only lowered up to a specific value

--- a/src/_gettsim/elterngeld/inputs.py
+++ b/src/_gettsim/elterngeld/inputs.py
@@ -31,5 +31,5 @@ def zu_versteuerndes_einkommen_vorjahr_y_sn() -> float:
 
     To compute this value using GETTSIM set `('einkommensteuer',
     'zu_versteuerndes_einkommen_y_sn')` as the TT target and use input data from the
-    year prior to the youngest child's birth year.
+    calendar year prior to the youngest child's birth year.
     """

--- a/src/_gettsim/elterngeld/inputs.py
+++ b/src/_gettsim/elterngeld/inputs.py
@@ -16,10 +16,23 @@ def claimed() -> bool:
 
 
 @policy_input()
-def nettoeinkommen_vorjahr_m() -> float:
-    """Net wage in the 12 months before birth of youngest child."""
+def mean_nettoeinkommen_in_12_monaten_vor_geburt_m() -> float:
+    """Mean net wage in the 12 months before birth of youngest child.
+
+    To compute this value using GETTSIM:
+    1. Use `elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m` as
+    the TT target
+    2. Apply it to data from the last 12 months before the birth of the youngest child
+    3. Use the result as input for this column.
+    """
 
 
 @policy_input()
 def zu_versteuerndes_einkommen_vorjahr_y_sn() -> float:
-    """Taxable income in the calendar year prior to the youngest child's birth year."""
+    """Taxable income in the calendar year prior to the youngest child's birth year.
+
+    To compute this value using GETTSIM:
+    1. Use `einkommensteuer__zu_versteuerndes_einkommen_y_sn` as the TT target
+    2. Apply it to data from the year prior to the youngest child's birth year
+    3. Use the result as input for this column.
+    """

--- a/src/_gettsim/elterngeld/inputs.py
+++ b/src/_gettsim/elterngeld/inputs.py
@@ -19,11 +19,9 @@ def claimed() -> bool:
 def mean_nettoeinkommen_in_12_monaten_vor_geburt_m() -> float:
     """Mean net wage in the 12 months before birth of youngest child.
 
-    To compute this value using GETTSIM:
-    1. Use `elterngeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m` as
-    the TT target
-    2. Apply it to data from the last 12 months before the birth of the youngest child
-    3. Use the result as input for this column.
+    To compute this value using GETTSIM set `('elterngeld',
+    'mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m')` as the TT target and
+    use input data from the last 12 months before the birth of the youngest child.
     """
 
 
@@ -31,8 +29,7 @@ def mean_nettoeinkommen_in_12_monaten_vor_geburt_m() -> float:
 def zu_versteuerndes_einkommen_vorjahr_y_sn() -> float:
     """Taxable income in the calendar year prior to the youngest child's birth year.
 
-    To compute this value using GETTSIM:
-    1. Use `einkommensteuer__zu_versteuerndes_einkommen_y_sn` as the TT target
-    2. Apply it to data from the year prior to the youngest child's birth year
-    3. Use the result as input for this column.
+    To compute this value using GETTSIM set `('einkommensteuer',
+    'zu_versteuerndes_einkommen_y_sn')` as the TT target and use input data from the
+    year prior to the youngest child's birth year.
     """

--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -107,7 +107,7 @@ def anspruchshöhe_kind_mit_budgetsatz_m(
     For the calculation, the relevant income, the age of the youngest child, the income
     threshold and the eligibility for erziehungsgeld is needed.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6
+    Legal reference: BGBl I. v. 17.02.2004
     """
     if ist_leistungsbegründendes_kind:
         out = max(
@@ -154,7 +154,7 @@ def abzug_durch_einkommen_m(
 ) -> float:
     """Reduction of parental leave benefits (means-test).
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (p.209)
+    Legal reference: BGBl I. v. 17.02.2004 S.209
     """
     if (
         anzurechnendes_einkommen_m > einkommensgrenze_m
@@ -180,7 +180,7 @@ def _leistungsbegründendes_kind_vor_abschaffung(
 ) -> bool:
     """Eligibility for parental leave benefit (Erziehungsgeld) on child level.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.207)
+    Legal reference: BGBl I. v. 17.02.2004 S.207
     """
     if budgetsatz:
         out = p_id_empfänger >= 0 and alter_monate <= maximales_kindsalter_budgetsatz
@@ -216,7 +216,7 @@ def _leistungsbegründendes_kind_nach_abschaffung(
 
     Abolished for children born after the cut-off date.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.207)
+    Legal reference: BGBl I. v. 17.02.2004 S.207
     """
     if budgetsatz and geburtsjahr <= abolishment_cohort:
         out = p_id_empfänger >= 0 and alter_monate <= maximales_kindsalter_budgetsatz
@@ -238,7 +238,7 @@ def grundsätzlich_anspruchsberechtigt(
 ) -> bool:
     """Eligibility for parental leave benefit (Erziehungsgeld) on parental level.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (p.207)
+    Legal reference: BGBl I. v. 17.02.2004 S.207
     """
     return leistungsbegründende_kinder_fg and (
         arbeitsstunden_w <= maximale_wochenarbeitszeit
@@ -247,7 +247,7 @@ def grundsätzlich_anspruchsberechtigt(
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
 def anzurechnendes_einkommen_y(
-    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_y_fg: float,
+    bruttolohn_vorjahr_y_fg: float,
     familie__anzahl_erwachsene_fg: int,
     ist_leistungsbegründendes_kind: bool,
     pauschaler_abzug_vom_einkommen: float,
@@ -255,14 +255,14 @@ def anzurechnendes_einkommen_y(
 ) -> float:
     """Income relevant for means testing for parental leave benefit (Erziehungsgeld).
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (p.209)
+    Legal reference: BGBl I. v. 17.02.2004 S.209
 
     There is special rule for "Beamte, Soldaten und Richter" which is not
     implemented yet.
     """
     if ist_leistungsbegründendes_kind:
         out = (
-            einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_y_fg
+            bruttolohn_vorjahr_y_fg
             - einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__arbeitnehmerpauschbetrag
             * familie__anzahl_erwachsene_fg
         ) * pauschaler_abzug_vom_einkommen
@@ -280,7 +280,7 @@ def einkommensgrenze_y(
 ) -> float:
     """Income threshold for parental leave benefit (Erziehungsgeld).
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.208)
+    Legal reference: BGBl I. v. 17.02.2004 S.208
     """
     out = (
         einkommensgrenze_ohne_geschwisterbonus
@@ -301,7 +301,7 @@ def einkommensgrenze_ohne_geschwisterbonus(
     """Income threshold for parental leave benefit (Erziehungsgeld) before adding the
     bonus for additional children.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.208)
+    Legal reference: BGBl I. v. 17.02.2004 S.208
     """
     if alter_monate < altersgrenze_für_reduziertes_einkommenslimit_kind_monate:
         return einkommensgrenze_ohne_geschwisterbonus_kind_jünger_als_reduzierungsgrenze
@@ -317,7 +317,7 @@ def einkommensgrenze_ohne_geschwisterbonus_kind_jünger_als_reduzierungsgrenze(
 ) -> float:
     """Base income threshold for parents of children younger than the age threshold.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.208)
+    Legal reference: BGBl I. v. 17.02.2004 S.208
     """
     if budgetsatz and familie__alleinerziehend_fg:
         return einkommensgrenze.regulär_alleinerziehend["budgetsatz"]
@@ -337,7 +337,7 @@ def einkommensgrenze_ohne_geschwisterbonus_kind_älter_als_reduzierungsgrenze(
 ) -> float:
     """Base income threshold for parents of children older than age threshold.
 
-    Legal reference: Bundesgesetzblatt Jahrgang 2004 Teil I Nr. 6 (pp.208)
+    Legal reference: BGBl I. v. 17.02.2004 S.208
     """
     if budgetsatz and familie__alleinerziehend_fg:
         return einkommensgrenze.reduziert_alleinerziehend["budgetsatz"]

--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -99,7 +99,7 @@ def erziehungsgeld_kind_ohne_budgetsatz_m() -> NotImplementedError:
 )
 def anspruchshöhe_kind_mit_budgetsatz_m(
     ist_leistungsbegründendes_kind: bool,
-    abzug_durch_einkommen_m: float,
+    abzug_durch_einkommen_m_fg: float,
     basisbetrag_m: float,
 ) -> float:
     """Parental leave benefit (Erziehungsgeld) on child level.
@@ -110,29 +110,23 @@ def anspruchshöhe_kind_mit_budgetsatz_m(
     Legal reference: BGBl I. v. 17.02.2004
     """
     if ist_leistungsbegründendes_kind:
-        out = max(
-            basisbetrag_m - abzug_durch_einkommen_m,
-            0.0,
-        )
+        return max(basisbetrag_m - abzug_durch_einkommen_m_fg, 0.0)
     else:
-        out = 0.0
-
-    return out
+        return 0.0
 
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
 def basisbetrag_m(
     budgetsatz: bool,
-    anzurechnendes_einkommen_y: float,
-    einkommensgrenze_y: float,
+    anzurechnendes_einkommen_y_fg: float,
+    einkommensgrenze_y_fg: float,
     alter_monate: int,
     altersgrenze_für_reduziertes_einkommenslimit_kind_monate: int,
     satz: dict[str, float],
 ) -> float:
     """Parental leave benefit (Erziehungsgeld) without means-test on child level."""
-    # no benefit if income is above threshold and child is younger than threshold
     if (
-        anzurechnendes_einkommen_y > einkommensgrenze_y
+        anzurechnendes_einkommen_y_fg > einkommensgrenze_y_fg
         and alter_monate < altersgrenze_für_reduziertes_einkommenslimit_kind_monate
     ):
         out = 0.0
@@ -145,9 +139,9 @@ def basisbetrag_m(
 
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
-def abzug_durch_einkommen_m(
-    anzurechnendes_einkommen_m: float,
-    einkommensgrenze_m: float,
+def abzug_durch_einkommen_m_fg(
+    anzurechnendes_einkommen_m_fg: float,
+    einkommensgrenze_m_fg: float,
     alter_monate: int,
     altersgrenze_für_reduziertes_einkommenslimit_kind_monate: float,
     abschlagsfaktor: float,
@@ -157,10 +151,10 @@ def abzug_durch_einkommen_m(
     Legal reference: BGBl I. v. 17.02.2004 S.209
     """
     if (
-        anzurechnendes_einkommen_m > einkommensgrenze_m
+        anzurechnendes_einkommen_m_fg > einkommensgrenze_m_fg
         and alter_monate >= altersgrenze_für_reduziertes_einkommenslimit_kind_monate
     ):
-        out = anzurechnendes_einkommen_m * abschlagsfaktor
+        out = anzurechnendes_einkommen_m_fg * abschlagsfaktor
     else:
         out = 0.0
     return out
@@ -246,8 +240,8 @@ def grundsätzlich_anspruchsberechtigt(
 
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
-def anzurechnendes_einkommen_y(
-    bruttolohn_vorjahr_abzüglich_werbungskosten_y: float,
+def anzurechnendes_einkommen_y_fg(
+    bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg: float,
     ist_leistungsbegründendes_kind: bool,
     pauschaler_abzug_vom_einkommen: float,
 ) -> float:
@@ -260,7 +254,7 @@ def anzurechnendes_einkommen_y(
     """
     if ist_leistungsbegründendes_kind:
         out = (
-            bruttolohn_vorjahr_abzüglich_werbungskosten_y
+            bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg
             * pauschaler_abzug_vom_einkommen
         )
     else:
@@ -269,7 +263,7 @@ def anzurechnendes_einkommen_y(
 
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
-def einkommensgrenze_y(
+def einkommensgrenze_y_fg(
     einkommensgrenze_ohne_geschwisterbonus: float,
     familie__anzahl_kinder_fg: float,
     ist_leistungsbegründendes_kind: bool,
@@ -279,13 +273,13 @@ def einkommensgrenze_y(
 
     Legal reference: BGBl I. v. 17.02.2004 S.208
     """
-    out = (
-        einkommensgrenze_ohne_geschwisterbonus
-        + (familie__anzahl_kinder_fg - 1) * aufschlag_einkommen
-    )
-    if not ist_leistungsbegründendes_kind:
-        out = 0.0
-    return out
+    if ist_leistungsbegründendes_kind:
+        return (
+            einkommensgrenze_ohne_geschwisterbonus
+            + (familie__anzahl_kinder_fg - 1) * aufschlag_einkommen
+        )
+    else:
+        return 0.0
 
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")

--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -241,7 +241,7 @@ def grundsätzlich_anspruchsberechtigt(
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
 def anzurechnendes_einkommen_y_fg(
-    bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg: float,
+    bruttolohn_vorjahr_nach_abzug_werbungskosten_y_fg: float,
     ist_leistungsbegründendes_kind: bool,
     pauschaler_abzug_vom_einkommen: float,
 ) -> float:
@@ -254,7 +254,7 @@ def anzurechnendes_einkommen_y_fg(
     """
     if ist_leistungsbegründendes_kind:
         out = (
-            bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg
+            bruttolohn_vorjahr_nach_abzug_werbungskosten_y_fg
             * pauschaler_abzug_vom_einkommen
         )
     else:

--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -247,11 +247,9 @@ def grundsätzlich_anspruchsberechtigt(
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
 def anzurechnendes_einkommen_y(
-    bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg: float,
-    familie__anzahl_erwachsene_fg: int,
+    bruttolohn_vorjahr_abzüglich_werbungskosten_y: float,
     ist_leistungsbegründendes_kind: bool,
     pauschaler_abzug_vom_einkommen: float,
-    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__arbeitnehmerpauschbetrag: float,
 ) -> float:
     """Income relevant for means testing for parental leave benefit (Erziehungsgeld).
 
@@ -262,10 +260,9 @@ def anzurechnendes_einkommen_y(
     """
     if ist_leistungsbegründendes_kind:
         out = (
-            bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg
-            - einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__arbeitnehmerpauschbetrag
-            * familie__anzahl_erwachsene_fg
-        ) * pauschaler_abzug_vom_einkommen
+            bruttolohn_vorjahr_abzüglich_werbungskosten_y
+            * pauschaler_abzug_vom_einkommen
+        )
     else:
         out = 0.0
     return out

--- a/src/_gettsim/erziehungsgeld/erziehungsgeld.py
+++ b/src/_gettsim/erziehungsgeld/erziehungsgeld.py
@@ -247,7 +247,7 @@ def grundsätzlich_anspruchsberechtigt(
 
 @policy_function(start_date="2004-01-01", end_date="2008-12-31")
 def anzurechnendes_einkommen_y(
-    bruttolohn_vorjahr_y_fg: float,
+    bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg: float,
     familie__anzahl_erwachsene_fg: int,
     ist_leistungsbegründendes_kind: bool,
     pauschaler_abzug_vom_einkommen: float,
@@ -262,7 +262,7 @@ def anzurechnendes_einkommen_y(
     """
     if ist_leistungsbegründendes_kind:
         out = (
-            bruttolohn_vorjahr_y_fg
+            bruttolohn_vorjahr_abzüglich_werbungskosten_y_fg
             - einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__arbeitnehmerpauschbetrag
             * familie__anzahl_erwachsene_fg
         ) * pauschaler_abzug_vom_einkommen

--- a/src/_gettsim/erziehungsgeld/inputs.py
+++ b/src/_gettsim/erziehungsgeld/inputs.py
@@ -6,6 +6,11 @@ from ttsim.tt_dag_elements import FKType, policy_input
 
 
 @policy_input(end_date="2008-12-31")
+def bruttolohn_vorjahr_y() -> float:
+    """Gross earnings of the previous year."""
+
+
+@policy_input(end_date="2008-12-31")
 def budgetsatz() -> bool:
     """Applied for "Budgetsatz" of parental leave benefit."""
 

--- a/src/_gettsim/erziehungsgeld/inputs.py
+++ b/src/_gettsim/erziehungsgeld/inputs.py
@@ -6,12 +6,13 @@ from ttsim.tt_dag_elements import FKType, policy_input
 
 
 @policy_input(end_date="2008-12-31")
-def bruttolohn_vorjahr_abzüglich_werbungskosten_y() -> float:
-    """Gross earnings of the previous year minus Werbungskosten.
+def bruttolohn_vorjahr_nach_abzug_werbungskosten_y() -> float:
+    """Gross earnings of the previous calendar year minus Werbungskosten.
 
     To compute this value using GETTSIM set `('einkommensteuer', 'einkünfte',
     'aus_nichtselbstständiger_arbeit', 'einnahmen_nach_abzug_werbungskosten_y')` as the
-    TT target and use input data from the year prior to the youngest child's birth year.
+    TT target and use input data from the calendar year prior to the youngest child's
+    birth year.
     """
 
 

--- a/src/_gettsim/erziehungsgeld/inputs.py
+++ b/src/_gettsim/erziehungsgeld/inputs.py
@@ -6,8 +6,13 @@ from ttsim.tt_dag_elements import FKType, policy_input
 
 
 @policy_input(end_date="2008-12-31")
-def bruttolohn_vorjahr_y() -> float:
-    """Gross earnings of the previous year."""
+def bruttolohn_vorjahr_abzüglich_werbungskosten_y() -> float:
+    """Gross earnings of the previous year minus Werbungskosten.
+
+    To compute this value using GETTSIM set `('einkommensteuer', 'einkünfte',
+    'aus_nichtselbstständiger_arbeit', 'einnahmen_nach_abzug_werbungskosten_y')` as the
+    TT target and use input data from the year prior to the youngest child's birth year.
+    """
 
 
 @policy_input(end_date="2008-12-31")

--- a/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
@@ -118,7 +118,7 @@ def grundsätzlich_anspruchsberechtigt(
 @policy_function()
 def mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y(
     sozialversicherung__rente__beitrag__beitragsbemessungsgrenze_y: float,
-    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_y: float,
+    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y: float,
     sozialversicherungspauschale: float,
     einkommensteuer__parameter_einkommensteuertarif: PiecewisePolynomialParamValue,
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__arbeitnehmerpauschbetrag: float,
@@ -134,7 +134,7 @@ def mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y(
     be the gross wage in the calendar year before unemployment.
     """
     berücksichtigungsfähige_einnahmen = min(
-        einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_y,
+        einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y,
         sozialversicherung__rente__beitrag__beitragsbemessungsgrenze_y,
     )
     pauschalisierte_sozialversicherungsbeiträge = (

--- a/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
@@ -116,7 +116,7 @@ def grundsätzlich_anspruchsberechtigt(
 
 
 @policy_function()
-def mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y(
+def mean_nettoeinkommen_für_bemessungsgrundlage_bei_arbeitslosigkeit_y(
     sozialversicherung__rente__beitrag__beitragsbemessungsgrenze_y: float,
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y: float,
     sozialversicherungspauschale: float,
@@ -125,7 +125,7 @@ def mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y(
     solidaritätszuschlag__parameter_solidaritätszuschlag: PiecewisePolynomialParamValue,
     xnp: ModuleType,
 ) -> float:
-    """Approximate last years income for unemployment benefit.
+    """Approximate the income relevant for calculating unemployment insurance benefits.
 
     This target can be used as an input in another GETTSIM call to compute
     Arbeitslosengeld. In principle, the relevant gross wage for this target is the sum

--- a/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/arbeitslosengeld.py
@@ -133,13 +133,13 @@ def mean_nettoeinkommen_für_bemessungsgrundlage_bei_arbeitslosigkeit_y(
         einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_y,
         sozialversicherung__rente__beitrag__beitragsbemessungsgrenze_y,
     )
-    pauschalisierte_sozialversicherungsbeiträge = (
+    pauschalierte_sozialversicherungsbeiträge = (
         sozialversicherungspauschale * berücksichtigungsfähige_einnahmen
     )
     return max(
         (
             berücksichtigungsfähige_einnahmen
-            - pauschalisierte_sozialversicherungsbeiträge
+            - pauschalierte_sozialversicherungsbeiträge
             - lohnsteuer__betrag_y
             - lohnsteuer__betrag_soli_y
         ),

--- a/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
@@ -9,11 +9,9 @@ from ttsim.tt_dag_elements import policy_input
 def mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m() -> float:
     """Mean net wage in the 12 months before unemployment.
 
-    To compute this value using GETTSIM:
-    1. Use `arbeitslosengeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y`
-    as the TT target
-    2. Apply it to data from the 12 months before the unemployment
-    3. Use the result as input for this column.
+    To compute this value using GETTSIM set `('arbeitslosengeld',
+    'mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y')` as the TT
+    target and use input data from the 12 months before the unemployment.
     """
 
 

--- a/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
@@ -6,6 +6,18 @@ from ttsim.tt_dag_elements import policy_input
 
 
 @policy_input()
+def mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m() -> float:
+    """Mean net wage in the 12 months before unemployment.
+
+    To compute this value using GETTSIM:
+    1. Use `arbeitslosengeld__mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y`
+    as the TT target
+    2. Apply it to data from the 12 months before the unemployment
+    3. Use the result as input for this column.
+    """
+
+
+@policy_input()
 def monate_beitragspflichtig_versichert_in_letzten_30_monaten() -> int:
     """Number of months of compulsory insurance in the 30 months before claiming unemployment."""
 

--- a/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
+++ b/src/_gettsim/sozialversicherung/arbeitslosen/inputs.py
@@ -10,7 +10,7 @@ def mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m() -> float:
     """Mean net wage in the 12 months before unemployment.
 
     To compute this value using GETTSIM set `('arbeitslosengeld',
-    'mean_nettoeinkommen_für_bemessungsgrundllage_nach_arbeitslosigkeit_y')` as the TT
+    'mean_nettoeinkommen_für_bemessungsgrundlage_bei_arbeitslosigkeit_y')` as the TT
     target and use input data from the 12 months before the unemployment.
     """
 

--- a/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
@@ -30,10 +30,10 @@ def betrag_m(basisbetrag_m: float, anzurechnendes_einkommen_m: float) -> float:
 @policy_function(start_date="2021-01-01")
 def einkommen_m(
     gesamteinnahmen_aus_renten_vorjahr_m: float,
-    einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_m: float,
-    einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_m: float,
-    einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_m: float,
-    einkommensteuer__einkünfte__aus_kapitalvermögen__betrag_m: float,
+    bruttolohn_vorjahr_m: float,
+    einnahmen_aus_selbstständiger_arbeit_vorvorjahr_m: float,
+    einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_m: float,
+    einnahmen_aus_kapitalvermögen_vorvorjahr_m: float,
 ) -> float:
     """Income relevant for Grundrentenzuschlag before deductions.
 
@@ -45,9 +45,6 @@ def einkommen_m(
       to be able to use administrative data on this income for the calculation: "It can
       be assumed that the tax office regularly has the data two years after the end of
       the assessment period, which can be retrieved from the pension insurance."
-    - Warning: Currently, earnings of dependent work and pensions are based on the last
-      year, and other income on the current year instead of the year two years ago to
-      avoid the need for several new input variables.
     - Warning: Freibeträge for income are currently not considered as `freibeträge_y`
       depends on pension income through
       `sozialversicherung__kranken__beitrag__betrag_versicherter_m` ->
@@ -58,10 +55,10 @@ def einkommen_m(
     # Sum income over different income sources.
     return (
         gesamteinnahmen_aus_renten_vorjahr_m
-        + einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_m
-        + einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_m  # income from self-employment
-        + einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_m  # rental income
-        + einkommensteuer__einkünfte__aus_kapitalvermögen__betrag_m
+        + bruttolohn_vorjahr_m
+        + einnahmen_aus_selbstständiger_arbeit_vorvorjahr_m
+        + einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_m
+        + einnahmen_aus_kapitalvermögen_vorvorjahr_m
     )
 
 

--- a/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
@@ -265,7 +265,7 @@ def gesamteinnahmen_aus_renten_für_einkommensberechnung_im_folgejahr_m(
     einkommensteuer__einkünfte__sonstige__rente__sonstige_private_vorsorge_m: float,
     einkommensteuer__einkünfte__sonstige__rente__betriebliche_altersvorsorge_m: float,
 ) -> float:
-    """Income from private and public pensions in the previous year.
+    """Income from private and public pensions in the previous calendar year.
 
     This target can be used as an input in another GETTSIM call to compute Grundrente.
     """

--- a/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/grundrente.py
@@ -29,7 +29,7 @@ def betrag_m(basisbetrag_m: float, anzurechnendes_einkommen_m: float) -> float:
 
 @policy_function(start_date="2021-01-01")
 def einkommen_m(
-    einkommensteuer__einkünfte__sonstige__rente__gesamtbetrag_vorjahr_m: float,
+    gesamteinnahmen_aus_renten_vorjahr_m: float,
     einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_m: float,
     einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_m: float,
     einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_m: float,
@@ -57,7 +57,7 @@ def einkommen_m(
     """
     # Sum income over different income sources.
     return (
-        einkommensteuer__einkünfte__sonstige__rente__gesamtbetrag_vorjahr_m
+        gesamteinnahmen_aus_renten_vorjahr_m
         + einkommensteuer__einkünfte__aus_nichtselbstständiger_arbeit__bruttolohn_vorjahr_m
         + einkommensteuer__einkünfte__aus_selbstständiger_arbeit__betrag_m  # income from self-employment
         + einkommensteuer__einkünfte__aus_vermietung_und_verpachtung__betrag_m  # rental income
@@ -258,3 +258,24 @@ def grundsätzlich_anspruchsberechtigt(
 ) -> bool:
     """Has accumulated enough insured years to be eligible."""
     return grundrentenzeiten_monate >= berücksichtigte_wartezeit_monate["min"]
+
+
+@policy_function(start_date="2021-01-01")
+def gesamteinnahmen_aus_renten_für_einkommensberechnung_im_folgejahr_m(
+    sozialversicherung__rente__altersrente__betrag_m: float,
+    sozialversicherung__rente__erwerbsminderung__betrag_m: float,
+    einkommensteuer__einkünfte__sonstige__rente__geförderte_private_vorsorge_m: float,
+    einkommensteuer__einkünfte__sonstige__rente__sonstige_private_vorsorge_m: float,
+    einkommensteuer__einkünfte__sonstige__rente__betriebliche_altersvorsorge_m: float,
+) -> float:
+    """Income from private and public pensions in the previous year.
+
+    This target can be used as an input in another GETTSIM call to compute Grundrente.
+    """
+    return (
+        sozialversicherung__rente__altersrente__betrag_m
+        + sozialversicherung__rente__erwerbsminderung__betrag_m
+        + einkommensteuer__einkünfte__sonstige__rente__geförderte_private_vorsorge_m
+        + einkommensteuer__einkünfte__sonstige__rente__sonstige_private_vorsorge_m
+        + einkommensteuer__einkünfte__sonstige__rente__betriebliche_altersvorsorge_m
+    )

--- a/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
@@ -39,7 +39,7 @@ def bruttolohn_vorjahr_y() -> float:
 
 @policy_input(start_date="2021-01-01")
 def einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y() -> float:
-    """Earnings from self-employment in the year before the previous year.
+    """Earnings from self-employment 2 years before.
 
     Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
     """
@@ -47,7 +47,7 @@ def einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y() -> float:
 
 @policy_input(start_date="2021-01-01")
 def einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y() -> float:
-    """Earnings from rental income in the year before the previous year.
+    """Earnings from rental income 2 years before.
 
     Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
     """
@@ -55,7 +55,7 @@ def einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y() -> float:
 
 @policy_input(start_date="2021-01-01")
 def einnahmen_aus_kapitalvermögen_vorvorjahr_y() -> float:
-    """Earnings from capital income in the year before the previous year.
+    """Earnings from capital income 2 years before.
 
     Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
     """

--- a/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
@@ -18,3 +18,12 @@ def grundrentenzeiten_monate() -> int:
 @policy_input(start_date="2021-01-01")
 def mean_entgeltpunkte() -> float:
     """Mean Entgeltpunkte during Bewertungszeiten."""
+
+
+@policy_input(start_date="2021-01-01")
+def gesamteinnahmen_aus_renten_vorjahr_m() -> float:
+    """Income from private and public pensions in the previous year.
+
+    GETTSIM can calculate this input based on the data of the previous year using the
+    target `('sozialversicherung', 'rente', 'grundrente', 'gesamteinnahmen_aus_renten_für_einkommensberechnung_im_folgejahr_m')`.
+    """

--- a/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
@@ -27,3 +27,35 @@ def gesamteinnahmen_aus_renten_vorjahr_m() -> float:
     GETTSIM can calculate this input based on the data of the previous year using the
     target `('sozialversicherung', 'rente', 'grundrente', 'gesamteinnahmen_aus_renten_für_einkommensberechnung_im_folgejahr_m')`.
     """
+
+
+@policy_input(start_date="2021-01-01")
+def bruttolohn_vorjahr_y() -> float:
+    """Earnings in the previous year.
+
+    Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
+    """
+
+
+@policy_input(start_date="2021-01-01")
+def einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y() -> float:
+    """Earnings from self-employment in the year before the previous year.
+
+    Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
+    """
+
+
+@policy_input(start_date="2021-01-01")
+def einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y() -> float:
+    """Earnings from rental income in the year before the previous year.
+
+    Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
+    """
+
+
+@policy_input(start_date="2021-01-01")
+def einnahmen_aus_kapitalvermögen_vorvorjahr_y() -> float:
+    """Earnings from capital income in the year before the previous year.
+
+    Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
+    """

--- a/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
+++ b/src/_gettsim/sozialversicherung/rente/grundrente/inputs.py
@@ -22,16 +22,16 @@ def mean_entgeltpunkte() -> float:
 
 @policy_input(start_date="2021-01-01")
 def gesamteinnahmen_aus_renten_vorjahr_m() -> float:
-    """Income from private and public pensions in the previous year.
+    """Income from private and public pensions in the previous calendar year.
 
-    GETTSIM can calculate this input based on the data of the previous year using the
+    GETTSIM can calculate this input based on the data of the previous calendar year using the
     target `('sozialversicherung', 'rente', 'grundrente', 'gesamteinnahmen_aus_renten_für_einkommensberechnung_im_folgejahr_m')`.
     """
 
 
 @policy_input(start_date="2021-01-01")
 def bruttolohn_vorjahr_y() -> float:
-    """Earnings in the previous year.
+    """Earnings in the previous calendar year.
 
     Calculation is based on the 'Einnahmen' definitions of the basic tax law (EStG).
     """

--- a/src/_gettsim_tests/test_data/elterngeld/2017-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2017-01-01/hh_id_2.yaml
@@ -29,7 +29,7 @@ inputs:
         - 0
       claimed:
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1800.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 18260.0

--- a/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_1.yaml
@@ -27,7 +27,7 @@ inputs:
         - 0
       claimed:
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_2.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1800.0
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_3.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 900.0
         - 3600.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_4.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - false
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
         - 3400.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2018-01-01/hh_id_6.yaml
@@ -27,7 +27,7 @@ inputs:
         - 0
       claimed:
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 900.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 7406.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_1.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_3.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 900.0
         - 0.0
         - 3400.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_5.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 3600.0
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_6.yaml
@@ -43,7 +43,7 @@ inputs:
         - false
         - false
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
         - 0.0
         - 900.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_7.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1800.0
         - 1800.0
         - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2019-01-01/hh_id_8.yaml
@@ -51,7 +51,7 @@ inputs:
         - false
         - false
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
         - 0.0
         - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/income_during_elterngeld.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/income_during_elterngeld.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1000.0
         - 0.0
         - 3400.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/maximum_elterngeld.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/maximum_elterngeld.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 3600.0
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/minimum_elterngeld.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/minimum_elterngeld.yaml
@@ -35,7 +35,7 @@ inputs:
       claimed:
         - true
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 0.0
         - 0.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_approximation.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_approximation.yaml
@@ -60,6 +60,6 @@ inputs:
       - false
 outputs:
   elterngeld:
-    nettoeinkommen_approximation_m:
+    mean_nettoeinkommen_für_bemessungsgrundllage_nach_geburt_m:
       - 790.0
       - 158.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_before_birth_1000.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_before_birth_1000.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1000.0
         - 0.0
         - 3400.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_before_birth_790.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/net_income_before_birth_790.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 790.0
         - 0.0
         - 3400.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-01-01/replacement_rate_decrease.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-01-01/replacement_rate_decrease.yaml
@@ -39,7 +39,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1220.0
         - 0.0
         - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-04-01/taxable_income_low.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-04-01/taxable_income_low.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2000.0
         - 13000.0
         - 0.0

--- a/src/_gettsim_tests/test_data/elterngeld/2024-04-01/taxable_income_too_high.yaml
+++ b/src/_gettsim_tests/test_data/elterngeld/2024-04-01/taxable_income_too_high.yaml
@@ -43,7 +43,7 @@ inputs:
         - true
         - false
         - false
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2000.0
         - 13000.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
@@ -24,14 +24,10 @@ inputs:
           bruttolohn_m:
             - 1500.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1500.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1500.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - true

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
@@ -28,7 +28,7 @@ inputs:
             - 1500.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1500.0
         - 0.0
     erziehungsgeld:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
@@ -25,7 +25,7 @@ inputs:
             - 1500.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1423.33
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
@@ -26,7 +26,7 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1500.0
+        - 1423.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_budgetsatz.yaml
@@ -75,12 +75,12 @@ outputs:
     anspruchshöhe_kind_m:
       - 0.0
       - 450.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 12980.8
     betrag_m:
       - 450.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 13500

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
@@ -26,7 +26,7 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1700.0
+        - 1623.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
@@ -24,14 +24,10 @@ inputs:
           bruttolohn_m:
             - 1400.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1700.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1700.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
@@ -75,12 +75,12 @@ outputs:
     anspruchshöhe_kind_m:
       - 0.0
       - 235.8
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 14804.8
     betrag_m:
       - 235.8
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 13500

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
@@ -28,7 +28,7 @@ inputs:
             - 1700.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1700.0
         - 0.0
     erziehungsgeld:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_high_income.yaml
@@ -25,7 +25,7 @@ inputs:
             - 1400.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1623.33
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
@@ -24,14 +24,10 @@ inputs:
           bruttolohn_m:
             - 1500.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1500.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1500.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
@@ -28,7 +28,7 @@ inputs:
             - 1500.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1500.0
         - 0.0
     erziehungsgeld:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
@@ -25,7 +25,7 @@ inputs:
             - 1500.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1423.33
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
@@ -75,12 +75,12 @@ outputs:
     anspruchshöhe_kind_m:
       - 0.0
       - 300.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 12980.8
     betrag_m:
       - 300.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 13500

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/alleinerz_one_child_regelsatz_low_income.yaml
@@ -26,7 +26,7 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1500.0
+        - 1423.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
@@ -94,7 +94,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 56969.6
@@ -102,7 +102,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 22086

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
@@ -29,16 +29,11 @@ inputs:
             - 1400.0
             - 5000.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1400.0
-            - 5000.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1400.0
         - 5000.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
@@ -30,7 +30,7 @@ inputs:
             - 5000.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1323.33
         - 4923.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
@@ -31,8 +31,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1400.0
-        - 5000.0
+        - 1323.33
+        - 4923.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_high_income.yaml
@@ -34,7 +34,7 @@ inputs:
             - 5000.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1400.0
         - 5000.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
@@ -30,7 +30,7 @@ inputs:
             - 3000.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1323.33
         - 2923.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
@@ -31,8 +31,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1400.0
-        - 3000.0
+        - 1323.33
+        - 2923.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
@@ -94,7 +94,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 38729.6
@@ -102,7 +102,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 22086

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
@@ -34,7 +34,7 @@ inputs:
             - 3000.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1400.0
         - 3000.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_budgetsatz_low_income.yaml
@@ -29,16 +29,11 @@ inputs:
             - 1400.0
             - 3000.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1400.0
-            - 3000.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1400.0
         - 3000.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
@@ -34,7 +34,7 @@ inputs:
             - 2500.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2500.0
         - 2500.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
@@ -30,7 +30,7 @@ inputs:
             - 2500.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 2423.33
         - 2423.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
@@ -31,8 +31,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 2500.0
-        - 2500.0
+        - 2423.33
+        - 2423.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
@@ -29,16 +29,11 @@ inputs:
             - 2500.0
             - 2500.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 2500.0
-            - 2500.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 2500.0
         - 2500.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_one_child_regelsatz.yaml
@@ -94,7 +94,7 @@ outputs:
       - 0.0
       - 0.0
       - 108.4597333
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 44201.6
@@ -102,7 +102,7 @@ outputs:
       - 108.4597333
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 16500

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -36,8 +36,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1400.0
-        - 1700.0
+        - 1323.33
+        - 1623.33
         - 0.0
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -35,7 +35,7 @@ inputs:
             - 0.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1323.33
         - 1623.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -40,7 +40,7 @@ inputs:
             - 0.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1400.0
         - 1700.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -34,18 +34,12 @@ inputs:
             - 1700.0
             - 0.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1400.0
-            - 1700.0
-            - 0.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1400.0
         - 1700.0
         - 0.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -113,7 +113,7 @@ outputs:
       - 0.0
       - 333.55
       - 300.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 26873.6
@@ -123,7 +123,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 19640

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -40,7 +40,7 @@ inputs:
             - 0.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 400.0
         - 1300.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -34,18 +34,12 @@ inputs:
             - 1300.0
             - 0.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 400.0
-            - 1300.0
-            - 0.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 400.0
         - 1300.0
         - 0.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -119,7 +119,7 @@ outputs:
       - 0.0
       - 300.0
       - 450.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 14105.6
@@ -129,7 +129,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 19640

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -35,7 +35,7 @@ inputs:
             - 0.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 323.33
         - 1223.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2005-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -36,8 +36,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 400.0
-        - 1300.0
+        - 323.33
+        - 1223.33
         - 0.0
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
@@ -75,12 +75,12 @@ outputs:
     anspruchshöhe_kind_m:
       - 0.0
       - 0.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0.0
     betrag_m:
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
@@ -24,14 +24,10 @@ inputs:
           bruttolohn_m:
             - 1500.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1500.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1500.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - true

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
@@ -28,7 +28,7 @@ inputs:
             - 1500.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1500.0
         - 0.0
     erziehungsgeld:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
@@ -25,7 +25,7 @@ inputs:
             - 1500.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1423.33
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/born_after_abolishment.yaml
@@ -26,7 +26,7 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1500.0
+        - 1423.33
         - 0.0
       budgetsatz:
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -36,8 +36,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 1400.0
-        - 1700.0
+        - 1323.33
+        - 1623.33
         - 0.0
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -35,7 +35,7 @@ inputs:
             - 0.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 1323.33
         - 1623.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -40,7 +40,7 @@ inputs:
             - 0.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1400.0
         - 1700.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -34,18 +34,12 @@ inputs:
             - 1700.0
             - 0.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 1400.0
-            - 1700.0
-            - 0.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 1400.0
         - 1700.0
         - 0.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_high_income.yaml
@@ -113,7 +113,7 @@ outputs:
       - 0.0
       - 333.55
       - 300.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 26873.6
@@ -123,7 +123,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 19640

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -113,7 +113,7 @@ outputs:
       - 0.0
       - 300.0
       - 450.0
-    anzurechnendes_einkommen_y:
+    anzurechnendes_einkommen_y_fg:
       - 0
       - 0
       - 14105.6
@@ -123,7 +123,7 @@ outputs:
       - 0.0
       - 0.0
       - 0.0
-    einkommensgrenze_y:
+    einkommensgrenze_y_fg:
       - 0
       - 0
       - 19640

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -40,7 +40,7 @@ inputs:
             - 0.0
             - 0.0
     elterngeld:
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 400.0
         - 1300.0
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -34,18 +34,12 @@ inputs:
             - 1300.0
             - 0.0
             - 0.0
-          bruttolohn_vorjahr_m:
-            - 400.0
-            - 1300.0
-            - 0.0
-            - 0.0
-    elterngeld:
-      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
+    erziehungsgeld:
+      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
         - 400.0
         - 1300.0
         - 0.0
         - 0.0
-    erziehungsgeld:
       budgetsatz:
         - false
         - false

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -35,7 +35,7 @@ inputs:
             - 0.0
             - 0.0
     erziehungsgeld:
-      bruttolohn_vorjahr_abzüglich_werbungskosten_m:
+      bruttolohn_vorjahr_nach_abzug_werbungskosten_m:
         - 323.33
         - 1223.33
         - 0.0

--- a/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
+++ b/src/_gettsim_tests/test_data/erziehungsgeld/2007-01-01/married_two_children_budgetsatz_and_regelsatz_low_income.yaml
@@ -36,8 +36,8 @@ inputs:
             - 0.0
     erziehungsgeld:
       bruttolohn_vorjahr_abzüglich_werbungskosten_m:
-        - 400.0
-        - 1300.0
+        - 323.33
+        - 1223.33
         - 0.0
         - 0.0
       budgetsatz:

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_1.yaml
@@ -138,7 +138,7 @@ inputs:
         - true
         - true
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 1000.0
         - 2000.0
         - 3000.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_2.yaml
@@ -139,7 +139,7 @@ inputs:
         - true
         - true
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 7000.0
         - 2500.0
         - 2300.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_3.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2000.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 24750.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_4.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 3000.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 36774.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_5.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 4000.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 48798.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_6.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 7000.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 84822.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_7.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2500.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 30804.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2019-01-01/hh_id_8.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2300.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 25962.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2023-07-01/ohne_unterschied_entgeltpunkte_ost_west.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2023-07-01/ohne_unterschied_entgeltpunkte_ost_west.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2300.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 25962.0

--- a/src/_gettsim_tests/test_data/full_taxes_and_transfers/2025-01-01/wohnort_ost_irrelevant.yaml
+++ b/src/_gettsim_tests/test_data/full_taxes_and_transfers/2025-01-01/wohnort_ost_irrelevant.yaml
@@ -67,7 +67,7 @@ inputs:
         - 0
       claimed:
         - true
-      nettoeinkommen_vorjahr_m:
+      mean_nettoeinkommen_in_12_monaten_vor_geburt_m:
         - 2300.0
       zu_versteuerndes_einkommen_vorjahr_y_sn:
         - 25962.0

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2010-01-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2010-01-01/hh_id_6.yaml
@@ -10,6 +10,9 @@ inputs:
         - true
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 2500.0
+          - 0.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 12
           - 11
@@ -29,12 +32,6 @@ inputs:
     arbeitsstunden_w:
       - 0.0
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 2500.0
-            - 0.0
     familie:
       p_id_elternteil_1:
         - -1
@@ -58,5 +55,5 @@ outputs:
   sozialversicherung:
     arbeitslosen:
       betrag_m:
-        - 1021.87
+        - 1675.0
         - 0.0

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2011-01-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2011-01-01/hh_id_7.yaml
@@ -9,6 +9,8 @@ inputs:
         - false
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 2300.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 12
         arbeitssuchend:
@@ -22,11 +24,6 @@ inputs:
       - 66
     arbeitsstunden_w:
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 2300.0
     familie:
       p_id_elternteil_1:
         - -1

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_1.yaml
@@ -9,6 +9,8 @@ inputs:
         - false
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 1000.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 12
         arbeitssuchend:
@@ -22,11 +24,6 @@ inputs:
       - 30
     arbeitsstunden_w:
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 1000.0
     familie:
       p_id_elternteil_1:
         - -1
@@ -44,4 +41,4 @@ outputs:
   sozialversicherung:
     arbeitslosen:
       betrag_m:
-        - 465.54
+        - 600.0

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_2.yaml
@@ -9,6 +9,8 @@ inputs:
         - false
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 2000.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 12
         arbeitssuchend:
@@ -22,11 +24,6 @@ inputs:
       - 30
     arbeitsstunden_w:
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 2000.0
     familie:
       p_id_elternteil_1:
         - -1
@@ -44,4 +41,4 @@ outputs:
   sozialversicherung:
     arbeitslosen:
       betrag_m:
-        - 789.76
+        - 1200.0

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_3.yaml
@@ -10,6 +10,9 @@ inputs:
         - false
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 0.0
+          - 3000.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 10
           - 12
@@ -29,12 +32,6 @@ inputs:
     arbeitsstunden_w:
       - 0.0
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 0.0
-            - 3000.0
     familie:
       p_id_elternteil_1:
         - 4

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2019-01-01/hh_id_4.yaml
@@ -10,6 +10,9 @@ inputs:
         - true
     sozialversicherung:
       arbeitslosen:
+        mean_nettoeinkommen_in_12_monaten_vor_arbeitslosigkeit_m:
+          - 4000.0
+          - 0.0
         monate_beitragspflichtig_versichert_in_letzten_30_monaten:
           - 12
           - 11
@@ -29,12 +32,6 @@ inputs:
     arbeitsstunden_w:
       - 20.0
       - 0.0
-    einkommensteuer:
-      einkünfte:
-        aus_nichtselbstständiger_arbeit:
-          bruttolohn_vorjahr_m:
-            - 4000.0
-            - 0.0
     familie:
       p_id_elternteil_1:
         - -1

--- a/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2025-01-01/bemessungsgrundlage.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/arbeitslosengeld/2025-01-01/bemessungsgrundlage.yaml
@@ -1,0 +1,42 @@
+---
+info:
+  precision_atol: 0.01
+  source: Regression test.
+inputs:
+  assumed:
+    einkommensteuer:
+      einkünfte:
+        aus_nichtselbstständiger_arbeit:
+          bruttolohn_m:
+            - 3000.0
+    lohnsteuer:
+      steuerklasse:
+        - 1
+    sozialversicherung:
+      pflege:
+        beitrag:
+          hat_kinder:
+            - false
+    kindergeld:
+      ist_leistungsbegründendes_kind:
+        - false
+    alter:
+      - 30
+    arbeitsstunden_w:
+      - 0.0
+    familie:
+      p_id_elternteil_1:
+        - -1
+      p_id_elternteil_2:
+        - -1
+    geburtsjahr:
+      - 1989
+    hh_id:
+      - 1
+    p_id:
+      - 1
+outputs:
+  sozialversicherung:
+    arbeitslosen:
+      mean_nettoeinkommen_für_bemessungsgrundlage_bei_arbeitslosigkeit_y:
+        - 25181.24

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_1.yaml
@@ -28,10 +28,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -55,6 +51,8 @@ inputs:
         entgeltpunkte_west:
           - 14.014
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 420
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_1.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_1.yaml
@@ -14,19 +14,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -52,6 +41,14 @@ inputs:
           - 14.014
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 420

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_10.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_10.yaml
@@ -27,10 +27,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -54,6 +50,8 @@ inputs:
         entgeltpunkte_west:
           - 41.0
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 492
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_10.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_10.yaml
@@ -13,19 +13,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -51,6 +40,14 @@ inputs:
           - 41.0
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 492

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_11.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_11.yaml
@@ -29,10 +29,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -56,6 +52,8 @@ inputs:
         entgeltpunkte_west:
           - 18.5
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 372
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_11.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_11.yaml
@@ -15,19 +15,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -53,6 +42,14 @@ inputs:
           - 18.5
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 372

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_12.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_12.yaml
@@ -26,10 +26,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -53,6 +49,8 @@ inputs:
         entgeltpunkte_west:
           - 0.0
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 0
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_12.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_12.yaml
@@ -12,19 +12,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -50,6 +39,14 @@ inputs:
           - 0.0
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 0

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_2.yaml
@@ -14,19 +14,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -52,6 +41,14 @@ inputs:
           - 17.5
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 420

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_2.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_2.yaml
@@ -28,10 +28,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -55,6 +51,8 @@ inputs:
         entgeltpunkte_west:
           - 17.5
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 420
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_3.yaml
@@ -15,19 +15,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -53,6 +42,14 @@ inputs:
           - 21.0
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 420

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_3.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_3.yaml
@@ -29,10 +29,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -56,6 +52,8 @@ inputs:
         entgeltpunkte_west:
           - 21.0
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 420
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_4.yaml
@@ -28,10 +28,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -55,6 +51,8 @@ inputs:
         entgeltpunkte_west:
           - 28.8
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 480
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_4.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_4.yaml
@@ -14,19 +14,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -52,6 +41,14 @@ inputs:
           - 28.8
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 480

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_5.yaml
@@ -28,10 +28,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -55,6 +51,8 @@ inputs:
         entgeltpunkte_west:
           - 0.0
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 408
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_5.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_5.yaml
@@ -14,19 +14,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -52,6 +41,14 @@ inputs:
           - 0.0
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 408

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_6.yaml
@@ -27,10 +27,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -54,6 +50,8 @@ inputs:
         entgeltpunkte_west:
           - 19.2
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 300
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_6.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_6.yaml
@@ -13,19 +13,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 0.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -51,6 +40,14 @@ inputs:
           - 19.2
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 300

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_7.yaml
@@ -27,10 +27,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -54,6 +50,8 @@ inputs:
         entgeltpunkte_west:
           - 19.2
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 300
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_7.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_7.yaml
@@ -13,19 +13,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 1400.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -51,6 +40,14 @@ inputs:
           - 19.2
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 1400.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 300

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_8.yaml
@@ -27,10 +27,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -54,6 +50,8 @@ inputs:
         entgeltpunkte_west:
           - 19.2
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 300
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_8.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_8.yaml
@@ -13,19 +13,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 2400.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -51,6 +40,14 @@ inputs:
           - 19.2
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 2400.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 300

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_9.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_9.yaml
@@ -15,19 +15,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 1380.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
     familie:
       p_id_ehepartner:
@@ -53,6 +42,14 @@ inputs:
           - 34.5
         grundrente:
           gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+          bruttolohn_vorjahr_m:
+            - 1380.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
             - 0.0
           bewertungszeiten_monate:
             - 552

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_9.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/hh_id_9.yaml
@@ -29,10 +29,6 @@ inputs:
         aus_vermietung_und_verpachtung:
           betrag_y:
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
     familie:
       p_id_ehepartner:
         - -1
@@ -56,6 +52,8 @@ inputs:
         entgeltpunkte_west:
           - 34.5
         grundrente:
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
           bewertungszeiten_monate:
             - 552
           grundrentenzeiten_monate:

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/married_couple.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/married_couple.yaml
@@ -33,11 +33,6 @@ inputs:
           betrag_y:
             - 0.0
             - 0.0
-        sonstige:
-          rente:
-            gesamtbetrag_vorjahr_m:
-              - 0.0
-              - 0.0
     familie:
       p_id_ehepartner:
         - 1
@@ -79,6 +74,9 @@ inputs:
           mean_entgeltpunkte:
             - 15.0
             - 15.0
+          gesamteinnahmen_aus_renten_vorjahr_m:
+            - 0.0
+            - 0.0
     wohnort_ost_hh:
       - false
       - false

--- a/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/married_couple.yaml
+++ b/src/_gettsim_tests/test_data/sozialversicherung/rente/grundrente/2021-07-01/married_couple.yaml
@@ -14,23 +14,8 @@ inputs:
       - 70
     einkommensteuer:
       einkünfte:
-        aus_kapitalvermögen:
-          kapitalerträge_y:
-            - 0.0
-            - 0.0
         aus_nichtselbstständiger_arbeit:
           bruttolohn_m:
-            - 0.0
-            - 0.0
-          bruttolohn_vorjahr_m:
-            - 700.0
-            - 700.0
-        aus_selbstständiger_arbeit:
-          betrag_y:
-            - 0.0
-            - 0.0
-        aus_vermietung_und_verpachtung:
-          betrag_y:
             - 0.0
             - 0.0
     familie:
@@ -68,6 +53,18 @@ inputs:
           bewertungszeiten_monate:
             - 300
             - 300
+          bruttolohn_vorjahr_m:
+            - 0.0
+            - 0.0
+          einnahmen_aus_selbstständiger_arbeit_vorvorjahr_y:
+            - 0.0
+            - 0.0
+          einnahmen_aus_vermietung_und_verpachtung_vorvorjahr_y:
+            - 0.0
+            - 0.0
+          einnahmen_aus_kapitalvermögen_vorvorjahr_y:
+            - 0.0
+            - 0.0
           grundrentenzeiten_monate:
             - 480
             - 480


### PR DESCRIPTION
### What problem do you want to solve?

This PR gets the input names (+docstrings)  of "vorjahr" inputs straight and puts them in the correct namespaces. 
