### PR TITLE
GEP 10: adopt the per-policy-system unit registry

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -261,7 +261,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -500,7 +500,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h84953be_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -739,7 +739,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -983,7 +983,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h3a581c9_11.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -1278,7 +1278,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -1530,7 +1530,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -1782,7 +1782,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -2039,7 +2039,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -2320,7 +2320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/09/b9/f668bc51129c0fec7728ae8b43180417fe1c1fe99f71d302739f6cc50944/optree-0.19.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -2562,7 +2562,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/51/3fb9e65ae76ee97bd611869a503fa3fc0a6e81dd8b737cf3003f682df7ff/orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -2804,7 +2804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/51/3fb9e65ae76ee97bd611869a503fa3fc0a6e81dd8b737cf3003f682df7ff/orjson-3.11.9-cp311-cp311-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -3051,7 +3051,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/64/3cc7b08cb1c0f1949895f9490217ca8db6ced7f3bf75c65a5bf31c07bf1e/optree-0.19.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -3341,7 +3341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/06/c2/05b8c890097c61a7f4406b35396b997a635200ded0339eda83dfbe526c5f/coverage-7.14.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/b6/156a8de1e1b47694f0e7de6675866936608d45dc68388fd017d36f8693be/simplejson-4.1.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -3586,7 +3586,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -3831,7 +3831,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -4081,7 +4081,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -4370,7 +4370,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -4616,7 +4616,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -4862,7 +4862,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -5113,7 +5113,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -5402,7 +5402,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/ca/59ea35fb99743549ec8b37eff141ece4431fea590c89e536ed8032ef45cf/coverage-7.14.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
@@ -5648,7 +5648,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/07/f4/84d160e9fa8cada1e0a9381cae4fa81eecd573577a5b34366d8ced59bdf7/simplejson-4.1.1-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -5894,7 +5894,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -6145,7 +6145,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -6434,7 +6434,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/01/8a/f767031dcd0d24c2bbab4b696dbcf004da4f3284e5e4649fc47bc0e2bb78/nvidia_nvvm-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0a/a7/b63e19b0cfb1ef4d2a6053aad1b1cc7344d1f14548c4dffd28b8416fc178/nvidia_cusparse-12.8.1.7-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/13/4a/02a64ee1f4708ad28f49ffa92735cb1a8325f617cb59f33951a07a8c4cca/nvidia_cusolver-12.2.2.18-py3-none-manylinux_2_27_x86_64.whl
@@ -6744,7 +6744,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl
@@ -6995,7 +6995,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
@@ -7251,7 +7251,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/18/72/ec1b5cbdcb140c132e6c7bdf99bd73e4f675439e77126c88f472fcffa09c/simplejson-4.1.1-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
@@ -7509,7 +7509,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: .
       - pypi: git+https://github.com/ttsim-dev/gettsim-personas.git?branch=main#6d8d9e9966b4fa8f8a5923c78fb31323c60980d9
-      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+      - pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
       - pypi: https://files.pythonhosted.org/packages/09/dc/6d8fbfc29d902251cf333414cf7dcfaf4b252a9920c881354584ed36270d/jax_metal-0.1.1-py3-none-macosx_13_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/12/1d/db378b5cca433b90b893f26dab728b280ddd89f272a1fdfed4aeaa05c686/coverage-7.14.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/1b/dd/a9fe6a0a09512da23951c68bf36466aeecd89def3183dc095edbc807ddc5/pint-0.25.3-py3-none-any.whl
@@ -19821,9 +19821,9 @@ packages:
   - dags>=0.6
   - gettsim>=1.1
   requires_python: '>=3.11'
-- pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-annotate-mettsim#78a137d116f7fdebd4bb95bd8b34c165ae7d0e1f
+- pypi: git+https://github.com/ttsim-dev/ttsim.git?branch=gep10-per-system-unit-registries#eee61585a0e083315bd2629b76511ffc44b4c0e6
   name: ttsim-backend
