### PR TITLE
Raise more errors during vectorization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsi
 
 ## Unpublished
 
+- {gh}`1043` Raise more errors during vectorization ({ghuser}`hmgaudecker`,
+  {ghuser}`timmens`)
+
+- {gh}`1044` Fail if ParamFunctions depends on ColumnObjects ({ghuser}`MImmesberger`,
+  {ghuser}`hmgaudecker`)
+
+- {gh}`1042` Add copy_environment function ({ghuser}`timmens`, {ghuser}`hmgaudecker`)
+
 - {gh}`1041` Don't create DAG cycles via automatically added functions
   ({ghuser}`MImmesberger`)
 

--- a/src/ttsim/tt_dag_elements/vectorization.py
+++ b/src/ttsim/tt_dag_elements/vectorization.py
@@ -211,6 +211,16 @@ class Transformer(ast.NodeTransformer):
         self.xnp = xnp
 
     def visit_Call(self, node: ast.Call) -> ast.AST:  # noqa: N802
+        # Forbid type-conversion calls
+        forbidden_type_conversions = {"float", "int", "bool", "complex", "str"}
+        if hasattr(node.func, "id") and node.func.id in forbidden_type_conversions:
+            msg = (
+                f"Forbidden type conversion '{node.func.id}' detected in function. "
+                f"Type conversions like float(), int(), bool(), complex(), str() are "
+                f"not allowed in vectorized functions.\n\nFunction: {self.func_loc}\n\n"
+                f"Problematic source code: \n\n{_node_to_formatted_source(node)}\n"
+            )
+            raise TranslateToVectorizableError(msg)
         self.generic_visit(node)
         return _call_to_call_from_module(
             node,
@@ -218,6 +228,26 @@ class Transformer(ast.NodeTransformer):
             func_loc=self.func_loc,
             xnp=self.xnp,
         )
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> ast.AST:  # noqa: N802
+        # Forbid +=, -=, *=, /=
+        forbidden_ops = (ast.Add, ast.Sub, ast.Mult, ast.Div)
+        if isinstance(node.op, forbidden_ops):
+            op_str = {
+                ast.Add: "+=",
+                ast.Sub: "-=",
+                ast.Mult: "*=",
+                ast.Div: "/=",
+            }[type(node.op)]
+            msg = (
+                f"Forbidden augmented assignment '{op_str}' detected in function. "
+                f"Operations like +=, -=, *=, /= are not allowed in vectorized "
+                f"functions.\n\nFunction: {self.func_loc}\n\n"
+                f"Problematic source code: \n\n{_node_to_formatted_source(node)}\n"
+            )
+            raise TranslateToVectorizableError(msg)
+        self.generic_visit(node)
+        return node
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> ast.UnaryOp | ast.Call:  # noqa: N802
         if isinstance(node.op, ast.Not):

--- a/src/ttsim/tt_dag_elements/vectorization.py
+++ b/src/ttsim/tt_dag_elements/vectorization.py
@@ -230,24 +230,14 @@ class Transformer(ast.NodeTransformer):
         )
 
     def visit_AugAssign(self, node: ast.AugAssign) -> ast.AST:  # noqa: N802
-        # Forbid +=, -=, *=, /=
-        forbidden_ops = (ast.Add, ast.Sub, ast.Mult, ast.Div)
-        if isinstance(node.op, forbidden_ops):
-            op_str = {
-                ast.Add: "+=",
-                ast.Sub: "-=",
-                ast.Mult: "*=",
-                ast.Div: "/=",
-            }[type(node.op)]
-            msg = (
-                f"Forbidden augmented assignment '{op_str}' detected in function. "
-                f"Operations like +=, -=, *=, /= are not allowed in vectorized "
-                f"functions.\n\nFunction: {self.func_loc}\n\n"
-                f"Problematic source code: \n\n{_node_to_formatted_source(node)}\n"
-            )
-            raise TranslateToVectorizableError(msg)
-        self.generic_visit(node)
-        return node
+        # Forbid any augmented assignment (+=, -=, *=, /=, etc.)
+        msg = (
+            "Augmented assignment is not allowed in vectorized functions. "
+            "Operations like +=, -=, *=, /=, etc. are forbidden.\n\n"
+            f"Function: {self.func_loc}\n\n"
+            f"Problematic source code: \n\n{_node_to_formatted_source(node)}\n"
+        )
+        raise TranslateToVectorizableError(msg)
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> ast.UnaryOp | ast.Call:  # noqa: N802
         if isinstance(node.op, ast.Not):

