### PR TITLE
Adopt ty + ty-jax pre-commit hooks; bump .ai-instructions to c2701d4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,10 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           frozen: true
-          environments: type-checking type-checking-jax
-      - name: Run ty
-        run: pixi run --locked ty
+          environments: py314 py314-jax
+      - name: Run ty (numpy backend)
+        run: pixi run --locked -e py314 prek run ty --all-files
         shell: bash -el {0}
-      - name: Run ty-jax
-        run: pixi run --locked ty-jax
+      - name: Run ty (jax backend)
+        run: pixi run --locked -e py314 prek run ty-jax --all-files
         shell: bash -el {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,30 @@ repos:
           - jupyter
           - pyi
           - python
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.49
+    hooks:
+      - id: ty
+        name: ty (numpy backend)
+        # `--no-project` keeps uv from creating a `.venv`/`uv.lock` in this
+        # pixi-managed repo; ty resolves third-party imports from the env named
+        # in `[tool.ty] environment.python` (run `pixi install` once).
+        args:
+          - --no-project
+  - repo: local
+    hooks:
+      - id: ty-jax
+        name: ty (jax backend)
+        # A local hook because the official hook's `uv check` cannot forward
+        # `--python` to ty; this checks against the JAX environment. Keep the
+        # ty pin in sync with the `ty-pre-commit` rev above.
+        language: python
+        additional_dependencies:
+          - ty==0.0.49
+        entry: ty check --python .pixi/envs/py314-jax
+        pass_filenames: false
+        always_run: true
+        require_serial: true
   - repo: https://github.com/kynan/nbstripout
     rev: 0.9.1
     hooks:
@@ -99,3 +123,8 @@ repos:
         files: docs/.
 ci:
   autoupdate_schedule: monthly
+  # pre-commit.ci has no pixi environments and blocks network at hook runtime;
+  # the GitHub Actions run-ty job covers type checking.
+  skip:
+    - ty
+    - ty-jax

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@ pixi run -e py314-jax tests src/gettsim/tests_germany/test_policy_cases.py
 # Run tests for a specific policy area (by test ID pattern)
 pixi run -e py314-jax tests -k "kindergeld"
 
-# Type checking
-pixi run ty
-pixi run ty-jax
+# Type checking (runs as the ty / ty-jax pre-commit hooks)
+prek run ty --all-files
+prek run ty-jax --all-files
 
 # Quality checks (linting, formatting)
 pixi run prek run --all-files
@@ -37,11 +37,11 @@ pixi run prek run --all-files
 pixi run docs
 ```
 
-Before finishing any task that modifies code, always run these three verification steps
-in order:
+Before finishing any task that modifies code, always run these two verification steps in
+order:
 
-1. `pixi run ty` and `pixi run ty-jax` (type checker)
-1. `pixi run prek run --all-files` (quality checks: linting, formatting, yaml, etc.)
+1. `pixi run prek run --all-files` (quality checks: ty / ty-jax type checking, linting,
+   formatting, yaml, etc.)
 1. `pixi run -e py314-jax tests -n 7` (full test suite)
 
 ## Architecture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,6 @@ py313 = [ "py313", "tests" ]
 py314 = [ "py314", "tests", "coverage" ]
 py314-cuda = [ "py314", "tests", "cuda" ]
 py314-jax = [ "py314", "tests", "jax" ]
-type-checking = [ "py314", "type-checking" ]
-type-checking-jax = [ "py314", "type-checking-jax", "jax" ]
 py314-metal = [ "py314", "tests", "metal" ]
 docs = [ "docs", "py313" ]
 [tool.pixi.feature.coverage.tasks]
@@ -165,20 +163,6 @@ tests = "dot -c && pytest"  # dot -c needed for pygraphviz on macOS
 [tool.pixi.feature.tests.target.win-64.tasks]
 tests = "pytest"
 [tool.pixi.feature.tests.tasks]
-[tool.pixi.feature.type-checking-jax.pypi-dependencies]
-ty = "*"
-types-PyYAML = "*"
-types-pytz = "*"
-gettsim-personas = { git = "https://github.com/ttsim-dev/gettsim-personas.git", branch = "main" }
-[tool.pixi.feature.type-checking-jax.tasks]
-ty-jax = "ty check"
-[tool.pixi.feature.type-checking.pypi-dependencies]
-ty = "*"
-types-PyYAML = "*"
-types-pytz = "*"
-gettsim-personas = { git = "https://github.com/ttsim-dev/gettsim-personas.git", branch = "main" }
-[tool.pixi.feature.type-checking.tasks]
-ty = "ty check"
 [tool.pixi.pypi-dependencies]
 gettsim = { path = ".", editable = true }
 jaxtyping = ">=0.3.2"
@@ -296,16 +280,16 @@ expand_tables = [
   "tool.pixi.feature.tests.target.osx-64.tasks",
   "tool.pixi.feature.tests.target.osx-arm64.tasks",
   "tool.pixi.feature.tests.target.win-64.tasks",
-  "tool.pixi.feature.type-checking.pypi-dependencies",
-  "tool.pixi.feature.type-checking.tasks",
-  "tool.pixi.feature.type-checking-jax.pypi-dependencies",
-  "tool.pixi.feature.type-checking-jax.tasks",
   "tool.pixi.pypi-dependencies",
   "tool.pixi.tasks",
   "tool.pixi.workspace",
 ]
 
 [tool.ty]
+# ty resolves third-party imports from this pixi env (the ty-pre-commit hook runs
+# `uv check --no-project`, so uv neither creates a `.venv` nor resolves deps). Run
+# `pixi install` once. The ty-jax hook overrides this on the command line for jax.
+environment.python = ".pixi/envs/py314"
 rules.ambiguous-protocol-member = "error"
 rules.deprecated = "error"
 rules.division-by-zero = "error"


### PR DESCRIPTION
Adopt the official `astral-sh/ty-pre-commit` hook (numpy) plus a local `ty-jax`
hook (both ty==0.0.49), checking against `.pixi/envs/py314` / `.pixi/envs/py314-jax`
via `[tool.ty] environment.python`.

- Remove the `type-checking` / `type-checking-jax` pixi envs + features (the old
  ty 0.0.23 pin + type stubs); ty 0.0.49 passes both backends with no new errors.
- pre-commit.ci skips `ty` / `ty-jax`; the GHA `run-ty` job runs them via prek.
- AGENTS.md: ty now runs via `prek run --all-files`.
- Bump `.ai-instructions` to c2701d4 (real tiering, distilled modules,
  ty-pre-commit boilerplate).

Branched fresh off `main` (the `chore/kwarg-call-sweep` line is already merged via
#1188), so this is a single clean commit. `prek run --all-files` passes, including
`ty (numpy backend)` and `ty (jax backend)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
