### PR TITLE
fix: update Grundsicherung im Alter asset exemption from 2023

### DIFF
--- a/src/gettsim/germany/grundsicherung/im_alter/freibeträge_und_mehrbedarfe.yaml
+++ b/src/gettsim/germany/grundsicherung/im_alter/freibeträge_und_mehrbedarfe.yaml
@@ -23,6 +23,9 @@ parameter_vermögensfreibetrag:
   2017-04-01:
     erwachsene: 5000
     kinder: 500
+  2023-01-01:
+    erwachsene: 10000
+    kinder: 10000
 anrechnungsfreier_anteil_gesetzliche_rente:
   name:
     de: Anrechnungsfreier Anteil der staatlichen Rente (bei mind. 33 Grundrentenzeiten)


### PR DESCRIPTION
## Bug
Fixes #1150 — the Grundsicherung im Alter asset exemption table still ended at the 2017 values.

## Fix
Added a 2023-01-01 policy entry for parameter_vermögensfreibetrag with the updated 10,000 EUR threshold per person for both adults and children.

## Testing
Validated the change is scoped to the policy parameter table and only affects values from 2023-01-01 onward.

Happy to address any feedback.

Greetings, saschabuehrle