### PR TITLE
Don't create DAG cycles via automatically added functions

### DIFF
--- a/tests/ttsim/interface_dag_elements/test_automatically_added_functions.py
+++ b/tests/ttsim/interface_dag_elements/test_automatically_added_functions.py
@@ -345,7 +345,7 @@ class TestCreateFunctionForTimeUnit:
         assert function(1) == 7
 
 
-def test_should_not_create_cycle():
+def test_time_conversions_should_not_create_cycle():
     # Check for:
     # https://github.com/iza-institute-of-labor-economics/gettsim/issues/621
     def x(test_m: int) -> int:
@@ -358,6 +358,28 @@ def test_should_not_create_cycle():
     )
 
     assert "test_m" not in time_conversion_functions
+
+
+def test_grouping_functions_should_not_create_cycle():
+    @policy_function()
+    def x(x_hh: int) -> int:
+        return x_hh
+
+    @policy_function()
+    def some_other_function_requiring_x_hh(x_hh: int) -> int:
+        return x_hh
+
+    grouping_functions = create_agg_by_group_functions(
+        column_functions={
+            "x": x,
+            "some_other_function_requiring_x_hh": some_other_function_requiring_x_hh,
+        },
+        input_columns=set(),
+        tt_targets=("some_other_function_requiring_x_hh",),
+        grouping_levels=("hh",),
+    )
+
+    assert "x_hh" not in grouping_functions
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What problem do you want to solve?

Closes #757

In fact, any occurences of automatically created cycles reported in #757 have already been solved via the namespaces structure.

In ALG2 we have

```python
@policy_function(start_date="2005-01-01")
def wohnfläche(
    wohnen__wohnfläche_hh: float,
    anzahl_personen_hh: int,
) -> float:
    """Share of household's dwelling size attributed to a single person."""
    return wohnen__wohnfläche_hh / anzahl_personen_hh
```

So we don't create a cycle anymore as we have `wohnen__wohnfläche -> wohnen__wohnfläche_hh` but `wohnen__wohnfläche_hh -> arbeitslosengeld_2__wohnfläche`.

Still, thanks to the work done by Lars in the past, a general TTSIM solution was easy to implement because it just copies the logic done for time-conversion functions.