-  version: 1.2.2.dev49+g78a137d11
+  version: 1.2.2.dev50+geee61585a
   requires_dist:
   - beartype>=0.18
   - dags>=0.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,10 +168,11 @@ jaxtyping = ">=0.3.2"
 kaleido = ">=1.0.0"
 pdbp = ">=1.7.1"
 dags = ">=0.6.0"
-# TEMPORARY (GEP 10 rollout): pin ttsim-backend to the GEP-10 mettsim branch so
-# CI installs the units-and-dimensionality ttsim the rollout requires. Revert to
-# `branch = "main"` once the ttsim GEP-10 stack merges, before this PR merges.
-ttsim-backend = { git = "https://github.com/ttsim-dev/ttsim.git", branch = "gep10-annotate-mettsim" }
+# TEMPORARY (GEP 10 rollout): pin ttsim-backend to the per-system-unit-registries
+# branch so CI installs the ttsim whose registry is per policy system, which this
+# rollout requires. Revert to `branch = "main"` once the ttsim GEP-10 stack merges,
+# before this PR merges.
+ttsim-backend = { git = "https://github.com/ttsim-dev/ttsim.git", branch = "gep10-per-system-unit-registries" }
 [tool.pixi.workspace]
 channels = [ "conda-forge" ]
 platforms = [ "linux-64", "osx-64", "osx-arm64", "win-64" ]

--- a/src/gettsim/__init__.py
+++ b/src/gettsim/__init__.py
@@ -65,6 +65,7 @@ from ttsim import (
 )
 from ttsim.main_args import MainArg
 from ttsim.main_args import OrigPolicyObjects as TTSimOrigPolicyObjects
+from ttsim.tt import UnitSystem
 
 from gettsim import germany
 