--- a/tests/ttsim/tt_dag_elements/test_vectorization.py
+++ b/tests/ttsim/tt_dag_elements/test_vectorization.py
@@ -61,18 +61,18 @@ def test_compare_str():
 # ======================================================================================
 
 
-def f1(x):
+def f0(x):
     if x < 0:
         return 0
     else:
         return 1
 
 
-def f1_exp(x):
+def f0_exp(x):
     return numpy.where(x < 0, 0, 1)
 
 
-def f2(x):
+def f1(x):
     if x < 0:
         out = 0
     else:
@@ -80,33 +80,33 @@ def f2(x):
     return out
 
 
-def f2_exp(x):
+def f1_exp(x):
     out = numpy.where(x < 0, 0, 1)
     return out
 
 
-def f3(x):
+def f2(x):
     return 0 if x < 0 else 1
 
 
-def f3_exp(x):
+def f2_exp(x):
     return numpy.where(x < 0, 0, 1)
 
 
-def f4(x):
+def f3(x):
     out = 1
     if x < 0:
         out = 0
     return out
 
 
-def f4_exp(x):
+def f3_exp(x):
     out = 1
     out = numpy.where(x < 0, 0, out)
     return out
 
 
-def f5(x):
+def f4(x):
     if x < 0:
         out = -1
     elif x > 0:
@@ -116,12 +116,12 @@ def f5(x):
     return out
 
 
-def f5_exp(x):
+def f4_exp(x):
     out = numpy.where(x < 0, -1, numpy.where(x > 0, 1, 0))
     return out
 
 
-def f6(flag, another_flag):
+def f5(flag, another_flag):
     if flag and not another_flag:
         out = 1
     else:
@@ -129,49 +129,49 @@ def f6(flag, another_flag):
     return out
 
 
-def f6_exp(flag, another_flag):
+def f5_exp(flag, another_flag):
     out = numpy.where(numpy.logical_and(flag, numpy.logical_not(another_flag)), 1, 0)
     return out
 
 
-def f7(x):
+def f6(x):
     out = 0 if x < 0 else 1
     return out
 
 
-def f7_exp(x):
+def f6_exp(x):
     out = numpy.where(x < 0, 0, 1)
     return out
 
 
-def f8(x):
+def f7(x):
     return -1 if x < 0 else (1 if x > 0 else 0)
 
 
-def f8_exp(x):
+def f7_exp(x):
     return numpy.where(x < 0, -1, numpy.where(x > 0, 1, 0))
 
 
 # expect no change since there is no if-clause and no [and|or] statement.
-def f9(x):
+def f8(x):
     y = numpy.sum(x)
     z = numpy.prod(x)
     return y * z
 
 
-def f10(x):
+def f9(x):
     flag = (x < 0) and (x > -1)
     another_flag = (x < 0) or (x > -1)
     return flag and not another_flag
 
 
-def f10_exp(x):
+def f9_exp(x):
     flag = numpy.logical_and(x < 0, x > -1)
     another_flag = numpy.logical_or(x < 0, x > -1)
     return numpy.logical_and(flag, numpy.logical_not(another_flag))
 
 
-def f11(x):
+def f10(x):
     if x < 0:
         out = -1
     else:
@@ -179,12 +179,12 @@ def f11(x):
     return out
 
 
-def f11_exp(x):
+def f10_exp(x):
     out = numpy.where(x < 0, -1, numpy.where(x > 0, 1, 0))
     return out
 
 
-def f13(x):
+def f11(x):
     a = x < 0
     b = x > 0
     c = x != 0
@@ -192,7 +192,7 @@ def f13(x):
     return ((a and b) or c) and d
 
 
-def f13_exp(x):
+def f11_exp(x):
     a = x < 0
     b = x > 0
     c = x != 0
@@ -200,7 +200,7 @@ def f13_exp(x):
     return numpy.logical_and(numpy.logical_or(numpy.logical_and(a, b), c), d)
 
 
-def f14(x):
+def f12(x):
     a = x < 0
     b = x > 0
     c = x != 0
@@ -208,7 +208,7 @@ def f14(x):
     return (a and b and c) or d
 
 
-def f14_exp(x):
+def f12_exp(x):
     a = x < 0
     b = x > 0
     c = x != 0
@@ -216,21 +216,21 @@ def f14_exp(x):
     return numpy.logical_or(numpy.logical_and(numpy.logical_and(a, b), c), d)
 
 
-def f15(x):
+def f13(x):
     return min(x, 0)
 
 
-def f15_exp(x):
+def f13_exp(x):
     return numpy.minimum(x, 0)
 
 
-def f17(x):
+def f14(x):
     a = x < 0
     b = x // 2
     return any((a, b))
 
 
