### PR TITLE
Fix Vermögensfreibetrag for Grundsicherung im Alter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,11 @@ chronological order. Since v1.0, GETTSIM's versioning follows a rule inspired by
 
 All releases are available on [Anaconda.org](https://anaconda.org/conda-forge/gettsim).
 
+## Unreleased
+
+- {gh}`1155` Fix Vermögensfreibetrag for Grundsicherung im Alter.
+  ({ghuser}`MImmesberger`)
+
 ## v1.2 — 2026-03-19
 
 - {gh}`1132` Implement GEP 8. ({ghuser} `hmgaudecker`, {ghuser}`MImmesberger`)

--- a/src/gettsim/germany/grundsicherung/im_alter/freibeträge_und_mehrbedarfe.yaml
+++ b/src/gettsim/germany/grundsicherung/im_alter/freibeträge_und_mehrbedarfe.yaml
@@ -23,6 +23,11 @@ parameter_vermögensfreibetrag:
   2017-04-01:
     erwachsene: 5000
     kinder: 500
+  2023-01-01:
+    erwachsene: 10000
+    kinder: 10000
+    reference: Art. 9 G. v. 16.12.2022 BGBl. I S. 2328
+    note: Bürgergeld-Gesetz
 anrechnungsfreier_anteil_gesetzliche_rente:
   name:
     de: Anrechnungsfreier Anteil der staatlichen Rente (bei mind. 33 Grundrentenzeiten)

--- a/src/gettsim/tests_germany/policy_cases/grundsicherung/im_alter/2023-07-01/vermögen_über_freibetrag.yaml
+++ b/src/gettsim/tests_germany/policy_cases/grundsicherung/im_alter/2023-07-01/vermögen_über_freibetrag.yaml
@@ -1,0 +1,121 @@
+---
+info:
+  note: |-
+    Single retiree with wealth above the new 10,000 EUR Vermögensfreibetrag
+    (per § 1 DurchführungsVO zu § 90 Abs. 2 Nr. 9 SGB XII, amended by
+    Art. 9 Bürgergeld-Gesetz). No entitlement due to wealth exceeding threshold.
+  precision_atol: 0.01
+  source: Self-created test case
+inputs:
+  assumed: {}
+  provided:
+    alter:
+      - 73
+    bürgergeld:
+      bezug_im_vorjahr:
+        - false
+      p_id_einstandspartner:
+        - -1
+    einkommensteuer:
+      betrag_y_sn:
+        - 0.0
+      einkünfte:
+        aus_selbstständiger_arbeit:
+          betrag_m:
+            - 0.0
+        aus_vermietung_und_verpachtung:
+          betrag_m:
+            - 0.0
+        sonstige:
+          alle_weiteren_m:
+            - 0.0
+      gemeinsam_veranlagt:
+        - false
+    einnahmen:
+      bruttolohn_m:
+        - 0.0
+      kapitalerträge_m:
+        - 0.0
+      renten:
+        betriebliche_altersvorsorge_m:
+          - 0.0
+        geförderte_private_vorsorge_m:
+          - 0.0
+        sonstige_private_vorsorge_m:
+          - 0.0
+        aus_berufsständischen_versicherungen_m:
+          - 0.0
+    elterngeld:
+      anrechenbarer_betrag_m:
+        - 0.0
+      betrag_m:
+        - 0.0
+    familie:
+      alleinerziehend:
+        - false
+      p_id_ehepartner:
+        - -1
+      p_id_elternteil_1:
+        - -1
+      p_id_elternteil_2:
+        - -1
+    geburtsjahr:
+      - 1950
+    geburtsmonat:
+      - 1
+    geburtstag:
+      - 1
+    hh_id:
+      - 0
+    kindergeld:
+      betrag_m_eg:
+        - 0.0
+      p_id_empfänger:
+        - -1
+    p_id:
+      - 0
+    schwerbehindert_grad_g:
+      - false
+    solidaritätszuschlag:
+      betrag_y_sn:
+        - 0.0
+    sozialversicherung:
+      arbeitslosen:
+        betrag_m:
+          - 0.0
+      beiträge_versicherter_m:
+        - 0.0
+      rente:
+        altersrente:
+          betrag_m:
+            - 250.0
+        bezieht_rente:
+          - true
+        erwerbsminderung:
+          betrag_m:
+            - 0.0
+        grundrente:
+          grundrentenzeiten_monate:
+            - 120
+    unterhalt:
+      tatsächlich_erhaltener_betrag_m:
+        - 0.0
+    unterhaltsvorschuss:
+      betrag_m_eg:
+        - 0.0
+    vermögen_eg:
+      - 10001.0
+    wohnen:
+      bewohnt_eigentum_hh:
+        - false
+      bruttokaltmiete_m_hh:
+        - 300.0
+      heizkosten_m_hh:
+        - 50.0
+      wohnfläche_hh:
+        - 45.0
+outputs:
+  grundsicherung:
+    im_alter:
+      betrag_m_eg:
+        - 0.0


### PR DESCRIPTION
## Summary

- Update `parameter_vermögensfreibetrag` to 10,000 EUR per person from 2023-01-01 (§1 DurchführungsVO zu §90 Abs. 2 Nr. 9 SGB XII, amended by Art. 9 Bürgergeld-Gesetz)
- Add test case verifying wealth above the new threshold denies benefits

Closes #1150

## Test plan

- [x] `pixi run ty` and `pixi run ty-jax` pass
- [x] `pixi run prek run --all-files` pass
- [x] Full test suite passes (`pixi run -e py314-jax tests -n 7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)