@@ -124,6 +125,7 @@ def main(
     policy_date: datetime.date | None = None,
     evaluation_date: datetime.date | None = None,
     orig_policy_objects: OrigPolicyObjects | None = None,
+    unit_system: UnitSystem | None = None,
     policy_environment: PolicyEnvironment | None = None,
     processed_data: QNameData | None = None,
     labels: Labels | None = None,
@@ -138,6 +140,8 @@ def main(
         orig_policy_objects = cast(
             "OrigPolicyObjects", TTSimOrigPolicyObjects.root(germany.ROOT_PATH)
         )
+    if unit_system is None:
+        unit_system = germany.UNIT_SYSTEM
 
     return _ttsim.main(**locals())
 

--- a/src/gettsim/germany/__init__.py
+++ b/src/gettsim/germany/__init__.py
@@ -2,30 +2,25 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ttsim.tt import (
-    register_currency,
-    register_statutory_currencies,
-    register_unit_builder_levels,
-)
+from ttsim.tt import UnitSystem
 
 ROOT_PATH = Path(__file__).parent
 
-# Germany's currencies. Registered on import so the [currency] dimension has
-# concrete currencies before the policy environment is assembled (GEP 10). The
-# euro is the base currency; the Deutsche Mark is worth 1/1.95583 euro, the rate
-# fixed by the Euro-Einführungsgesetz. The statutory-currency mapping tells the
-# engine which currency each policy date computes in: the Deutsche Mark through
-# 2001 and the euro from 2002, when the euro became legal tender. Parameters are
-# never converted (GEP 10) — every pre-2002 currency value carries its statutory
-# DM amount, every value from 2002 its statutory euro amount.
-register_currency(name="EUR", base=True)
-register_currency(name="DM", definition="EUR / 1.95583")
-register_statutory_currencies({"0001-01-01": "DM", "2002-01-01": "EUR"})
-
-# Germany's grouping levels. Registered on import so the fluent unit builder
-# offers `Unit.X.PER_HH` / `per_bg` / … before the policy modules (whose
-# decorators use them) are loaded (GEP 10 compositional units).
-register_unit_builder_levels(["hh", "ehe", "fg", "bg", "eg", "wthh", "sn"])
+# Germany's unit system, built on import so the [currency] dimension has concrete
+# currencies and the fluent builder offers `Unit.X.PER_HH` / `per_bg` / … before
+# the policy modules (whose decorators use them) are loaded (GEP 10). The euro is
+# the base currency; the Deutsche Mark is worth 1/1.95583 euro, the rate fixed by
+# the Euro-Einführungsgesetz. The statutory-currency mapping tells the engine
+# which currency each policy date computes in: the Deutsche Mark through 2001 and
+# the euro from 2002, when the euro became legal tender. Parameters are never
+# converted (GEP 10) — every pre-2002 currency value carries its statutory DM
+# amount, every value from 2002 its statutory euro amount.
+UNIT_SYSTEM = UnitSystem(
+    base_currency="EUR",
+    other_currencies={"DM": "EUR / 1.95583"},
+    statutory_currencies={"0001-01-01": "DM", "2002-01-01": "EUR"},
+    grouping_levels=["hh", "ehe", "fg", "bg", "eg", "wthh", "sn"],
+)
 
 
 WARNING_MSG_FOR_GETTSIM_BG_ID_WTHH_ID_ETC = """

--- a/src/gettsim/plot/dag/__init__.py
+++ b/src/gettsim/plot/dag/__init__.py
@@ -9,6 +9,7 @@ from ttsim.main_args import InputData, Labels, OrigPolicyObjects
 
 # Hoisted at runtime: beartype must resolve these on `@beartype`-decorated
 # `gettsim.plot.dag.*` boundaries that this module exposes.
+from ttsim.tt import UnitSystem
 from ttsim.typing import DashedISOString, PolicyEnvironment, QNameData
 
 from gettsim import germany
@@ -107,6 +108,7 @@ def tt(
     # Elements of main
     policy_date_str: DashedISOString | None = None,
     orig_policy_objects: OrigPolicyObjects | None = None,
+    unit_system: UnitSystem | None = None,
     input_data: InputData | None = None,
     processed_data: QNameData | None = None,
     labels: Labels | None = None,
@@ -155,6 +157,8 @@ def tt(
             hierarchy.
         policy_date_str: The date for which to plot the DAG.
         orig_policy_objects: The orig policy objects.
+        unit_system: The policy system's currencies and grouping levels. Defaults
+            to Germany's.
         input_data: The input data.
         processed_data: The processed data.
         labels: The labels.
@@ -171,6 +175,7 @@ def tt(
     """
     return ttsim.plot.dag.tt(
         root=germany.ROOT_PATH,
+        unit_system=unit_system if unit_system is not None else germany.UNIT_SYSTEM,
         primary_nodes=primary_nodes,
         selection_type=selection_type,
         selection_depth=selection_depth,

--- a/src/gettsim/tests_germany/test_currency.py
+++ b/src/gettsim/tests_germany/test_currency.py
@@ -1,6 +1,6 @@
-"""GETTSIM's currency registration (GEP 10).
+"""GETTSIM's unit system (GEP 10).
 
-Importing ``gettsim`` registers the euro as the base currency and the
+``gettsim.germany.UNIT_SYSTEM`` declares the euro as the base currency and the
 Deutsche Mark relative to it, plus the dated statutory-currency mapping that
 tells the engine which currency each policy date computes in.
 """
@@ -10,29 +10,27 @@ from __future__ import annotations
 import datetime
 
 import pytest
-from ttsim.tt.currencies import (
-    base_currency,
-    currency_conversion_factor,
-    statutory_currency_for_date,
-)
 
-# Importing gettsim runs germany/__init__.py, which registers the currencies.
-import gettsim  # noqa: F401
+from gettsim.germany import UNIT_SYSTEM
 
 #: 1 euro = 1.95583 DM, fixed by the Euro-Einführungsgesetz.
 DM_PER_EUR = 1.95583
 
 
 def test_euro_is_the_base_currency():
-    assert base_currency() == "EUR"
+    assert UNIT_SYSTEM.base_currency == "EUR"
 
 
 def test_deutsche_mark_converts_to_euro_at_the_statutory_rate():
-    assert currency_conversion_factor("DM", "EUR") == pytest.approx(1 / DM_PER_EUR)
+    assert UNIT_SYSTEM.currency_conversion_factor(
+        source_currency="DM", target_currency="EUR"
+    ) == pytest.approx(1 / DM_PER_EUR)
 
 
 def test_euro_converts_to_deutsche_mark_at_the_statutory_rate():
-    assert currency_conversion_factor("EUR", "DM") == pytest.approx(DM_PER_EUR)
+    assert UNIT_SYSTEM.currency_conversion_factor(
+        source_currency="EUR", target_currency="DM"
+    ) == pytest.approx(DM_PER_EUR)
 
 
 @pytest.mark.parametrize(
@@ -45,4 +43,4 @@ def test_euro_converts_to_deutsche_mark_at_the_statutory_rate():
     ],
 )
 def test_statutory_currency_changes_over_to_the_euro_in_2002(policy_date, expected):
-    assert statutory_currency_for_date(policy_date) == expected
+    assert UNIT_SYSTEM.statutory_currency_for_date(policy_date=policy_date) == expected

--- a/src/gettsim/tests_germany/test_policy_cases.py
+++ b/src/gettsim/tests_germany/test_policy_cases.py
@@ -72,7 +72,12 @@ def orig_gettsim_objects() -> dict[
     ids=POLICY_TEST_IDS_AND_CASES.keys(),
 )
 def test_policy_cases(test: PolicyTest, backend: Literal["numpy", "jax"]):
-    execute_test(test=test, root=germany.ROOT_PATH, backend=backend)
+    execute_test(
+        test=test,
+        root=germany.ROOT_PATH,
+        backend=backend,
+        unit_system=germany.UNIT_SYSTEM,
+    )
 
 
 @pytest.mark.skipif(
@@ -95,6 +100,7 @@ def test_gettsim_policy_environment_is_complete(orig_gettsim_objects, date):
         name="GETTSIM",
         policy_date=date,
         orig_policy_objects=orig_gettsim_objects,
+        unit_system=germany.UNIT_SYSTEM,
     )
 
 


### PR DESCRIPTION
Stacked on #1212 (`gep10-rollout`). Adopts the per-policy-system unit registry from ttsim (ttsim-dev/ttsim#145), so GETTSIM's euro base and mettsim's castar base coexist in one process — the dev repo's full test suite runs in a single command.

## What

- `germany/__init__.py`: the four import-time registration calls (`register_currency` × 2, `register_statutory_currencies`, `register_unit_builder_levels`) become one declared value:
  ```python
  UNIT_SYSTEM = UnitSystem(
      base_currency="EUR",
      other_currencies={"DM": "EUR / 1.95583"},
      statutory_currencies={"0001-01-01": "DM", "2002-01-01": "EUR"},
      grouping_levels=["hh", "ehe", "fg", "bg", "eg", "wthh", "sn"],
  )
  ```
- `main()` and `plot.dag.tt()` gain a `unit_system` parameter, defaulted from `germany.UNIT_SYSTEM` exactly as `orig_policy_objects` is defaulted from `germany.ROOT_PATH`. Users never name it.
- Tests exercising the currency API (`test_currency.py`) or ttsim's test helpers (`test_policy_cases.py`) pass the system through.

No `unit=` decorator, policy module, or parameter YAML changes.

## Temporary pin

`ttsim-backend` is pinned to the `gep10-per-system-unit-registries` branch (re-locked in the same commit). Revert to `main` once the ttsim GEP-10 stack merges, before this PR merges — same pattern as the existing rollout pin.

## Verification (from the dev repo)

- The original reproducer `pixi run -e py314 tests ttsim/tests/tt/test_units.py gettsim/src/gettsim/tests_germany/test_currency.py` now passes (173 tests); it died at collection before, on the EUR/CASTAR base collision.
- `pixi run -e py314 tests -n 7` (whole dev repo): every ttsim, gettsim, and mettsim test passes. The only remaining failures are pre-existing soep-preparation import issues (sklearn / wealth-imputation models), unrelated to units.
- `pixi run ty`: back to the 9-diagnostic baseline (7 soep, 2 unrelated) — the GEP-10 stack adds none.
- `prek run --all-files`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)