-def f17_exp(x):
+def f14_exp(x):
     a = x < 0
     b = x // 2
     return numpy.any((a, b))
@@ -243,21 +243,21 @@ another_flag = rng.binomial(1, 0.75, size=100)
 
 
 TEST_CASES = [
+    (f0, f0_exp, (x,)),
     (f1, f1_exp, (x,)),
     (f2, f2_exp, (x,)),
     (f3, f3_exp, (x,)),
     (f4, f4_exp, (x,)),
-    (f5, f5_exp, (x,)),
-    (f6, f6_exp, (flag, another_flag)),
+    (f5, f5_exp, (flag, another_flag)),
+    (f6, f6_exp, (x,)),
     (f7, f7_exp, (x,)),
-    (f8, f8_exp, (x,)),
-    (f9, f9, (x,)),
+    (f8, f8, (x,)),
+    (f9, f9_exp, (x,)),
     (f10, f10_exp, (x,)),
     (f11, f11_exp, (x,)),
+    (f12, f12_exp, (x,)),
     (f13, f13_exp, (x,)),
     (f14, f14_exp, (x,)),
-    (f15, f15_exp, (x,)),
-    (f17, f17_exp, (x,)),
 ]
 
 
@@ -319,7 +319,7 @@ def g4(x):
 
 def test_notimplemented_error():
     with pytest.raises(NotImplementedError):
-        _make_vectorizable(f1, backend="dask", xnp=numpy)
+        _make_vectorizable(f0, backend="dask", xnp=numpy)
 
 
 @pytest.mark.parametrize("func", [g1, g2, g3, g4])

--- a/tests/ttsim/tt_dag_elements/test_vectorization.py
+++ b/tests/ttsim/tt_dag_elements/test_vectorization.py
@@ -184,19 +184,6 @@ def f11_exp(x):
     return out
 
 
-def f12(x):
-    out = 0
-    if x < 1:
-        out += 1
-    return out
-
-
-def f12_exp(x):
-    out = 0
-    out += numpy.where(x < 1, 1, out)
-    return out
-
-
 def f13(x):
     a = x < 0
     b = x > 0
@@ -237,14 +224,6 @@ def f15_exp(x):
     return numpy.minimum(x, 0)
 
 
-def f16(x):
-    return float(sum(x))
-
-
-def f16_exp(x):
-    return float(numpy.sum(x))
-
-
 def f17(x):
     a = x < 0
     b = x // 2
@@ -255,14 +234,6 @@ def f17_exp(x):
     a = x < 0
     b = x // 2
     return numpy.any((a, b))
-
-
-def f18(x):
-    return int(any(x)) + 1
-
-
-def f18_exp(x):
-    return int(numpy.any(x)) + 1
 
 
 x = numpy.arange(-10, 10)
@@ -283,13 +254,10 @@ TEST_CASES = [
     (f9, f9, (x,)),
     (f10, f10_exp, (x,)),
     (f11, f11_exp, (x,)),
-    (f12, f12_exp, (x,)),
     (f13, f13_exp, (x,)),
     (f14, f14_exp, (x,)),
     (f15, f15_exp, (x,)),
-    (f16, f16_exp, (x,)),
     (f17, f17_exp, (x,)),
-    (f18, f18_exp, (x,)),
 ]
 
 
@@ -875,12 +843,12 @@ def test_forbidden_type_conversions_raise(func, xnp):
     ],
 )
 def test_forbidden_augassign_raise(func, xnp):
-    """Test that forbidden augmented assignments raise the correct error."""
+    """Test that augmented assignments raise the correct error."""
     with pytest.raises(
-        TranslateToVectorizableError, match="Forbidden augmented assignment"
+        TranslateToVectorizableError, match="Augmented assignment is not allowed"
     ):
         _make_vectorizable(func, backend="numpy", xnp=xnp)
     with pytest.raises(
-        TranslateToVectorizableError, match="Forbidden augmented assignment"
+        TranslateToVectorizableError, match="Augmented assignment is not allowed"
     ):
         make_vectorizable_source(func, backend="numpy", xnp=xnp)


### PR DESCRIPTION
It agentic day and I had Cursor take a stab at #869.

@timmens, could you please double-check, also what Marvin writes over there? I was a little surprised that in-place operations worked for him, maybe they only fail in corner cases? Anyhow, they are almost always bad practice and I wouldn't mind prohibiting them if there is an epsilon chance for failure.

With the additional checks, some tests fail. However, I believe they are misguided in the first place in that they contain reduction operations. So they would not make sense with scalar input, which is the case we have in mind for the vectorisation?